### PR TITLE
feat: monaco editor improvements

### DIFF
--- a/frontend/src/features/dataset/Dataset.tsx
+++ b/frontend/src/features/dataset/Dataset.tsx
@@ -29,7 +29,7 @@ const Dataset: React.FC<any> = () => {
       </NavBar>
       <div className='flex flex-grow overflow-hidden'>
         <DatasetNavSidebar qriRef={qriRef} />
-        <div className='h-full'>
+        <div className='h-full overflow-hidden'>
           <Switch>
             <Route path='/ds/:username/:dataset' exact><Workflow qriRef={qriRef} /></Route>
             <Route path='/ds/:username/:dataset/components'><DatasetComponents /></Route>

--- a/frontend/src/features/workflow/RunBar.tsx
+++ b/frontend/src/features/workflow/RunBar.tsx
@@ -20,7 +20,7 @@ const RunBar: React.FC<RunBarProps> = ({
   onDeploy,
   onDeployCancel,
 }) => (
-  <div className='pt-4 sticky top-0 shadow-md'>
+  <div className='pt-4 sticky top-0 shadow-md z-10'>
    <div className='flex bg-gray-100 rounded border border-gray-200'>
      <div className='flex-2'>
        {(status !== RunState.waiting) && <p><RunStateIcon state={status} /></p>}


### PR DESCRIPTION
- editor properly resizes width when the window is resized
- editor theme customizations (only sets gray background, but a custom theme is now defined in the code that we can to later)
- run bar appears above code editors (z-index change, was below)
- editor automatically increases vertical height when new lines are added
- editor no longer consumes scroll wheel events, so user can scroll up and down the workflow editor with ease