### PR TITLE
feat: add postCSS to storybook (for tailwind)

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   "stories": [
     "../src/**/*.stories.tsx",
@@ -7,5 +9,27 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app"
-  ]
+  ],
+  webpackFinal: async config => {
+    config.module.rules = [
+      ...config.module.rules,
+      {
+        test: /\.css$/,
+        loaders: [
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+              config: {
+                path: './.storybook/',
+              },
+            },
+          },
+        ],
+        include: path.resolve(__dirname, '../'),
+      }
+    ],
+    config.resolve.extensions.push('.ts', '.tsx');
+    return config;
+  },
 }

--- a/frontend/.storybook/postcss.config.js
+++ b/frontend/.storybook/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -2,7 +2,7 @@ import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
 import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction } from './workflowActions';
 import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
-import { NewWorkflow, Workflow } from '../../../qrimatic/workflow';
+import { Workflow } from '../../../qrimatic/workflow';
 import { EventLogLine } from '../../../qrimatic/eventLog';
 
 export const RUN_EVENT_LOG = 'RUN_EVENT_LOG'


### PR DESCRIPTION
Adds postcss webpack config to react storybook so that it can properly parse the `@tailwind base;` and other postCSS syntax in `index.css`