### PR TITLE
feat: improve run state icons

### DIFF
--- a/frontend/src/chrome/Icon.tsx
+++ b/frontend/src/chrome/Icon.tsx
@@ -6,6 +6,7 @@ import {
   faArrowRight,
   faBars,
   faBolt,
+  faCircle,
   faClock,
   faCloudUploadAlt,
   faCode,
@@ -44,6 +45,7 @@ interface IconProps {
 const icons: Record<string, IconDefinition> = {
   'arrowRight': faArrowRight,
   'bars': faBars,
+  'circle': faCircle,
   'clock': faClock,
   'code': faCode,
   'bolt': faBolt,

--- a/frontend/src/features/workflow/CodeEditor.tsx
+++ b/frontend/src/features/workflow/CodeEditor.tsx
@@ -9,7 +9,7 @@ export interface CodeEditorProps {
 
 const LINE_HEIGHT = 19
 const MIN_LINE_COUNT = 4
-const PADDING = 14
+const PADDING = 15
 
 const CodeEditor: React.FC<CodeEditorProps> = ({ script, onChange }) => {
   const ref = useRef<MonacoEditor>(null)
@@ -51,7 +51,6 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ script, onChange }) => {
   }
 
   const handleResize = () => {
-    console.log('calling layout')
     if (theEditor) theEditor.layout()
   }
 

--- a/frontend/src/features/workflow/RunStateIcon.tsx
+++ b/frontend/src/features/workflow/RunStateIcon.tsx
@@ -12,13 +12,13 @@ const RunStateIcon: React.FC<RunStateIconProps> = ({ state }) => (
     {((s: RunState) => {
       switch (s) {
         case 'waiting':
-          return <span className='text-gray-500'><Icon icon='check' /></span>
+          return <span className='text-gray-400'><Icon icon='circle' size='sm'/></span>
         case 'running':
-          return <span className='text-blue-500'><Icon icon='check' /></span>
+          return <span className='text-blue-500'><Icon icon='spinner' size='sm' spin /></span>
         case 'succeeded':
-          return <span className='text-green-500'><Icon icon='check' /></span>
+          return <span className='text-green-500'><Icon icon='check' size='sm'/></span>
         case 'failed':
-          return <span className='text-red-500'><Icon icon='close' /></span>
+          return <span className='text-red-500'><Icon icon='exclamationCircle' size='sm' /></span>
         case 'skipped':
           return <span></span>
         default:

--- a/frontend/src/features/workflow/WorkflowOutline.tsx
+++ b/frontend/src/features/workflow/WorkflowOutline.tsx
@@ -33,11 +33,11 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDepl
           {workflow && workflow.steps?.map((step: TransformStep, i: number) => {
             let r
             if (run) {
-              r = (run?.steps && run?.steps.length >= i) ? run.steps[i] : NewRunStep({ status: RunState.waiting })
+              r = (run?.steps && run?.steps.length >= i && run.steps[i]) ? run.steps[i] : NewRunStep({ status: RunState.waiting })
             }
             return (
               <div key={i} className='text-sm ml-2'>
-                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name} 
+                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name}
                 {r && <div className='float-right text-green-500'><RunStateIcon state={r.status || RunState.waiting} /></div>}
               </div>
             )


### PR DESCRIPTION
- Modifies run state icons to show
  * waiting: gray circle
  * running: blue spinner
  * succeeded: green check
  * failed: red exclamation circle
  
- Makes runstate icons smaller in outline view
- Fixes logic that was causing no run state icon to appear at certain times
- 
  
![Jan-28-2021 15-40-37](https://user-images.githubusercontent.com/1833820/106203723-d95b8680-6189-11eb-8bd0-f3de8c788a38.gif)
