### PR TITLE
feat(frontend): WorkflowEditor loads transform referenced in url

### DIFF
--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -1,9 +1,9 @@
-import Dataset, { newDataset } from "../../../qri/dataset";
+import Dataset, { NewDataset } from "../../../qri/dataset";
 import { QriRef } from "../../../qri/ref";
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
 
 export function mapDataset(d: object | []): Dataset {
-  return newDataset((d as Record<string,any>).dataset)
+  return NewDataset((d as Record<string,any>).dataset)
 }
 
 export function loadDataset (ref: QriRef): ApiActionThunk {

--- a/frontend/src/features/dataset/state/datasetState.ts
+++ b/frontend/src/features/dataset/state/datasetState.ts
@@ -1,6 +1,6 @@
 import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import Dataset, { newDataset } from '../../../qri/dataset';
+import Dataset, { NewDataset } from '../../../qri/dataset';
 
 export const selectDataset = (state: RootState): Dataset => state.dataset.dataset
 
@@ -9,12 +9,11 @@ export interface DatasetState {
 }
 
 const initialState: DatasetState = {
-  dataset: newDataset({}),
+  dataset: NewDataset({}),
 }
 
 export const datasetReducer = createReducer(initialState, {
   'API_DATASET_SUCCESS': (state, action) => {
-    console.log('fetched dataset', action)
     state.dataset = action.payload.data as Dataset
   },
 })

--- a/frontend/src/features/workflow/WorkflowCell.tsx
+++ b/frontend/src/features/workflow/WorkflowCell.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { RunStep } from '../../qrimatic/run'
-import { TransformStep } from '../../qrimatic/workflow'
+import { TransformStep } from '../../qri/dataset'
 import CodeEditor from './CodeEditor'
 import Output from './output/Output'
 import RunStateIcon from './RunStateIcon'

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -7,19 +7,27 @@ import WorkflowCell from './WorkflowCell';
 import Triggers from './Triggers';
 import OnComplete from './OnComplete';
 import { NewRunStep, RunState, RunStep } from '../../qrimatic/run';
-import { TransformStep } from '../../qrimatic/workflow';
+import { TransformStep } from '../../qri/dataset';
 import { selectLatestRun, selectWorkflow } from './state/workflowState';
-import { changeWorkflowStep, runWorkflow, setWorkflow, tempSetWorkflowEvents } from './state/workflowActions';
+import { changeWorkflowTransformStep, runWorkflow, setWorkflow, setWorkflowRef, tempSetWorkflowEvents } from './state/workflowActions';
 import { eventLogSuccess, eventLogWithError, NewEventLogLines } from '../../qrimatic/eventLog'
 import { selectTemplate } from '../template/templates';
+import { QriRef } from '../../qri/ref';
 
 interface WorkflowEditorLocationState {
   template: string
 }
 
-const WorkflowEditor: React.FC<any> = () => {
+export interface WorkflowEditorProps {
+  qriRef: QriRef
+}
+
+const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
   const location = useLocation<WorkflowEditorLocationState>()
+  const workflow = useSelector(selectWorkflow)
+  const latestRun = useSelector(selectLatestRun)
+  const running = latestRun ? (latestRun.status === 'running') : false
 
   useEffect(() => {
     if (location.state && location.state.template) {
@@ -27,11 +35,11 @@ const WorkflowEditor: React.FC<any> = () => {
     }
   }, [dispatch, location.state])
 
-  const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
-  const workflow = useSelector(selectWorkflow)
-  const latestRun = useSelector(selectLatestRun)
+  useEffect(() => {
+    dispatch(setWorkflowRef(qriRef))
+  }, [dispatch, qriRef])
 
-  const running = latestRun ? (latestRun.status === 'running') : false
+  const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
 
   const collapseState = (step: TransformStep, run?: RunStep): "all" | "collapsed" | "only-editor" | "only-output" => {
     if (collapseStates[step.name]) {
@@ -129,7 +137,7 @@ const WorkflowEditor: React.FC<any> = () => {
                 }}
                 onChangeValue={(i:number, v:string) => {
                   if (workflow && workflow.steps) {
-                    dispatch(changeWorkflowStep(i,v))
+                    dispatch(changeWorkflowTransformStep(i,v))
                   }
                 }}
               />)

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -1,11 +1,13 @@
+import { QriRef } from '../../../qri/ref'
 import { EventLogLine } from '../../../qrimatic/eventLog'
 import { Workflow, workflowScriptString } from '../../../qrimatic/workflow'
 import { CALL_API, ApiActionThunk } from '../../../store/api'
 import { 
-  WORKFLOW_CHANGE_STEP,
+  WORKFLOW_CHANGE_TRANSFORM_STEP,
   RUN_EVENT_LOG,
   TEMP_SET_WORKFLOW_EVENTS,
-  SET_WORKFLOW
+  SET_WORKFLOW,
+  SET_WORKFLOW_REF
  } from './workflowState'
 
 
@@ -15,9 +17,9 @@ export interface SetWorkflowStepAction {
   script: string
 }
 
-export function changeWorkflowStep(index: number, script: string): SetWorkflowStepAction {
+export function changeWorkflowTransformStep(index: number, script: string): SetWorkflowStepAction {
   return {
-    type: WORKFLOW_CHANGE_STEP,
+    type: WORKFLOW_CHANGE_TRANSFORM_STEP,
     index,
     script,
   }
@@ -61,7 +63,6 @@ export function deployWorkflow(w: Workflow): ApiActionThunk {
   }
 }
 
-
 export interface EventLogAction {
   type: string
   data: EventLogLine
@@ -101,5 +102,17 @@ export function tempSetWorkflowEvents(id: string, events: EventLogLine[]): TempW
     type: TEMP_SET_WORKFLOW_EVENTS,
     id,
     events
+  }
+}
+
+export interface SetWorkflowRefAction {
+  type: string
+  qriRef: QriRef
+}
+
+ export function setWorkflowRef(qriRef: QriRef): SetWorkflowRefAction {
+  return {
+    type: SET_WORKFLOW_REF,
+    qriRef,
   }
 }

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -1,13 +1,17 @@
-import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction } from './workflowActions';
+
+import { RootState } from '../../../store/store';
+import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction, SetWorkflowRefAction } from './workflowActions';
 import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
-import { NewWorkflow, Workflow } from '../../../qrimatic/workflow';
+import { Workflow } from '../../../qrimatic/workflow';
 import { EventLogLine } from '../../../qrimatic/eventLog';
+import Dataset from '../../../qri/dataset';
+import { QriRef } from '../../../qri/ref';
 
 export const RUN_EVENT_LOG = 'RUN_EVENT_LOG'
-export const WORKFLOW_CHANGE_STEP = 'WORKFLOW_CHANGE_STEP'
+export const WORKFLOW_CHANGE_TRANSFORM_STEP = 'WORKFLOW_CHANGE_TRANSFORM_STEP'
 export const SET_WORKFLOW = 'SET_WORKFLOW'
+export const SET_WORKFLOW_REF = 'SET_WORKFLOW_REF'
 
 // temp action used to work around the api, auto sets the events
 // of the workflow without having to have a working api
@@ -24,6 +28,8 @@ export const selectLatestRun = (state: RootState): Run | undefined => {
 export const selectWorkflow = (state: RootState): Workflow => state.workflow.workflow
 
 export interface WorkflowState {
+  // reference the workflow editor is manipulating
+  qriRef?: QriRef,
   workflow: Workflow,
 
   lastRunID?: string,
@@ -65,11 +71,27 @@ export const workflowReducer = createReducer(initialState, {
     state.lastRunID = action.id
   },
   SET_WORKFLOW: setWorkflow,
-  WORKFLOW_CHANGE_STEP: changeWorkflowStep,
+  WORKFLOW_CHANGE_TRANSFORM_STEP: changeWorkflowTransformStep,
   RUN_EVENT_LOG: addRunEvent,
+  SET_WORKFLOW_REF: (state, action: SetWorkflowRefAction) => {
+    state.qriRef = action.qriRef
+    state.workflow.datasetID = `${action.qriRef.username}/${action.qriRef.name}`
+  },
+  // listen for dataset fetching actions, if the reference of the fetched dataset
+  // matches the ref the workbench reducer is tuned to, load the transform script
+  // into the workbench
+  'API_DATASET_SUCCESS': (state, action) => {
+    const d = action.payload.data as Dataset
+    // TODO (b5) - this should check peername *and* confirm the loaded version is HEAD
+    if (state.qriRef?.name === d.name) {
+      if (d.transform?.steps) {
+        state.workflow.steps = d.transform.steps
+      }
+    }
+  },
 })
 
-function changeWorkflowStep(state: WorkflowState, action: SetWorkflowStepAction) {
+function changeWorkflowTransformStep(state: WorkflowState, action: SetWorkflowStepAction) {
   if (state.workflow.steps) {
     state.workflow.steps[action.index].script = action.script
   }

--- a/frontend/src/qri/dataset.ts
+++ b/frontend/src/qri/dataset.ts
@@ -16,20 +16,20 @@ export interface Dataset {
 
 export default Dataset
 
-export function newDataset(d: Record<string,any>): Dataset {
+export function NewDataset(d: Record<string,any>): Dataset {
   return {
     peername: d.peername || '',
     name: d.name || '',
     path: d.path || '',
 
-    commit: newCommit(d.commit || {}),
-    meta: newMeta(d.meta || {}),
-    structure: newStructure(d.structure || {}),
+    commit: NewCommit(d.commit || {}),
+    meta: NewMeta(d.meta || {}),
+    structure: NewStructure(d.structure || {}),
     body: d.body,
     bodyPath: d.bodyPath,
     readme: d.readme,
-    transform: newTransform(d.transform || {}),
-    stats: newStats(d.stats || {}),
+    transform: NewTransform(d.transform || {}),
+    stats: NewStats(d.stats || {}),
     viz: d.viz
   }
 }
@@ -68,7 +68,7 @@ export interface Commit {
   count?: number // commit chain height
 }
 
-export function newCommit(d: Record<string,any>): Commit {
+export function NewCommit(d: Record<string,any>): Commit {
   return {
     author: d.author,
     message: d.message,
@@ -98,7 +98,7 @@ export interface Meta {
   [key: string]: any
 }
 
-export function newMeta(d: Record<string,any>): Meta {
+export function NewMeta(d: Record<string,any>): Meta {
   return Object.assign({}, d)
 }
 
@@ -133,7 +133,7 @@ export interface Structure {
   schema?: Schema
 }
 
-export function newStructure(d: Record<string,any>): Structure {
+export function NewStructure(d: Record<string,any>): Structure {
   return {
     depth: d.depth,
     entries: d.entries,
@@ -177,7 +177,7 @@ export interface Stats {
   stats: IStatTypes[]
 }
 
-export function newStats(d: Record<string,any>): Stats {
+export function NewStats(d: Record<string,any>): Stats {
   return {
     path: d.path,
     stats: d.stats,
@@ -227,14 +227,31 @@ export interface INumericStats {
 }
 
 export interface Transform {
-  syntax: string
   bodyBytes?: string
+  steps: TransformStep[]
+  syntaxes?: Record<string,string>
 }
 
-export function newTransform(d: Record<string,any>): Transform {
+export function NewTransform(d: Record<string,any>): Transform {
   return {
-    syntax: d.syntax || '',
     bodyBytes: d.bodyBytes,
+    steps: d.steps
+  }
+}
+
+export interface TransformStep {
+  category: string
+  name: string
+  syntax: string
+  script: string
+}
+
+export function NewTransformStep(data: Record<string,any>): TransformStep {
+  return {
+    name: data.name,
+    syntax: data.syntax,
+    category: data.category,
+    script: data.script
   }
 }
 

--- a/frontend/src/qrimatic/workflow.ts
+++ b/frontend/src/qrimatic/workflow.ts
@@ -1,3 +1,4 @@
+import { NewTransformStep, TransformStep } from "../qri/dataset"
 import { VersionInfo } from "../qri/versionInfo"
 
 
@@ -54,22 +55,6 @@ export function NewWorkflowTrigger(data: Record<string,any>): WorkflowTrigger {
     workflowID: data.workflowID || '',
     type: data.type,
     disabled: data.disabled || false,
-  }
-}
-
-export interface TransformStep {
-  category: string
-  name: string
-  syntax: string
-  script: string
-}
-
-export function NewTransformStep(data: Record<string,any>): TransformStep {
-  return {
-    name: data.name,
-    syntax: data.syntax,
-    category: data.category,
-    script: data.script
   }
 }
 


### PR DESCRIPTION
Dataset component wraps the WorkflowEditor component. The dataset component extracts a qriRef from router params, and provides it to the WorkflowEditor. The Dataset component also fires off an API call to load the dataset that matches the ref whenever it changes.

Down in Workflow editor we fire an event to update the ref the workflow section of the state tree is tuned to with an effect hook. The workflow reducer listens for API_DATASET_SUCCESS actions and if the ref of the api response matches the ref the workflow reducer is tuned to, it updates the workflow transform script.

There are two bugs not handled yet:
* if the user has edited the script, it would get clobbered if a matching API fetch action completed while they were mid edit. The right solution there is to have *two* transform scripts in the workflow reducer. one we "reset" to, and another for user edits. successful api responses should write to the "reset" slot.
* the references don't confirm the version loaded is HEAD. successfully loading a historical commit will lead to the wrong script loaded into the workflow reducer