### PR TITLE
feat(`Workflow`): adjust UI based on the `lastRunType`

### DIFF
--- a/frontend/src/features/app/Modal.tsx
+++ b/frontend/src/features/app/Modal.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { clearModal } from './state/appActions'
 import { ModalType, selectModal } from './state/appState'
-import DeployWorkflowModal from '../workflow/modal/DeployWorkflowModal'
+import DeployWorkflowModal, { DeployWorkflowModalProps } from '../workflow/modal/DeployWorkflowModal'
 import ScheduleModal from '../workflow/modal/ScheduleModal'
 
 const Modal: React.FC<any> = () => {
@@ -28,7 +28,7 @@ const Modal: React.FC<any> = () => {
                     case ModalType.schedulePicker:
                       return <ScheduleModal {...modal.props} />
                     case ModalType.deployWorkflow:
-                        return <DeployWorkflowModal {...modal.props} />
+                        return <DeployWorkflowModal {...modal.props as DeployWorkflowModalProps} />
                     default:
                       return null
                   }

--- a/frontend/src/features/app/Modal.tsx
+++ b/frontend/src/features/app/Modal.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { clearModal } from './state/appActions'
 import { ModalType, selectModal } from './state/appState'
-import DeployWorkflowModal, { DeployWorkflowModalProps } from '../workflow/modal/DeployWorkflowModal'
+import DeployWorkflowModal from '../workflow/modal/DeployWorkflowModal'
 import ScheduleModal from '../workflow/modal/ScheduleModal'
 
 const Modal: React.FC<any> = () => {
@@ -28,7 +28,7 @@ const Modal: React.FC<any> = () => {
                     case ModalType.schedulePicker:
                       return <ScheduleModal {...modal.props} />
                     case ModalType.deployWorkflow:
-                        return <DeployWorkflowModal {...modal.props as DeployWorkflowModalProps} />
+                        return <DeployWorkflowModal {...modal.props} />
                     default:
                       return null
                   }

--- a/frontend/src/features/workflow/RunBar.tsx
+++ b/frontend/src/features/workflow/RunBar.tsx
@@ -13,8 +13,17 @@ const RunBar: React.FC<RunBarProps> = ({
   status,
   onRun,
   onRunCancel
-}) => (
-  <div className=''>
+}) => {
+
+  // TODO (ramfox): when we get the ability to switch between "dry run" and "run and save"
+  // we need to switch on `runButtonType` and set `setRunButtonType`
+  // const dispatch = useDispatch()
+  // const runButtonType = useSelector(selectRunButtonType)
+  // const handleSwitchButtonTypes = (runType: RunType) => {
+  //   dispatch(setRunButtonType(runType))
+  //   dispatch(clearRun())
+  // }
+  return (<div className=''>
     <div className='flex'>
       <div className='flex-2 mr-2'>
         <div className='inline-block align-middle'>
@@ -28,7 +37,7 @@ const RunBar: React.FC<RunBarProps> = ({
         >{(status === RunState.running) ? 'Cancel' : 'Dry Run' }</button>
       </div>
     </div>
-  </div>
-)
+  </div>)
+}
 
 export default RunBar

--- a/frontend/src/features/workflow/Workflow.tsx
+++ b/frontend/src/features/workflow/Workflow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -10,10 +10,14 @@ import { QriRef } from '../../qri/ref';
 import { ModalType } from '../app/state/appState';
 import { showModal } from '../app/state/appActions';
 import WorkflowEditor from './WorkflowEditor';
+import { RunType } from '../../qrimatic/run';
+import { DeployWorkflowModalProps } from './modal/DeployWorkflowModal';
 
 interface WorkflowLocationState {
   template: string
 }
+
+export type SetRunTypeFunc = React.Dispatch<React.SetStateAction<RunType>>
 
 export interface WorkflowProps {
   qriRef: QriRef
@@ -24,6 +28,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const location = useLocation<WorkflowLocationState>()
   const workflow = useSelector(selectWorkflow)
   const latestRun = useSelector(selectLatestRun)
+  const [lastRunType, setLastRunType] = useState<RunType>(RunType.dry)
 
   useEffect(() => {
     if (location.state && location.state.template) {
@@ -38,10 +43,14 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
     dispatch(loadWorkflowByDatasetRef(qriRef))
   }, [dispatch, qriRef])
 
+  const handleDeploy = () => {
+    dispatch(showModal<DeployWorkflowModalProps>(ModalType.deployWorkflow, {setIfSave: () => setLastRunType(RunType.save)}))
+  }
+
   return (
     <div className='flex h-full'>
-      <WorkflowOutline workflow={workflow} run={latestRun} onDeploy={() => { dispatch(showModal(ModalType.deployWorkflow)) }} />
-      <WorkflowEditor workflow={workflow} run={latestRun} />
+      <WorkflowOutline workflow={workflow} run={latestRun} lastRunType={lastRunType} onDeploy={handleDeploy} />
+      <WorkflowEditor workflow={workflow} run={latestRun} lastRunType={lastRunType} setLastRunType={setLastRunType} />
     </div>
   )
 }

--- a/frontend/src/features/workflow/Workflow.tsx
+++ b/frontend/src/features/workflow/Workflow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -10,14 +10,10 @@ import { QriRef } from '../../qri/ref';
 import { ModalType } from '../app/state/appState';
 import { showModal } from '../app/state/appActions';
 import WorkflowEditor from './WorkflowEditor';
-import { RunType } from '../../qrimatic/run';
-import { DeployWorkflowModalProps } from './modal/DeployWorkflowModal';
 
 interface WorkflowLocationState {
   template: string
 }
-
-export type SetRunTypeFunc = React.Dispatch<React.SetStateAction<RunType>>
 
 export interface WorkflowProps {
   qriRef: QriRef
@@ -28,7 +24,6 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const location = useLocation<WorkflowLocationState>()
   const workflow = useSelector(selectWorkflow)
   const latestRun = useSelector(selectLatestRun)
-  const [lastRunType, setLastRunType] = useState<RunType>(RunType.dry)
 
   useEffect(() => {
     if (location.state && location.state.template) {
@@ -44,13 +39,13 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   }, [dispatch, qriRef])
 
   const handleDeploy = () => {
-    dispatch(showModal<DeployWorkflowModalProps>(ModalType.deployWorkflow, {setIfSave: () => setLastRunType(RunType.save)}))
+    dispatch(showModal(ModalType.deployWorkflow))
   }
 
   return (
     <div className='flex h-full'>
-      <WorkflowOutline workflow={workflow} run={latestRun} lastRunType={lastRunType} onDeploy={handleDeploy} />
-      <WorkflowEditor workflow={workflow} run={latestRun} lastRunType={lastRunType} setLastRunType={setLastRunType} />
+      <WorkflowOutline workflow={workflow} run={latestRun} onDeploy={handleDeploy} />
+      <WorkflowEditor workflow={workflow} run={latestRun} />
     </div>
   )
 }

--- a/frontend/src/features/workflow/WorkflowCell.tsx
+++ b/frontend/src/features/workflow/WorkflowCell.tsx
@@ -24,7 +24,9 @@ const nameLookup = (name: string) => {
     case 'transform':
       return 'Shape your data into the desired output for your dataset'
     case 'save':
-      return 'Saving will commit changes to your qri dataset after running the code above. You can preview the changes here after each dry run of the workflow'
+      return 'Saving will commit changes to your qri dataset after running the code above.'
+    case 'result':
+        return 'You can preview the changes here after each dry run of the workflow'
     default:
       return ''
   }

--- a/frontend/src/features/workflow/WorkflowOutline.tsx
+++ b/frontend/src/features/workflow/WorkflowOutline.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 
 import Icon from '../../chrome/Icon'
 import { TransformStep } from '../../qri/dataset'
-import { getOutputNameFromRunType, NewRunStep, Run, RunState, RunType } from '../../qrimatic/run'
+import { getOutputNameFromRunType, NewRunStep, Run, RunState } from '../../qrimatic/run'
 import { Workflow } from '../../qrimatic/workflow'
 import RunStateIcon from './RunStateIcon'
+import { selectRunType } from './state/workflowState'
 
 export interface WorkflowOutlineProps {
   workflow?: Workflow
   run?: Run
   onDeploy: () => void
-  lastRunType: RunType
 }
 
-const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDeploy, lastRunType }) => {
+const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDeploy }) => {
+  const runType = useSelector(selectRunType)
+  
   return (
     <div className='outline h-full w-56 flex-none'>
       <div className='p-4 text-left'>
@@ -38,7 +41,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDepl
             }
             return (
               <div key={i} className='text-sm ml-2'>
-                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name === 'save' ? getOutputNameFromRunType(lastRunType) : step.name}
+                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name === 'save' ? getOutputNameFromRunType(runType) : step.name}
                 {r && <div className='float-right text-green-500'><RunStateIcon state={r.status || RunState.waiting} /></div>}
               </div>
             )

--- a/frontend/src/features/workflow/WorkflowOutline.tsx
+++ b/frontend/src/features/workflow/WorkflowOutline.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Icon from '../../chrome/Icon'
 import { TransformStep } from '../../qri/dataset'
-import { NewRunStep, Run, RunState } from '../../qrimatic/run'
+import { getOutputNameFromRunType, NewRunStep, Run, RunState, RunType } from '../../qrimatic/run'
 import { Workflow } from '../../qrimatic/workflow'
 import RunStateIcon from './RunStateIcon'
 
@@ -10,9 +10,10 @@ export interface WorkflowOutlineProps {
   workflow?: Workflow
   run?: Run
   onDeploy: () => void
+  lastRunType: RunType
 }
 
-const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDeploy }) => {
+const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDeploy, lastRunType }) => {
   return (
     <div className='outline h-full w-56 flex-none'>
       <div className='p-4 text-left'>
@@ -37,7 +38,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({ workflow, run, onDepl
             }
             return (
               <div key={i} className='text-sm ml-2'>
-                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name}
+                <span className='font-black text-gray-400'>{i+1}</span> &nbsp; {step.name === 'save' ? getOutputNameFromRunType(lastRunType) : step.name}
                 {r && <div className='float-right text-green-500'><RunStateIcon state={r.status || RunState.waiting} /></div>}
               </div>
             )

--- a/frontend/src/features/workflow/modal/DeployWorkflowModal.tsx
+++ b/frontend/src/features/workflow/modal/DeployWorkflowModal.tsx
@@ -1,15 +1,12 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { RunType } from '../../../qrimatic/run'
 
 import { clearModal } from '../../app/state/appActions'
-import { deployWorkflow } from '../state/workflowActions'
+import { clearRun, deployWorkflow, setRunType } from '../state/workflowActions'
 import { selectWorkflow } from '../state/workflowState'
 
-export interface DeployWorkflowModalProps {
-  setIfSave: () => void
-}
-
-const DeployWorkflowModal: React.FC<DeployWorkflowModalProps> = ({ setIfSave }) => {
+const DeployWorkflowModal: React.FC = () => {
   const dispatch = useDispatch()
   const workflow = useSelector(selectWorkflow)
   const [save, setSave] = useState(true)
@@ -21,7 +18,8 @@ const DeployWorkflowModal: React.FC<DeployWorkflowModalProps> = ({ setIfSave }) 
      <button
        className='py-1 px-4 mx-1 font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-300'
        onClick={() => {
-         save && setIfSave()
+         save && dispatch(setRunType(RunType.save))
+         dispatch(clearRun())
          dispatch(deployWorkflow(workflow))
          dispatch(clearModal())
        }}>Deploy!</button>

--- a/frontend/src/features/workflow/modal/DeployWorkflowModal.tsx
+++ b/frontend/src/features/workflow/modal/DeployWorkflowModal.tsx
@@ -1,21 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { clearModal } from '../../app/state/appActions'
 import { deployWorkflow } from '../state/workflowActions'
 import { selectWorkflow } from '../state/workflowState'
 
-const DeployWorkflowModal: React.FC = () => {
+export interface DeployWorkflowModalProps {
+  setIfSave: () => void
+}
+
+const DeployWorkflowModal: React.FC<DeployWorkflowModalProps> = ({ setIfSave }) => {
   const dispatch = useDispatch()
   const workflow = useSelector(selectWorkflow)
+  const [save, setSave] = useState(true)
 
   return (
     <div className="mt-3 sm:mt-0 sm:ml-4 sm:text-left">
      <h3 className="text-2xl leading-6 font-medium text-gray-900">Deploy</h3>
-     <p><input type='checkbox' checked disabled /> Run &amp; save before deploying</p>
+     <p><input type='checkbox' checked={save} onClick={() => setSave(!save)} disabled /> Run &amp; save before deploying</p>
      <button
        className='py-1 px-4 mx-1 font-semibold shadow-md text-white bg-gray-600 hover:bg-gray-300'
        onClick={() => {
+         save && setIfSave()
          dispatch(deployWorkflow(workflow))
          dispatch(clearModal())
        }}>Deploy!</button>

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -8,8 +8,12 @@ import {
   RUN_EVENT_LOG,
   TEMP_SET_WORKFLOW_EVENTS,
   SET_WORKFLOW,
-  SET_WORKFLOW_REF
+  SET_WORKFLOW_REF,
+  SET_RUN_TYPE,
+  CLEAR_RUN,
+  SET_RUN_BUTTON_TYPE
 } from './workflowState'
+import { RunType } from '../../../qrimatic/run'
 
 export function mapWorkflow(d: object | []): Workflow {
   return NewWorkflow((d as Record<string,any>))
@@ -150,5 +154,39 @@ export interface SetWorkflowRefAction {
   return {
     type: SET_WORKFLOW_REF,
     qriRef,
+  }
+}
+
+export interface SetRunTypeAction {
+  type: string,
+  runType: RunType
+}
+
+export function setRunType(runType: RunType): SetRunTypeAction {
+  return {
+    type: SET_RUN_TYPE,
+    runType
+  }
+}
+
+export interface SetRunButtonTypeAction {
+  type: string,
+  runButtonType: RunType
+}
+
+export function setRunButtonType(runButtonType: RunType): SetRunButtonTypeAction {
+  return {
+    type: SET_RUN_BUTTON_TYPE,
+    runButtonType
+  }
+}
+
+export interface ClearRunAction {
+  type: string
+}
+
+export function clearRun(): ClearRunAction {
+  return {
+    type: CLEAR_RUN
   }
 }

--- a/frontend/src/features/workflow/state/workflowState.ts
+++ b/frontend/src/features/workflow/state/workflowState.ts
@@ -1,8 +1,8 @@
 import { createReducer } from '@reduxjs/toolkit'
 
 import { RootState } from '../../../store/store';
-import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction, SetWorkflowRefAction, WorkflowTriggerAction } from './workflowActions';
-import { NewRunFromEventLog, Run } from '../../../qrimatic/run';
+import { EventLogAction, SetWorkflowAction, SetWorkflowStepAction, SetWorkflowRefAction, WorkflowTriggerAction, SetRunTypeAction, SetRunButtonTypeAction } from './workflowActions';
+import { NewRunFromEventLog, Run, RunType } from '../../../qrimatic/run';
 import { Workflow } from '../../../qrimatic/workflow';
 import { EventLogLine } from '../../../qri/eventLog';
 import Dataset from '../../../qri/dataset';
@@ -13,6 +13,9 @@ export const WORKFLOW_CHANGE_TRIGGER = 'WORKFLOW_CHANGE_TRIGGER'
 export const WORKFLOW_CHANGE_TRANSFORM_STEP = 'WORKFLOW_CHANGE_TRANSFORM_STEP'
 export const SET_WORKFLOW = 'SET_WORKFLOW'
 export const SET_WORKFLOW_REF = 'SET_WORKFLOW_REF'
+export const SET_RUN_TYPE = 'SET_RUN_TYPE'
+export const SET_RUN_BUTTON_TYPE = 'SET_RUN_BUTTON_TYPE'
+export const CLEAR_RUN = 'CLEAR_RUN'
 
 // temp action used to work around the api, auto sets the events
 // of the workflow without having to have a working api
@@ -28,16 +31,24 @@ export const selectLatestRun = (state: RootState): Run | undefined => {
 
 export const selectWorkflow = (state: RootState): Workflow => state.workflow.workflow
 
+export const selectRunType = (state: RootState): RunType => state.workflow.runType
+
+export const selectRunButtonType = (state: RootState): RunType => state.workflow.runButtonType
+
 export interface WorkflowState {
   // reference the workflow editor is manipulating
   qriRef?: QriRef,
   workflow: Workflow,
 
+  runType: RunType,
+  runButtonType: RunType,
   lastRunID?: string,
   events: EventLogLine[],
 }
 
 const initialState: WorkflowState = {
+  runType: RunType.dry,
+  runButtonType: RunType.dry,
   workflow: {
     id: '',
     datasetID: 'fake_id',
@@ -79,6 +90,13 @@ export const workflowReducer = createReducer(initialState, {
     state.qriRef = action.qriRef
     state.workflow.datasetID = `${action.qriRef.username}/${action.qriRef.name}`
   },
+  SET_RUN_TYPE: (state, action: SetRunTypeAction) => {
+    state.runType = action.runType
+  },
+  SET_RUN_BUTTON_TYPE: (state, action: SetRunButtonTypeAction) => {
+    state.runButtonType = action.runButtonType
+  },
+  CLEAR_RUN: clearRun,
   // listen for dataset fetching actions, if the reference of the fetched dataset
   // matches the ref the workbench reducer is tuned to, load the transform script
   // into the workbench
@@ -131,4 +149,8 @@ function setWorkflow(state: WorkflowState, action: SetWorkflowAction) {
   state.workflow = action.workflow
   state.events = []
   return
+}
+
+function clearRun(state: WorkflowState) {
+  state.events = []
 }

--- a/frontend/src/qrimatic/run.ts
+++ b/frontend/src/qrimatic/run.ts
@@ -8,12 +8,27 @@ export enum RunState {
   skipped = 'skipped'
 }
 
+export enum RunType {
+  dry = 'dry',
+  save = 'save'
+}
+
+export function getOutputNameFromRunType(runType: RunType): string {
+  switch (runType){
+    case RunType.dry:
+      return "result"
+    case RunType.save:
+      return "save"
+  }
+}
+
 export interface Run {
   id: string
   status: RunState
   startTime?: Date
   stopTime?: Date
   duration?: string
+  runType: RunType
 
   steps: RunStep[]
 }
@@ -22,7 +37,8 @@ export function NewRun(data: Record<string,any>): Run {
   return {
     id: data.id || '',
     status: data.status || RunState.waiting,
-    steps: data.steps && data.steps.map(NewRunStep)
+    steps: data.steps && data.steps.map(NewRunStep),
+    runType: RunType.dry
   }
 }
 


### PR DESCRIPTION
closes #57 

- Adds `RunType` with options `dry` and `save`
- adds `getOutputNameFromRunType(runType: RunType): string` that takes a run type and converts it to a human readable name
- adds `lastRunType` and `setLastRunType` state to `Workflow` that tracks the LAST type of run we have done (defaulting to `RunType.dry`)
- plumbs `lastRunType` down into `WorkflowOutline`, and `WorkflowCell`, which uses `getOutputNameFromRunType` to determine what to show to the user.
- in `WorkflowCell`, adds description for "result"
- plumbs `setLastRunType` down to `RunBar`, when we click "run" or "dryrun", at that moment we should change the display (unless we "clear" the display, and then it should reflect if we have "run" or "dryrun" selected, but that's for the future)
- plumbs `setLastRunType` to the `deploy` modal as the param `setIfSave`. If we have "save" selected when we deploy, we need to ensure we need to update the `lastRunType`

Can test this by clicking the "deploy" button, which right now is defaulted to saving when clicked, and then clicking "run", which defaults to a dry run.

when we are able to switch between "dry run" and "run and save" WITHOUT HAVING RUN ANYTHING YET this will get more complicated, however until we can "clear" and also toggle between both states, we only need to rely on the last thing run.