### PR TITLE
refactor(frontend): fit events to qri backend

### DIFF
--- a/frontend/src/features/websocket/middleware/websocket.ts
+++ b/frontend/src/features/websocket/middleware/websocket.ts
@@ -1,7 +1,7 @@
 import { Dispatch, AnyAction, Store } from 'redux'
 
 import { QriRef } from '../../../qri/ref'
-import { NewEventLogLine } from '../../../qrimatic/eventLog'
+import { NewEventLogLine } from '../../../qri/eventLog'
 import { RootState } from '../../../store/store'
 import { jobScheduled, jobUnscheduled, jobStarted, jobStopped } from '../../job/state/jobActions'
 import { trackVersionTransfer, completeVersionTransfer, removeVersionTransfer } from '../../transfer/state/transferActions'
@@ -111,7 +111,7 @@ const middleware = () => {
     try {
       const event = JSON.parse(e.data)
 
-      if (event.type.startsWith("transform:")) {
+      if (event.type.startsWith("tf:")) {
         dispatch(runEventLog(NewEventLogLine(event)))
         return
       }

--- a/frontend/src/features/workflow/Workflow.tsx
+++ b/frontend/src/features/workflow/Workflow.tsx
@@ -36,7 +36,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   }, [dispatch, qriRef])
 
   return (
-    <div className='flex h-full bg-gray-100'>
+    <div className='flex h-full'>
       <WorkflowOutline run={latestRun} onDeploy={() => { dispatch(showModal(AppModalType.deployWorkflow)) }} />
       <WorkflowEditor workflow={workflow} run={latestRun} />
     </div>

--- a/frontend/src/features/workflow/output/LogLinePrint.tsx
+++ b/frontend/src/features/workflow/output/LogLinePrint.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EventLogLine, EventLogLineType } from '../../qrimatic/eventLog'
+import { EventLogLine, EventLogLineType } from '../../../qri/eventLog'
 
 export interface LogLineProps {
   line: EventLogLine
@@ -7,9 +7,8 @@ export interface LogLineProps {
 
 const LogLinePrint: React.FC<LogLineProps> = ({ line }) => {
   switch (line.type) {
-    case EventLogLineType.ETWarn:
-     return <p className='text-yellow-500'>{line.data.msg}</p>
-    case EventLogLineType.ETDebug:
+    case EventLogLineType.ETPrint:
+      // TODO (b5) - utilize line.data.lvl to set output colour
      return <p className='text-gray-500'>{line.data.msg}</p>
     case EventLogLineType.ETError:
      return <p className='text-red-500'>{line.data.msg}</p>

--- a/frontend/src/features/workflow/output/Output.tsx
+++ b/frontend/src/features/workflow/output/Output.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
+
 import { Dataset } from '../../../qri/dataset'
-import { EventLogLine, EventLogLineType } from '../../../qrimatic/eventLog'
+import { EventLogLine, EventLogLineType } from '../../../qri/eventLog'
 import { DatasetPreview } from './DatasetPreview'
-import LogLinePrint from '../LogLinePrint'
+import LogLinePrint from './LogLinePrint'
 
 export interface OutputProps {
   data?: EventLogLine[]
@@ -14,11 +15,9 @@ const Output: React.FC<OutputProps> = ({ data }) => {
     {data && data.map((line, i) => {
       switch (line.type) {
         case EventLogLineType.ETPrint:
-        case EventLogLineType.ETDebug:
         case EventLogLineType.ETError:
-        case EventLogLineType.ETWarn:
           return <LogLinePrint key={i} line={line} />
-        case EventLogLineType.ETDataset:
+        case EventLogLineType.ETDatasetPreview:
           return <DatasetPreview key={i} data={line.data as Dataset}/>
         default:
           return <p key={i}>{JSON.stringify(line, undefined, 2)}</p>

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -1,5 +1,5 @@
 import { QriRef } from '../../../qri/ref'
-import { EventLogLine } from '../../../qrimatic/eventLog'
+import { EventLogLine } from '../../../qri/eventLog'
 import { Workflow, workflowScriptString } from '../../../qrimatic/workflow'
 import { CALL_API, ApiActionThunk } from '../../../store/api'
 import { 

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -4,7 +4,7 @@ import { RootState } from '../../../store/store';
 import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction, SetWorkflowRefAction } from './workflowActions';
 import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
 import { Workflow } from '../../../qrimatic/workflow';
-import { EventLogLine } from '../../../qrimatic/eventLog';
+import { EventLogLine } from '../../../qri/eventLog';
 import Dataset from '../../../qri/dataset';
 import { QriRef } from '../../../qri/ref';
 

--- a/frontend/src/features/workflow/stories/data/eventLogSuccess.json
+++ b/frontend/src/features/workflow/stories/data/eventLogSuccess.json
@@ -1,22 +1,4 @@
-
-export const eventLogWithError = [
-  { "type": "transform:TransformStart", "ts": 1609459200090, "sid": "aaaa", "data": {"id": "aaaa" }},
-  { "type": "transform:TransformStepStart", "ts": 1609459300090, "sid": "aaaa", "data": {"name": "setup" }},
-  { "type": "transform:VersionPulled", "ts": 1609459400090, "sid": "aaaa", "data": {"refstring": "rico/presidents@QmFoo", "remote": "https://registy.qri.cloud" }},
-  { "type": "transform:TransformStepStop",     "ts": 1609459500090, "sid": "aaaa", "data": {"name": "setup", "status": "succeeded" }},
-  { "type": "transform:TransformStepStart",   "ts": 1609459600090, "sid": "aaaa", "data": {"name": "download" }},
-  { "type": "transform:Print",                    "ts": 1609459700090, "sid": "aaaa", "data": {"msg": "oh hai there" }},
-  { "type": "transform:HttpRequestStart", "ts": 1609459800090, "sid": "aaaa", "data": {"id": "bbbb", "downloadSize": 230409, "method": "GET", "url": "https://registy.qri.cloud" }},
-  { "type": "transform:HttpRequestStop", "ts": 1609459900090, "sid": "aaaa", "data": {"size": 230409, "method": "GET", "url": "https://registy.qri.cloud" }},
-  { "type": "transform:TransformStepStop",    "ts": 1609460000090, "sid": "aaaa", "data": {"name": "download", "status": "succeeded" }},
-  { "type": "transform:TransformStepStart",   "ts": 1609460100090, "sid": "aaaa", "data": {"name": "transform" }},
-  { "type": "transform:Error",    "ts": 1609460200090, "sid": "aaaa", "data": {"msg": "oh shit. it broke." }},
-  { "type": "transform:TransformStepStop",    "ts": 1609460300090, "sid": "aaaa", "data": {"name": "transform", "status": "failed", "error": "oh shit. it broke."}},
-  { "type": "transform:TransformStepSkip",   "ts": 1609460400090, "sid": "aaaa", "data": {"name": "save" }},
-  { "type": "transform:TransformStop",        "ts": 1609460500090, "sid": "aaaa", "data": {"status": "failed" }}
-]
-
-export const eventLogSuccess = [
+[
   { "type": "transform:TransformStart",        "ts": 1609460600090, "sid": "bbbb", "data": {"id": "bbbb" }},
   { "type": "transform:TransformStepStart",   "ts": 1609460700090, "sid": "bbbb", "data": {"name": "setup" }},
   { "type": "transform:VersionPulled",           "ts": 1609460800090, "sid": "bbbb", "data": {"refstring": "rico/presidents@QmFoo", "remote": "https://registy.qri.cloud" }},
@@ -2058,50 +2040,3 @@ export const eventLogSuccess = [
   { "type": "transform:TransformStepStop",    "ts": 1609461800090, "sid": "bbbb", "data": {"name": "save", "status": "succeeded"}},
   { "type": "transform:TransformStop",        "ts": 1609461900090, "sid": "aaaa", "data": {"status": "failed" }}
 ]
-
-export enum EventLogLineType {
-  ETDebug = "transform:Debug",
-  ETPrint = "transform:Print",
-  ETWarn = "transform:Warn",
-  ETError = "transform:Error",
-  ETReference = "transform:Reference",
-  ETDataset = "transform:Dataset",
-  ETChangeReport = "transform:ChangeReport",
-  ETHistory = "transform:History",
-  ETProfile = "transform:Profile",
-
-  ETVersionSaved = "transform:VersionSaved",
-  ETVersionPulled = "transform:VersionPulled",
-  ETVersionPushed = "transform:VersionPushed",
-  ETHistoryChanged = "transform:HistoryChanged",
-  
-  ETTransformStart = "transform:TransformStart",
-  ETTransformStop = "transform:TransformStop",
-  ETTransformSkip = "transform:TransformSkip",
-  ETTransformStepStart = "transform:TransformStepStart",
-  ETTransformStepStop = "transform:TransformStepStop",
-  ETTransformStepSkip = "transform:TransformStepSkip",
-
-  ETHttpRequestStart = "transform:HttpRequestStart",
-  ETHttpRequestStop = "transform:HttpRequestStop",
-}
-
-export interface EventLogLine {
-  type: EventLogLineType
-  ts: number
-  sid: string
-  data: Record<string,any>
-}
-
-export function NewEventLogLine(data: Record<string,any>): EventLogLine {
-  return {
-    type: data.type,
-    ts: data.ts,
-    sid: data.sid,
-    data: data.data
-  }
-}
-
-export function NewEventLogLines(data: Record<string,any>[]): EventLogLine[] {
-  return data.map(NewEventLogLine)
-}

--- a/frontend/src/features/workflow/stories/data/eventLogWithError.json
+++ b/frontend/src/features/workflow/stories/data/eventLogWithError.json
@@ -1,0 +1,16 @@
+[
+  { "type": "transform:TransformStart", "ts": 1609459200090, "sid": "aaaa", "data": {"id": "aaaa" }},
+  { "type": "transform:TransformStepStart", "ts": 1609459300090, "sid": "aaaa", "data": {"name": "setup" }},
+  { "type": "transform:VersionPulled", "ts": 1609459400090, "sid": "aaaa", "data": {"refstring": "rico/presidents@QmFoo", "remote": "https://registy.qri.cloud" }},
+  { "type": "transform:TransformStepStop",     "ts": 1609459500090, "sid": "aaaa", "data": {"name": "setup", "status": "succeeded" }},
+  { "type": "transform:TransformStepStart",   "ts": 1609459600090, "sid": "aaaa", "data": {"name": "download" }},
+  { "type": "transform:Print",                    "ts": 1609459700090, "sid": "aaaa", "data": {"msg": "oh hai there" }},
+  { "type": "transform:HttpRequestStart", "ts": 1609459800090, "sid": "aaaa", "data": {"id": "bbbb", "downloadSize": 230409, "method": "GET", "url": "https://registy.qri.cloud" }},
+  { "type": "transform:HttpRequestStop", "ts": 1609459900090, "sid": "aaaa", "data": {"size": 230409, "method": "GET", "url": "https://registy.qri.cloud" }},
+  { "type": "transform:TransformStepStop",    "ts": 1609460000090, "sid": "aaaa", "data": {"name": "download", "status": "succeeded" }},
+  { "type": "transform:TransformStepStart",   "ts": 1609460100090, "sid": "aaaa", "data": {"name": "transform" }},
+  { "type": "transform:Error",    "ts": 1609460200090, "sid": "aaaa", "data": {"msg": "oh shit. it broke." }},
+  { "type": "transform:TransformStepStop",    "ts": 1609460300090, "sid": "aaaa", "data": {"name": "transform", "status": "failed", "error": "oh shit. it broke."}},
+  { "type": "transform:TransformStepSkip",   "ts": 1609460400090, "sid": "aaaa", "data": {"name": "save" }},
+  { "type": "transform:TransformStop",        "ts": 1609460500090, "sid": "aaaa", "data": {"status": "failed" }}
+]

--- a/frontend/src/qri/eventLog.ts
+++ b/frontend/src/qri/eventLog.ts
@@ -1,0 +1,44 @@
+export enum EventLogLineType {
+  ETTransformStart = "tf:Start",
+  ETTransformStop = "tf:Stop",
+  ETTransformStepStart = "tf:StepStart",
+  ETTransformStepStop = "tf:StepStop",
+  ETTransformStepSkip = "tf:StepSkip",
+
+  ETPrint = "tf:Print",
+  ETError = "tf:Error",
+  
+  ETReference = "tf:Reference",
+  ETDatasetPreview = "tf:DatasetPreview",
+  ETChangeReport = "tf:ChangeReport",
+  ETHistory = "tf:History",
+  ETProfile = "tf:Profile",
+
+  ETVersionSaved = "tf:VersionSaved",
+  ETVersionPulled = "tf:VersionPulled",
+  ETVersionPushed = "tf:VersionPushed",
+  ETHistoryChanged = "tf:HistoryChanged",
+
+  ETHttpRequestStart = "tf:HttpRequestStart",
+  ETHttpRequestStop = "tf:HttpRequestStop",
+}
+
+export interface EventLogLine {
+  type: EventLogLineType
+  ts: number
+  sessionID: string
+  data: Record<string,any>
+}
+
+export function NewEventLogLine(data: Record<string,any>): EventLogLine {
+  return {
+    type: data.type,
+    ts: data.ts,
+    sessionID: data.sessionID,
+    data: data.data
+  }
+}
+
+export function NewEventLogLines(data: Record<string,any>[]): EventLogLine[] {
+  return data.map(NewEventLogLine)
+}


### PR DESCRIPTION
frontend expectations now align with backend field names for `/apply` & corresponding websocket events