### PR TITLE
run bar enhancements and tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 vscode/
 .idea/
 build/
+qrimatic/qrimatic

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "react-tooltip": "^4.2.11",
+    "react-tooltip": "4.2.13",
     "sleep-promise": "^9.0.0",
     "styled-components": "^5.2.1",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",

--- a/frontend/src/chrome/TooltipContent.tsx
+++ b/frontend/src/chrome/TooltipContent.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface TooltipContentProps {
+  text: string,
+  subtext?: string
+}
+
+
+const TooltipContent: React.FC<TooltipContentProps> = ({ text, subtext }) => (
+  <div className='text-left' style={{ maxWidth: '140px'}}>
+    <div className='font-semibold text-sm mb-1'>{text}</div>
+    <div className='font-semibold text-xs text-gray-400'>{subtext}</div>
+  </div>
+)
+
+export default TooltipContent

--- a/frontend/src/features/app/App.css
+++ b/frontend/src/features/app/App.css
@@ -37,3 +37,10 @@
     transform: translateY(0px)
   }
 }
+
+
+/* override fade-in/fade-out transition on react-tooltip */
+.__react_component_tooltip {
+	transition: opacity 0.1s ease-in-out !important;
+	visibility: visible;
+}

--- a/frontend/src/features/app/App.tsx
+++ b/frontend/src/features/app/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { ConnectedRouter } from 'connected-react-router'
 import { useDispatch } from 'react-redux';
+import ReactTooltip from 'react-tooltip'
 
 import { history } from '../../store/store'
 import Routes from '../../routes'
@@ -11,9 +12,15 @@ import './App.css';
 
 const App: React.FC<any> = () => {
   const dispatch = useDispatch()
+
   useEffect(() => {
     dispatch(wsConnect())
+    // this "wires up" all of the tooltips, must be called on update, as tooltips
+    // in descendents can come and go
+    ReactTooltip.rebuild()
   })
+
+
 
   return (
     <div id='app' className='flex flex-col h-screen'>
@@ -21,6 +28,22 @@ const App: React.FC<any> = () => {
         <Modal />
         <Routes />
       </ConnectedRouter>
+      {/*
+        This is a global react-tooltip element for general use in the app.
+        Local/specialized implementations are also possible, see SideNavItem
+        To add a tooltip to any element, add a data-tip={'tooltip text'} and
+        data-for='global' attributes
+
+        See useEffect(), which calls rebuild() to re-bind all tooltipsToolti
+      */}
+      <ReactTooltip
+        id='global'
+        place='bottom'
+        type='dark'
+        effect='solid'
+        delayShow={50}
+        multiline
+      />
     </div>
   );
 }

--- a/frontend/src/features/dataset/DatasetNavSidebar.tsx
+++ b/frontend/src/features/dataset/DatasetNavSidebar.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+
 import { QriRef } from '../../qri/ref'
 import SideNavItem from './SideNavItem'
+import TooltipContent from '../../chrome/TooltipContent'
 
 export interface DatasetNavSidebarProps {
   qriRef: QriRef
@@ -8,9 +10,39 @@ export interface DatasetNavSidebarProps {
 
 const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
   <div className='side-nav border-r border-1 h-full'>
-    <SideNavItem icon='code' to={`/ds/${qriRef.username}/${qriRef.name}`} />
-    <SideNavItem icon='table' to={`/ds/${qriRef.username}/${qriRef.name}/components`}/>
-    <SideNavItem icon='clock' to={`/ds/${qriRef.username}/${qriRef.name}/history`}/>
+    <SideNavItem
+      id='workflow-editor'
+      icon='code'
+      to={`/ds/${qriRef.username}/${qriRef.name}`}
+      tooltip={
+        <TooltipContent
+          text='Workflow Editor'
+          subtext='Automate updates to this dataset'
+        />
+      }
+    />
+    <SideNavItem
+      id='components'
+      icon='table'
+      to={`/ds/${qriRef.username}/${qriRef.name}/components`}
+      tooltip={
+        <TooltipContent
+          text='Components'
+          subtext='Explore the lastest version of this dataset'
+        />
+      }
+    />
+    <SideNavItem
+      id='activity-feed'
+      icon='clock'
+      to={`/ds/${qriRef.username}/${qriRef.name}/history`}
+      tooltip={
+        <TooltipContent
+          text='Activity Feed'
+          subtext='Inspect recent job activity and updates'
+        />
+      }
+    />
   </div>
 )
 

--- a/frontend/src/features/dataset/SideNavItem.tsx
+++ b/frontend/src/features/dataset/SideNavItem.tsx
@@ -1,20 +1,39 @@
 import React from 'react'
 import { Link, useLocation } from 'react-router-dom';
+import ReactTooltip from 'react-tooltip'
 
 import Icon from '../../chrome/Icon';
 
 export interface SideNavItemProps {
+  id: string;
   icon: string;
   to: string;
+  tooltip?: React.ReactNode
 }
 
-const SideNavItem: React.FC<SideNavItemProps> = ({ icon, to }) => {
+const SideNavItem: React.FC<SideNavItemProps> = ({ id, icon, to, tooltip }) => {
   const { pathname } = useLocation();
   const active = pathname === to
   return (
       <Link to={to} className=''>
-        <div className={`text-gray-500 text-center h-10 w-10 m-3 rounded py-2 hover:bg-gray-300 transition-all duration-200 ${active && 'bg-gray-300'}`}>
+        <div
+          className={`text-gray-500 text-center h-10 w-10 m-3 rounded py-2 hover:bg-gray-300 transition-all duration-200 ${active && 'bg-gray-300'}`}
+          data-tip
+          data-for={id}
+        >
           <Icon icon={icon} />
+          {tooltip && (
+            <ReactTooltip
+              id={id}
+              place='right'
+              effect='solid'
+              offset={{
+                right: 10
+              }}
+            >
+              {tooltip}
+            </ReactTooltip>
+          )}
         </div>
       </Link>
   )

--- a/frontend/src/features/workflow/RunBar.tsx
+++ b/frontend/src/features/workflow/RunBar.tsx
@@ -7,35 +7,27 @@ export interface RunBarProps {
  status: RunState,
  onRun: () => void,
  onRunCancel: () => void,
- showDeployButton?: boolean,
- onDeploy: () => void,
- onDeployCancel: () => void,
 }
 
 const RunBar: React.FC<RunBarProps> = ({
   status,
   onRun,
-  onRunCancel,
-  showDeployButton,
-  onDeploy,
-  onDeployCancel,
+  onRunCancel
 }) => (
-  <div className='pt-4 sticky top-0 shadow-md z-10'>
-   <div className='flex bg-gray-100 rounded border border-gray-200'>
-     <div className='flex-2'>
-       {(status !== RunState.waiting) && <p><RunStateIcon state={status} /></p>}
-     </div>
-     <div className='flex-1 text-right'>
-       <button
-         className='py-1 px-4 mx-1 font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-300'
-         onClick={() => {(status === RunState.running) ? onRunCancel() : onRun() }}
-       >{(status === RunState.running) ? 'Cancel' : 'Run' }</button>
-       {showDeployButton && <button
-         className='py-1 px-4 mx-1 font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-300'
-         onClick={() => {(status === RunState.running) ? onDeployCancel() : onDeploy() }}
-       >{(status === RunState.running) ? 'Cancel' : 'Deploy' }</button>}
-     </div>
-   </div>
+  <div className=''>
+    <div className='flex'>
+      <div className='flex-2 mr-2'>
+        <div className='inline-block align-middle'>
+          <RunStateIcon state={status} size='md' />
+        </div>
+      </div>
+      <div className='flex-1 text-right'>
+        <button
+          className='w-40 py-1 px-4 mx-1 font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-500 rounded'
+          onClick={() => {(status === RunState.running) ? onRunCancel() : onRun() }}
+        >{(status === RunState.running) ? 'Cancel' : 'Dry Run' }</button>
+      </div>
+    </div>
   </div>
 )
 

--- a/frontend/src/features/workflow/RunStateIcon.tsx
+++ b/frontend/src/features/workflow/RunStateIcon.tsx
@@ -5,20 +5,21 @@ import { RunState } from '../../qrimatic/run'
 
 export interface RunStateIconProps {
   state: RunState
+  size?: "sm" | "xs" | "md" | "lg"
 }
 
-const RunStateIcon: React.FC<RunStateIconProps> = ({ state }) => (
+const RunStateIcon: React.FC<RunStateIconProps> = ({ state, size='sm' }) => (
   <span className='text-sm pl-2'>
     {((s: RunState) => {
       switch (s) {
         case 'waiting':
-          return <span className='text-gray-400'><Icon icon='circle' size='sm'/></span>
+          return <span className='text-gray-400'><Icon icon='circle' size={size}/></span>
         case 'running':
-          return <span className='text-blue-500'><Icon icon='spinner' size='sm' spin /></span>
+          return <span className='text-blue-500'><Icon icon='spinner' size={size} spin /></span>
         case 'succeeded':
-          return <span className='text-green-500'><Icon icon='check' size='sm'/></span>
+          return <span className='text-green-500'><Icon icon='check' size={size}/></span>
         case 'failed':
-          return <span className='text-red-500'><Icon icon='exclamationCircle' size='sm' /></span>
+          return <span className='text-red-500'><Icon icon='exclamationCircle' size={size} /></span>
         case 'skipped':
           return <span></span>
         default:

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -7,8 +7,6 @@ import OnComplete from './OnComplete';
 import { NewRunStep, Run, RunState, RunStep } from '../../qrimatic/run';
 import { TransformStep } from '../../qri/dataset';
 import { changeWorkflowTransformStep, runWorkflow } from './state/workflowActions';
-import { ModalType } from '../app/state/appState';
-import { showModal } from '../app/state/appActions';
 import RunBar from './RunBar';
 import { Workflow } from '../../qrimatic/workflow';
 
@@ -44,20 +42,25 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ run, workflow }) => {
   return (
     <div className='overflow-y-auto p-4 text-left h-full flex-grow'>
       <WorkflowTriggersEditor triggers={workflow.triggers} />
-      <section className='p-4 bg-white shadow-sm mb-4'>
-        <h2 className='text-2xl font-semibold text-gray-600 mb-1'>Script</h2>
-        <div className='text-xs mb-3'>Use code to download source data, transform it, and commit the next version of this dataset</div>
-        <RunBar
-          status={run ? run.status : RunState.waiting }
-          onRun={() => {
-            setCollapseStates({})
-            dispatch(runWorkflow(workflow))
-          }}
-          onRunCancel={() => { alert('cannot cancel runs yet') }}
-          onDeploy={() => { dispatch(showModal(ModalType.deployWorkflow)) }}
-          onDeployCancel={() => { alert('cannot cancel deploys yet') }}
-        />
-        <div>
+      <section className='bg-white shadow-sm mb-4'>
+        <div className='bg-white sticky top-0 z-10 p-4 flex bg-opacity-90'>
+          <div className='flex-grow'>
+            <h2 className='text-2xl font-semibold text-gray-600 mb-1'>Script</h2>
+            <div className='text-xs'>Use code to download source data, transform it, and commit the next version of this dataset</div>
+          </div>
+          <div>
+            <RunBar
+              status={run ? run.status : RunState.waiting }
+              onRun={() => {
+                setCollapseStates({})
+                dispatch(runWorkflow(workflow))
+              }}
+              onRunCancel={() => { alert('cannot cancel runs yet') }}
+            />
+          </div>
+        </div>
+
+        <div className='px-4'>
           {workflow.steps && workflow.steps.map((step, i) => {
             let r
             if (run) {

--- a/frontend/src/features/workflow/WorkflowOutline.tsx
+++ b/frontend/src/features/workflow/WorkflowOutline.tsx
@@ -54,7 +54,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDepl
           <Icon icon='envelope'/>
         </div>
         <button
-          className='mt-4 py-1 px-4 w-full font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-300 rounded'
+          className='mt-4 py-1 px-4 w-full font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-500 rounded'
           onClick={() => { onDeploy() }}
         >
           Deploy Workflow

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11478,9 +11478,10 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-tooltip@^4.2.11:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.11.tgz#244d4d1833c583160c4e6c95a8a89e0fb320e18a"
+react-tooltip@^4.2.13:
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.13.tgz#908db8a41dc10ae2ae9cc1864746cde939aaab0f"
+  integrity sha512-iAZ02wSxChLWb7Vnu0zeQMyAo/jiGHrwFNILWaR3pCKaFVRjKcv/B6TBI4+Xd66xLXVzLngwJ91Tf5D+mqAqVA==
   dependencies:
     prop-types "^15.7.2"
     uuid "^7.0.3"


### PR DESCRIPTION
- Adds react-tooltip and implements uniform multiline tooltips as a prop of `SideNavItem` 
- Refactors the sticky run bar, now the section header for "Scripts" will be sticky
- Renames "Run" button to "Dry Run"