### PR TITLE
feat: layout improvements

### DIFF
--- a/frontend/src/chrome/Icon.tsx
+++ b/frontend/src/chrome/Icon.tsx
@@ -3,22 +3,30 @@ import classNames from 'classnames'
 
 import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome'
 import {
+  faArrowRight,
+  faBars,
   faBolt,
   faClock,
   faCloudUploadAlt,
   faCode,
   faProjectDiagram,
   faEnvelope,
+  faHdd,
   faList,
   faCheck,
+  faPlus,
   faTimes,
   faExclamationCircle,
   faSpinner,
   faTable,
-  faBars,
 
   IconDefinition
 } from '@fortawesome/free-solid-svg-icons'
+
+import {
+  faFile
+} from '@fortawesome/free-regular-svg-icons'
+
 
 interface IconProps {
   // name of the icon
@@ -34,20 +42,24 @@ interface IconProps {
 }
 
 const icons: Record<string, IconDefinition> = {
+  'arrowRight': faArrowRight,
+  'bars': faBars,
   'clock': faClock,
   'code': faCode,
   'bolt': faBolt,
   'projectDiagram': faProjectDiagram,
   'cloudUpload': faCloudUploadAlt,
   'envelope': faEnvelope,
+  'file': faFile,
+  'hdd': faHdd,
   'list': faList,
   'check': faCheck,
   'close': faCheck, // TODO (b5) - close icon def
+  'plus': faPlus,
   'times': faTimes,
   'exclamationCircle': faExclamationCircle,
   'spinner': faSpinner,
   'table': faTable,
-  'bars': faBars
 }
 
 const sizes: {[key: string]: FontAwesomeIconProps['size']} = {

--- a/frontend/src/chrome/RelativeTimestamp.tsx
+++ b/frontend/src/chrome/RelativeTimestamp.tsx
@@ -11,7 +11,7 @@ const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({ ti
     className='relative-timestamp'
     title={format(timestamp, 'MMM d yyyy, h:mm zz')}
   >
-    {formatDistanceToNow(timestamp)}
+    {formatDistanceToNow(timestamp, { addSuffix: true })}
   </span>
 )
 

--- a/frontend/src/features/app/App.test.tsx
+++ b/frontend/src/features/app/App.test.tsx
@@ -12,5 +12,5 @@ test('initial app render', () => {
   );
 
   // app should render the splash route by default, text pulled from theere
-  expect(getByText(/Create A Dataset/i)).toBeInTheDocument();
+  expect(getByText(/New Dataset/i)).toBeInTheDocument();
 });

--- a/frontend/src/features/app/PageLayout.tsx
+++ b/frontend/src/features/app/PageLayout.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import NavBar from '../navbar/NavBar'
+
+export interface PageLayoutProps {}
+
+// for non-dataset views, contains Navbar and full-height content area with
+//overflow-y-scroll
+const PageLayout: React.FC<PageLayoutProps> = ({ children }) => (
+  <div className='flex flex-col h-full bg-gray-100'>
+    <NavBar />
+    <div className='flex-grow overflow-y-scroll bg-white'>
+      {children}
+    </div>
+  </div>
+)
+
+export default PageLayout

--- a/frontend/src/features/collection/Collection.tsx
+++ b/frontend/src/features/collection/Collection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import NavBar from '../navbar/NavBar'
+import PageLayout from '../app/PageLayout'
 import { VersionInfo } from '../../qri/versionInfo'
 import DatasetsTable from './DatasetsTable'
 import { loadDatasets } from './state/collectionActions'
@@ -15,20 +15,24 @@ const Collection: React.FC<any> = () => {
     dispatch(loadDatasets(1,50))
   }, [dispatch])
 
-  return (<div>
-    <NavBar />
-    <header>
-      <h1 className='text-2xl font-bold'>Collection</h1>
-    </header>
-    <DatasetsTable
-      filteredDatasets={datasets}
-      // When the clearSelectedTrigger changes value, it triggers the ReactDataTable
-      // to its internal the selections
-      clearSelectedTrigger={false}
-      onRowClicked={(row: VersionInfo) => {}}
-      onSelectedRowsChange={() => {}}
-      />
-  </div>)
+  return (
+    <PageLayout>
+      <div className='max-w-screen-xl mx-auto px-10 py-20'>
+        <header className='mb-8'>
+          <h1 className='text-2xl font-extrabold'>Datasets</h1>
+        </header>
+
+        <DatasetsTable
+          filteredDatasets={datasets}
+          // When the clearSelectedTrigger changes value, it triggers the ReactDataTable
+          // to its internal the selections
+          clearSelectedTrigger={false}
+          onRowClicked={(row: VersionInfo) => {}}
+          onSelectedRowsChange={() => {}}
+        />
+      </div>
+    </PageLayout>
+  )
 }
 
 export default Collection

--- a/frontend/src/features/collection/DatasetsTable.tsx
+++ b/frontend/src/features/collection/DatasetsTable.tsx
@@ -4,8 +4,8 @@ import ReactDataTable from 'react-data-table-component'
 import ReactTooltip from 'react-tooltip'
 import { Link } from 'react-router-dom'
 
+import Icon from '../../chrome/Icon'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
-// import StatusIcons from './StatusIcons'
 import ExportButton from '../../chrome/ExportButton'
 import { VersionInfo } from '../../qri/versionInfo'
 
@@ -81,7 +81,18 @@ const DatasetsTable: React.FC<DatasetsTableProps> = ({
       selector: 'name',
       sortable: true,
       grow: 2,
-      cell: (row: VersionInfo) => <Link to={`/ds/${row.username}/${row.name}`}>{row.username}/{row.name}</Link>
+      cell: (row: VersionInfo) => (
+        <div className='p-3'>
+          <div className='font-medium text-sm mb-1'>
+            <Link to={`/ds/${row.username}/${row.name}`}>{row.username}/{row.name}</Link>
+          </div>
+          <div className='text-gray-500 text-xs'>
+            <span className='mr-4'><Icon icon='hdd' size='sm' className='mr-1' />{numeral(row.bodySize).format('0.0 b')}</span>
+            <span className='mr-4'><Icon icon='bars' size='sm' className='mr-1' />{numeral(row.bodyRows).format('0,0a')} rows</span>
+            <span className='mr-4'><Icon icon='file' size='sm' className='mr-1' />{row.bodyFormat}</span>
+          </div>
+        </div>
+      )
     },
     {
       name: 'updated',
@@ -97,30 +108,16 @@ const DatasetsTable: React.FC<DatasetsTableProps> = ({
       }
     },
     {
-      name: 'size',
-      selector: 'size',
-      sortable: true,
-      width: '100px',
-      cell: (row: VersionInfo) => row.bodySize ? numeral(row.bodySize).format('0.00 b') : '--'
-    },
-    {
-      name: 'rows',
-      selector: 'rows',
-      sortable: true,
-      width: '60px',
-      cell: (row: VersionInfo) => row.bodyRows ? numeral(row.bodyRows).format('0a') : '--'
-    },
-    {
       name: 'status',
       selector: 'status',
-      width: '85px',
+      width: '180px',
       // cell: (row: VersionInfo) => <StatusIcons data={row} onClickFolder={onOpenInFinder} /> // eslint-disable-line
       cell: (row: VersionInfo) => <p>todo - status icons</p>
     },
     {
       name: '',
       selector: 'hamburger',
-      width: '60px',
+      width: '120px',
       // eslint-disable-next-line react/display-name
       cell: (row: VersionInfo) => {
         return <ExportButton qriRef={row} showIcon={true} size={'md'} />
@@ -136,11 +133,9 @@ const DatasetsTable: React.FC<DatasetsTableProps> = ({
       customStyles={customStyles}
       sortFunction={customSort}
       selectableRows={true}
-      fixedHeader
-      overflowY
-      overflowYOffset='250px'
       highlightOnHover
       pointerOnHover
+      noHeader
       onRowClicked={onRowClicked}
       onSelectedRowsChange={onSelectedRowsChange}
       clearSelectedRows={clearSelectedTrigger}

--- a/frontend/src/features/navbar/AppNavItems.tsx
+++ b/frontend/src/features/navbar/AppNavItems.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import Icon from '../../chrome/Icon'
+
 const AppNavItems: React.FC<any> = () => (
   <>
-    <Link className='px-1 font-bold' to='/'>Qrimatic</Link>
+    <Link className='px-1 font-bold text-lg tracking-tight' to='/'>Qrimatic</Link>
     <div className='w-10'></div>
-    <Link className='px-1' to='/collection'>Collection</Link>
+    <Link className='px-4' to='/collection'>Collection</Link>
     <Link className='px-1' to='/notifications'>Notifications</Link>
-    <Link className='px-1' to='/ds/new'>New Workflow</Link>
+
+    <div className='flex ml-auto'>
+    <Link to="/ds/new">
+      <div className="px-6 py-2 rounded bg-blue-600 text-blue-50 max-w-max shadow-sm hover:shadow-lg font-semibold">
+        <Icon className='mr-3' icon='plus' size='md' /> New Dataset
+      </div>
+    </Link>
+    </div>
   </>
 )
 

--- a/frontend/src/features/navbar/NavBar.tsx
+++ b/frontend/src/features/navbar/NavBar.tsx
@@ -8,12 +8,14 @@ export interface NavBarProps {
 
 const NavBar: React.FC<any> = ({ menu = [], children }) => {
   return (
-    <div className='bg-gray-800 text-white text-bold flex p-2'>
+    <div className='bg-gray-800 text-white text-bold flex p-4 items-center'>
       {(menu.length > 0) && <NavBarMenu items={menu} />}
+      <div className="py-2 opacity-0">.</div> {/* forces height */}
       {children
         ? children
         : <AppNavItems />
       }
+
     </div>
   )
 }

--- a/frontend/src/features/navbar/NavBarMenu.tsx
+++ b/frontend/src/features/navbar/NavBarMenu.tsx
@@ -16,7 +16,7 @@ const NavBarMenu: React.FC<NavBarMenuProps> = ({ items = [] }) => {
   const [open, setOpen] = useState(false)
 
   return (
-    <div className='relative mr-5 ml-3'>
+    <div className='relative mr-5 ml-1'>
       <div className='text-gray-400' onClick={() => { setOpen(!open) }}><Icon icon='bars' /></div>
       {open &&
         <div className='absolute bg-gray-600 p-5'>

--- a/frontend/src/features/notification/NotificationList.tsx
+++ b/frontend/src/features/notification/NotificationList.tsx
@@ -1,37 +1,42 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import NotificationMenu from './NotificationMenu';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-const NotificationList: React.FC<any> = () => {
-  return (
-    <div>
-    <h1>Notifications</h1>
-    <div> 
-      <h1>Sidebar</h1>
-      <NotificationMenu />
-    </div>
-    <div> Main
-    <div>
-      [-] Selected | Select All | Mark as read | Delete ||| [Filter Notifications: ______________________ ] ||| Group By: [Dataset / Date]
-    </div>
+import NotificationMenu from './NotificationMenu';
+import PageLayout from '../app/PageLayout'
+
+
+const NotificationList: React.FC<any> = () => (
+  <PageLayout>
+    <div className='max-w-screen-xl mx-auto px-10 py-20'>
+      <header className='mb-8'>
+        <h1 className='text-2xl font-extrabold'>Notifications</h1>
+      </header>
       <div>
-        <Link to='/job/id_1234_2'>
-          <h5>[ ] |success| - job/dataset_name (id_1234_2, 01/01/2021 13:03:46)</h5>
-        </Link>
+        <h1>Sidebar</h1>
+        <NotificationMenu />
       </div>
+      <div> Main
       <div>
-        <Link to='/job/id_1234_1'>
-          <h5>[x] |success| - job/dataset_name (id_1234_1, 01/01/2021 13:02:46)</h5>
-        </Link>
+        [-] Selected | Select All | Mark as read | Delete ||| [Filter Notifications: ______________________ ] ||| Group By: [Dataset / Date]
       </div>
-      <div>
-        <Link to='/job/id_1234_0'>
-          <h5>[ ] |success| - job/dataset_name (id_1234_0, 01/01/2021 13:01:46)</h5>
-        </Link>
+        <div>
+          <Link to='/job/id_1234_2'>
+            <h5>[ ] |success| - job/dataset_name (id_1234_2, 01/01/2021 13:03:46)</h5>
+          </Link>
+        </div>
+        <div>
+          <Link to='/job/id_1234_1'>
+            <h5>[x] |success| - job/dataset_name (id_1234_1, 01/01/2021 13:02:46)</h5>
+          </Link>
+        </div>
+        <div>
+          <Link to='/job/id_1234_0'>
+            <h5>[ ] |success| - job/dataset_name (id_1234_0, 01/01/2021 13:01:46)</h5>
+          </Link>
+        </div>
       </div>
     </div>
-    </div>
-  )
-}
+  </PageLayout>
+)
 
 export default NotificationList;

--- a/frontend/src/features/splash/Splash.tsx
+++ b/frontend/src/features/splash/Splash.tsx
@@ -1,20 +1,37 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-const Splash: React.FC<any> = () => {
-  return (
-    <div className='py-6 px-6 text-left'>
-      <h1 className='text-xl font-medium text-black'>Automate Your Data.</h1>
+import PageLayout from '../app/PageLayout';
+import Icon from '../../chrome/Icon';
 
-      <div className='max-w-small'>
-        <Link to='/ds/new'>
-          <div className='py-2 px-4 font-semibold rounded-lg shadow-md text-white bg-gray-600 hover:bg-gray-300'>
-            <p>Create A Dataset</p>
+const Splash: React.FC<any> = () => (
+  <PageLayout>
+    <div className='max-w-screen-xl mx-auto px-10 py-20'>
+      <div className="text-center pb-12 md:pb-16">
+        <h1 className="text-5xl md:text-6xl font-extrabold leading-tighter tracking-tighter mb-4">
+          Datasets that update themselves
+        </h1>
+        <div className="max-w-3xl mx-auto">
+          <p className="text-xl text-gray-600 mb-8">
+            Qrimatic binds code to data, so you can keep your data fresh.  Just write a script to move and munge your data, set a schedule, and we'll take care of the rest.
+          </p>
+          <div className="max-w-xs mx-auto sm:max-w-none sm:flex sm:justify-center">
+            <Link to="/ds/new" >
+              <div className="px-8 py-4 rounded bg-black text-blue-50 max-w-max shadow-sm hover:shadow-lg font-semibold mr-2">
+                Learn More
+              </div>
+            </Link>
+
+            <Link to="/ds/new" >
+              <div className="px-8 py-4 rounded bg-blue-600 text-blue-50 max-w-max shadow-sm hover:shadow-lg font-semibold">
+                Try it out now <Icon className='ml-3' icon='arrowRight' />
+              </div>
+            </Link>
           </div>
-        </Link>
+        </div>
       </div>
     </div>
-  )
-}
+  </PageLayout>
+)
 
 export default Splash;

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import NavBar from '../navbar/NavBar'
+
 const templates = [
   {
     name: 'CSV Download',
@@ -22,26 +24,36 @@ const templates = [
 
 const TemplateList: React.FC<any> = () => {
   return (
-    <div className='text-left p-10 max-w-screen-md mx-auto'>
-      <h1 className='text-black text-xl'>New Dataset</h1>
-      <p>Choose a template</p>
-      <br />
-      <div className='text-lg text-bold flex flex-wrap -mx-2 overflow-hidden'>
-        {
-          templates.map(({ name, id }) => (
-            <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
-              <Link to={{ 
-                pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}`,
-                state: { template: id }
-              }}>
-                <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm p-10 text-center'>
-                    <h3>{name}</h3>
+    <div className='flex flex-col h-full bg-gray-100'>
+      <NavBar menu={[
+        { type: 'link', label: 'back to collection', to: '/collection' },
+        { type: 'hr' }
+      ]}>
+        <p className='font-bold text-white'>New Dataset</p>
+      </NavBar>
+        <div className='max-w-screen-xl mx-auto px-10 py-20'>
+          <header className='mb-8'>
+            <h1 className='text-2xl font-extrabold'>Choose a Dataset Template</h1>
+          </header>
+          <p>Each template contains starter code for a common data update technique.  Choose the best fit and start customizing your new dataset workflow.</p>
+          <br />
+          <div className='text-lg text-bold flex flex-wrap -mx-2 overflow-hidden'>
+            {
+              templates.map(({ name, id }) => (
+                <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
+                  <Link to={{
+                    pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}`,
+                    state: { template: id }
+                  }}>
+                    <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm px-10 py-16 text-center'>
+                        <div className='font-semibold text-lg'>{name}</div>
+                    </div>
+                  </Link>
                 </div>
-              </Link>
-            </div>
-          ))
-        }
-      </div>
+              ))
+            }
+          </div>
+        </div>
     </div>
   )
 }


### PR DESCRIPTION
This PR has some layout improvements that will make it easier to navigate around the nascent app.  

- Adds `TopLevelLayout` component to standardize Navbar and content area for non-dataset views
- Improves `Splash` with some welcome text, subtitle, and buttons
- Standardizes height of Navbar in both contexts (dataset vs non-dataset)
- Adds a 'New Dataset' button to Navbar on non-dataset views
- Adds a two-line view to the name column in collection view, freeing up horizontal space and putting dataset metrics under the name"


<img width="1283" alt="React_Redux_App" src="https://user-images.githubusercontent.com/1833820/106061738-cd0cf600-60c3-11eb-90a0-262b06607ba3.png">
