### PR TITLE
feat(templates): add types for different template & wire choices through router/link

### DIFF
--- a/frontend/src/chrome/NavBar.tsx
+++ b/frontend/src/chrome/NavBar.tsx
@@ -8,6 +8,7 @@ const NavBar: React.FC<any> = () => {
       <div className='w-10'></div>
       <Link className='px-1' to='/collection'>Collection</Link>
       <Link className='px-1' to='/notifications'>Notifications</Link>
+      <Link className='px-1' to='/ds/new'>New Workflow</Link>
     </div>
   )
 }

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -1,18 +1,23 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { TemplateType } from './templates'
 
 const templates = [
   {
-    name: 'CSV Download'
+    name: 'CSV Download',
+    type: TemplateType.CSVDownload
   },
   {
-    name: 'API Call'
+    name: 'API Call',
+    type: TemplateType.APICall
   },
   {
-    name: 'Database Query'
+    name: 'Database Query',
+    type: TemplateType.DatabaseQuery
   },
   {
-    name: 'Web Scrape'
+    name: 'Web Scrape',
+    type: TemplateType.Webscrape
   }
 ]
 
@@ -24,9 +29,12 @@ const TemplateList: React.FC<any> = () => {
       <br />
       <div className='text-lg text-bold flex flex-wrap -mx-2 overflow-hidden'>
         {
-          templates.map(({ name }) => (
-            <div className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
-              <Link to='/datasets/edit'>
+          templates.map(({ name, type }) => (
+            <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
+              <Link to={{ 
+                pathname: `/ds/temp/dataset_${Math.floor(Math.random() * 1000)}`,
+                state: { template: type }
+              }}>
                 <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm p-10 text-center'>
                     <h3>{name}</h3>
                 </div>

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -1,23 +1,22 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { TemplateType } from './templates'
 
 const templates = [
   {
     name: 'CSV Download',
-    type: TemplateType.CSVDownload
+    type: 'CSVDownload'
   },
   {
     name: 'API Call',
-    type: TemplateType.APICall
+    type: 'APICall'
   },
   {
     name: 'Database Query',
-    type: TemplateType.DatabaseQuery
+    type: 'DatabaseQuery'
   },
   {
     name: 'Web Scrape',
-    type: TemplateType.Webscrape
+    type: 'Webscrape'
   }
 ]
 
@@ -32,7 +31,7 @@ const TemplateList: React.FC<any> = () => {
           templates.map(({ name, type }) => (
             <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
               <Link to={{ 
-                pathname: `/ds/temp/dataset_${Math.floor(Math.random() * 1000)}`,
+                pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}`,
                 state: { template: type }
               }}>
                 <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm p-10 text-center'>

--- a/frontend/src/features/template/templates.ts
+++ b/frontend/src/features/template/templates.ts
@@ -1,0 +1,97 @@
+import { Workflow } from '../../qrimatic/workflow'
+
+export enum TemplateType {
+  CSVDownload = 'CSVDownload',
+  APICall = 'APICall',
+  DatabaseQuery = 'DatabaseQuery',
+  Webscrape = 'Webscrape'
+}
+
+export interface ITemplate extends Workflow {
+  type: TemplateType
+}
+
+// TODO (ramfox): need to formalize possible trigger & on completion types
+
+export const CSVDownload:  ITemplate = {
+  type: TemplateType.CSVDownload,
+  triggers: [{
+    // repeat every hour
+    type: 'cron',
+    value: 'R/PT1H'
+  }],
+  steps: [
+    { type: 'starlark', name: 'setup', value: `# load_ds("b5/csvdownload")` },
+    { type: 'starlark', name: 'download', value: `def download(ctx):\n\treturn "your download here"` },
+    { type: 'starlark', name: 'transform', value: 'def transform(ds,ctx):\n\tds.set_body([[1,2,3],[4,5,6]])' },
+    { type: 'save', name: 'save', value: '' }
+  ],
+  onCompletion: [
+    { type: 'push', value: 'https://registry.qri.cloud' }
+  ]
+} 
+
+export const APICall:  ITemplate = {
+  type: TemplateType.APICall,
+  triggers: [{
+    // repeat every hour
+    type: 'cron',
+    value: 'R/PT1H'
+  }],
+  steps: [
+    { type: 'starlark', name: 'setup', value: `# load_ds("b5/apicall")` },
+    { type: 'starlark', name: 'download', value: `def download(ctx):\n\treturn "your download here"` },
+    { type: 'starlark', name: 'transform', value: 'def transform(ds,ctx):\n\tds.set_body([[1,2,3],[4,5,6]])' },
+    { type: 'save', name: 'save', value: '' }
+  ],
+  onCompletion: [
+    { type: 'push', value: 'https://registry.qri.cloud' }
+  ]
+} 
+
+export const DatabaseQuery:  ITemplate = {
+  type: TemplateType.DatabaseQuery,
+  triggers: [{
+    // repeat every hour
+    type: 'cron',
+    value: 'R/PT1H'
+  }],
+  steps: [
+    { type: 'starlark', name: 'setup', value: `# load_ds("b5/databasequery")` },
+    { type: 'starlark', name: 'download', value: `def download(ctx):\n\treturn "your download here"` },
+    { type: 'starlark', name: 'transform', value: 'def transform(ds,ctx):\n\tds.set_body([[1,2,3],[4,5,6]])' },
+    { type: 'save', name: 'save', value: '' }
+  ],
+  onCompletion: [
+    { type: 'push', value: 'https://registry.qri.cloud' }
+  ]
+} 
+
+export const Webscrape:  ITemplate = {
+  type: TemplateType.Webscrape,
+  triggers: [{
+    // repeat every hour
+    type: 'cron',
+    value: 'R/PT1H'
+  }],
+  steps: [
+    { type: 'starlark', name: 'setup', value: `# load_ds("b5/webscrape")` },
+    { type: 'starlark', name: 'download', value: `def download(ctx):\n\treturn "your download here"` },
+    { type: 'starlark', name: 'transform', value: 'def transform(ds,ctx):\n\tds.set_body([[1,2,3],[4,5,6]])' },
+    { type: 'save', name: 'save', value: '' }
+  ],
+  onCompletion: [
+    { type: 'push', value: 'https://registry.qri.cloud' }
+  ]
+} 
+
+export const Templates: {[key in TemplateType]: ITemplate} = {
+  [TemplateType.CSVDownload]: CSVDownload,
+  [TemplateType.APICall]: APICall,
+  [TemplateType.DatabaseQuery]: DatabaseQuery,
+  [TemplateType.Webscrape]: Webscrape
+}
+
+export function selectTemplate(templateType: TemplateType): ITemplate {
+  return Templates[templateType]
+}

--- a/frontend/src/features/template/templates.ts
+++ b/frontend/src/features/template/templates.ts
@@ -1,20 +1,9 @@
 import { Workflow } from '../../qrimatic/workflow'
 
-export enum TemplateType {
-  CSVDownload = 'CSVDownload',
-  APICall = 'APICall',
-  DatabaseQuery = 'DatabaseQuery',
-  Webscrape = 'Webscrape'
-}
-
-export interface ITemplate extends Workflow {
-  type: TemplateType
-}
-
 // TODO (ramfox): need to formalize possible trigger & on completion types
 
-export const CSVDownload:  ITemplate = {
-  type: TemplateType.CSVDownload,
+export const CSVDownload:  Workflow = {
+  id: 'CSVDownload',
   triggers: [{
     // repeat every hour
     type: 'cron',
@@ -31,8 +20,8 @@ export const CSVDownload:  ITemplate = {
   ]
 } 
 
-export const APICall:  ITemplate = {
-  type: TemplateType.APICall,
+export const APICall:  Workflow = {
+  id: 'APICall',
   triggers: [{
     // repeat every hour
     type: 'cron',
@@ -49,8 +38,8 @@ export const APICall:  ITemplate = {
   ]
 } 
 
-export const DatabaseQuery:  ITemplate = {
-  type: TemplateType.DatabaseQuery,
+export const DatabaseQuery:  Workflow = {
+  id: 'DatabaseQuery',
   triggers: [{
     // repeat every hour
     type: 'cron',
@@ -67,8 +56,8 @@ export const DatabaseQuery:  ITemplate = {
   ]
 } 
 
-export const Webscrape:  ITemplate = {
-  type: TemplateType.Webscrape,
+export const Webscrape:  Workflow = {
+  id: 'Webscrape',
   triggers: [{
     // repeat every hour
     type: 'cron',
@@ -85,13 +74,13 @@ export const Webscrape:  ITemplate = {
   ]
 } 
 
-export const Templates: {[key in TemplateType]: ITemplate} = {
-  [TemplateType.CSVDownload]: CSVDownload,
-  [TemplateType.APICall]: APICall,
-  [TemplateType.DatabaseQuery]: DatabaseQuery,
-  [TemplateType.Webscrape]: Webscrape
+export const Templates: Record<string, Workflow> = {
+  'CSVDownload': CSVDownload,
+  'APICall': APICall,
+  'DatabaseQuery': DatabaseQuery,
+  'Webscrape': Webscrape
 }
 
-export function selectTemplate(templateType: TemplateType): ITemplate {
-  return Templates[templateType]
+export function selectTemplate(id: string): Workflow {
+  return Templates[id]
 }

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -1,20 +1,34 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux';
 
 import WorkflowCell from './WorkflowCell';
 import { NewRunStep, RunState, RunStep } from '../../qrimatic/run';
 import { WorkflowStep } from '../../qrimatic/workflow';
-import { useDispatch, useSelector } from 'react-redux';
 import { selectLatestRun, selectWorkflow } from './state/workflowState';
-import { changeWorkflowStep, runWorkflow, tempSetWorkflowEvents } from './state/workflowActions';
+import { changeWorkflowStep, runWorkflow, setWorkflow, tempSetWorkflowEvents } from './state/workflowActions';
 import { eventLogSuccess, eventLogWithError, NewEventLogLines } from '../../qrimatic/eventLog'
 import { showModal } from '../app/state/appActions';
 import { AppModalType } from '../app/state/appState';
+import { selectTemplate, TemplateType } from '../template/templates';
+
+interface WorkflowEditorLocationState {
+  template: TemplateType
+}
 
 const WorkflowEditor: React.FC<any> = () => {
+  const location = useLocation<WorkflowEditorLocationState>()
+  const dispatch = useDispatch()
+  useEffect(() => {
+    if (location.state && location.state.template) {
+      dispatch(setWorkflow(selectTemplate(location.state.template)))
+    }
+  }, [])
+
   const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
   const workflow = useSelector(selectWorkflow)
   const latestRun = useSelector(selectLatestRun)
-  const dispatch = useDispatch()
+
   const running = latestRun ? (latestRun.status === 'running') : false
 
   const collapseState = (step: WorkflowStep, run?: RunStep): "all" | "collapsed" | "only-editor" | "only-output" => {

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -10,10 +10,10 @@ import { changeWorkflowStep, runWorkflow, setWorkflow, tempSetWorkflowEvents } f
 import { eventLogSuccess, eventLogWithError, NewEventLogLines } from '../../qrimatic/eventLog'
 import { showModal } from '../app/state/appActions';
 import { AppModalType } from '../app/state/appState';
-import { selectTemplate, TemplateType } from '../template/templates';
+import { selectTemplate } from '../template/templates';
 
 interface WorkflowEditorLocationState {
-  template: TemplateType
+  template: string
 }
 
 const WorkflowEditor: React.FC<any> = () => {

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -17,13 +17,14 @@ interface WorkflowEditorLocationState {
 }
 
 const WorkflowEditor: React.FC<any> = () => {
-  const location = useLocation<WorkflowEditorLocationState>()
   const dispatch = useDispatch()
+  const location = useLocation<WorkflowEditorLocationState>()
+  
   useEffect(() => {
     if (location.state && location.state.template) {
       dispatch(setWorkflow(selectTemplate(location.state.template)))
     }
-  }, [])
+  }, [dispatch, location.state])
 
   const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
   const workflow = useSelector(selectWorkflow)

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -9,13 +9,13 @@ import {
  } from './workflowState'
 
 
-export interface WorkflowAction {
+export interface SetWorkflowStepAction {
   type: string
   index: number
   value: string
 }
 
-export function changeWorkflowStep(index: number, value: string): WorkflowAction {
+export function changeWorkflowStep(index: number, value: string): SetWorkflowStepAction {
   return {
     type: WORKFLOW_CHANGE_STEP,
     index,

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -4,7 +4,8 @@ import { CALL_API, ApiActionThunk } from '../../../store/api'
 import { 
   WORKFLOW_CHANGE_STEP,
   RUN_EVENT_LOG,
-  TEMP_SET_WORKFLOW_EVENTS
+  TEMP_SET_WORKFLOW_EVENTS,
+  SET_WORKFLOW
  } from './workflowState'
 
 
@@ -49,6 +50,18 @@ export function runEventLog(event: EventLogLine): EventLogAction {
   return {
     type: RUN_EVENT_LOG,
     data: event,
+  }
+}
+
+export interface SetWorkflowAction {
+  type: string
+  workflow: Workflow
+}
+
+export function setWorkflow(workflow: Workflow): SetWorkflowAction {
+  return {
+    type: SET_WORKFLOW,
+    workflow
   }
 }
 

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -1,6 +1,6 @@
 import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import { EventLogAction, SetWorkflowAction, WorkflowAction } from './workflowActions';
+import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction } from './workflowActions';
 import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
 import { NewWorkflow, Workflow } from '../../../qrimatic/workflow';
 import { EventLogLine } from '../../../qrimatic/eventLog';
@@ -15,7 +15,7 @@ export const TEMP_SET_WORKFLOW_EVENTS = 'TEMP_SET_WORKFLOW_EVENTS'
 
 export const selectLatestRun = (state: RootState): Run | undefined => {
   if (state.workflow.lastRunID) {
-    console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
+    // console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
     return NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events)
   }
   return undefined
@@ -65,7 +65,7 @@ export const workflowReducer = createReducer(initialState, {
   RUN_EVENT_LOG: addRunEvent,
 })
 
-function changeWorkflowStep(state: WorkflowState, action: WorkflowAction) {
+function changeWorkflowStep(state: WorkflowState, action: SetWorkflowStepAction) {
   if (state.workflow.steps) {
     state.workflow.steps[action.index].value = action.value
   }

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -1,12 +1,13 @@
 import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import { EventLogAction, WorkflowAction } from './workflowActions';
+import { EventLogAction, SetWorkflowAction, WorkflowAction } from './workflowActions';
 import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
 import { NewWorkflow, Workflow } from '../../../qrimatic/workflow';
 import { EventLogLine } from '../../../qrimatic/eventLog';
 
 export const RUN_EVENT_LOG = 'RUN_EVENT_LOG'
 export const WORKFLOW_CHANGE_STEP = 'WORKFLOW_CHANGE_STEP'
+export const SET_WORKFLOW = 'SET_WORKFLOW'
 
 // temp action used to work around the api, auto sets the events
 // of the workflow without having to have a working api
@@ -59,6 +60,7 @@ export const workflowReducer = createReducer(initialState, {
     state.events = action.events
     state.lastRunID = action.id
   },
+  SET_WORKFLOW: setWorkflow,
   WORKFLOW_CHANGE_STEP: changeWorkflowStep,
   RUN_EVENT_LOG: addRunEvent,
 })
@@ -73,4 +75,10 @@ function changeWorkflowStep(state: WorkflowState, action: WorkflowAction) {
 function addRunEvent(state: WorkflowState, action: EventLogAction) {
   state.events.push(action.data)
   state.events.sort((a,b) => a.ts - b.ts)
+}
+
+function setWorkflow(state: WorkflowState, action: SetWorkflowAction) {
+  state.workflow = action.workflow
+  state.events = []
+  return
 }

--- a/frontend/src/qrimatic/workflow.ts
+++ b/frontend/src/qrimatic/workflow.ts
@@ -1,7 +1,10 @@
 
 
 export interface Workflow {
+  // id of the workflow
+  id: string
   triggers?: WorkflowTrigger[]
+  // init id of the dataset
   datasetID?: string
   steps?: WorkflowStep[]
   onCompletion?: WorkflowHook[]
@@ -9,6 +12,8 @@ export interface Workflow {
 
 export function NewWorkflow(data: Record<string,any>): Workflow {
   return {
+    // TODO (ramfox): where/when do we get an id?
+    id: data.id || 'temp_id',
     datasetID: data.datasetID,
     triggers: data.triggers && data.triggers.map(NewWorkflowTrigger),
     steps: data.steps && data.steps.map(NewWorkflowStep),


### PR DESCRIPTION
- Adds enum `TemplateType` to distinguish between each template
- Adds template objects that describe each template (this is what needs to be updated/altered when we come up with the template copy)
- Adds a `Templates` object that we can easily select each template from
- Adds `selectTemplate`, that pulls out a template based on the `TemplateType`
- In the `TemplateList` page, we now link to a dummy user page `/ds/test/dataset_${random num}`, that sends over the `TemplateType` for the workflow editor to parse
- The `WorkflowEditor` now has an effect that runs each time the location is updated: it checks if there is a specified template. If so, it pushes the specified template to the `WorkflowState`
- Also adds a `New Workflow` link at the top of navigation