### PR TITLE
feat(`DatasetComponents`): bring Component View into the app!

### DIFF
--- a/frontend/src/chrome/StatusDot.tsx
+++ b/frontend/src/chrome/StatusDot.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import classNames from 'classnames'
 import { faExclamation } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ComponentStatus } from '../../models/store'

--- a/frontend/src/features/app/App.tsx
+++ b/frontend/src/features/app/App.tsx
@@ -23,7 +23,7 @@ const App: React.FC<any> = () => {
 
 
   return (
-    <div id='app' className='flex flex-col h-screen'>
+    <div id='app' className='flex flex-col h-screen w-screen'>
       <ConnectedRouter history={history}>
         <Modal />
         <Routes />

--- a/frontend/src/features/collection/DatasetsTable.tsx
+++ b/frontend/src/features/collection/DatasetsTable.tsx
@@ -8,6 +8,7 @@ import Icon from '../../chrome/Icon'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import ExportButton from '../../chrome/ExportButton'
 import { VersionInfo } from '../../qri/versionInfo'
+import { pathToWorkflowEditor } from '../dataset/state/datasetPaths'
 
 interface DatasetsTableProps {
   filteredDatasets: VersionInfo[]
@@ -84,7 +85,7 @@ const DatasetsTable: React.FC<DatasetsTableProps> = ({
       cell: (row: VersionInfo) => (
         <div className='p-3'>
           <div className='font-medium text-sm mb-1'>
-            <Link to={`/ds/${row.username}/${row.name}`}>{row.username}/{row.name}</Link>
+            <Link to={pathToWorkflowEditor(row.username, row.name)}>{row.username}/{row.name}</Link>
           </div>
           <div className='text-gray-500 text-xs'>
             <span className='mr-4'><Icon icon='hdd' size='sm' className='mr-1' />{numeral(row.bodySize).format('0.0 b')}</span>

--- a/frontend/src/features/collection/state/collectionState.ts
+++ b/frontend/src/features/collection/state/collectionState.ts
@@ -15,7 +15,6 @@ const initialState: CollectionState = {
 
 export const collectionReducer = createReducer(initialState, {
   'API_LIST_SUCCESS': (state, action) => {
-    console.log('listed datasets', action)
     state.datasets = action.payload.data as VersionInfo[]
   },
 })

--- a/frontend/src/features/dataset/Dataset.tsx
+++ b/frontend/src/features/dataset/Dataset.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { newQriRef } from '../../qri/ref';
 import Workflow from '../workflow/Workflow';
 import DatasetComponents from './DatasetComponents';
-import { loadDataset } from './state/datasetActions'
+import { loadBody, loadDataset } from './state/datasetActions'
 import NavBar from '../navbar/NavBar';
 import DatasetNavSidebar from './DatasetNavSidebar';
 import DatasetTitleMenu from './DatasetTitleMenu';
@@ -19,27 +19,28 @@ const Dataset: React.FC<any> = () => {
   const { url } = useRouteMatch()
 
   useEffect(() => {
-    dispatch(loadDataset(qriRef))
-  }, [dispatch, qriRef])
+      const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
+      dispatch(loadDataset(ref))
+      dispatch(loadBody(ref))
+  }, [dispatch, qriRef.username, qriRef.name, qriRef.path])
 
   return (
-    <div className='flex flex-col h-full' style={{ backgroundColor: '#F4F7FC'}}>
+    <div className='flex flex-col h-full w-full' style={{ backgroundColor: '#F4F7FC'}}>
       <NavBar menu={[
         { type: 'link', label: 'back to collection', to: '/collection' },
         { type: 'hr' }
       ]}>
         <DatasetTitleMenu qriRef={qriRef} />
       </NavBar>
-      <div className='flex flex-grow overflow-hidden relative'>
+      <div className='flex flex-grow h-full w-full overflow-hidden relative'>
         <DatasetNavSidebar qriRef={qriRef} />
-        <div className='h-full overflow-hidden flex-grow'>
-          <Switch>
-            <Route path='/ds/:username/:dataset' exact><Workflow qriRef={qriRef} /></Route>
-            <Route path='/ds/:username/:dataset/components'><Redirect to={`${url}/body`} /></Route>
-            <Route path='/ds/:username/:dataset/components/:componentName'><DatasetComponents /></Route>
-            <Route path='/ds/:username/:dataset/history'><DatasetActivityFeed qriRef={qriRef} /></Route>
-          </Switch>
-        </div>
+        <Switch>
+          <Route path='/ds/:username/:name/workflow'><Workflow qriRef={qriRef} /></Route>
+          <Route path='/ds/:username/:name' exact><Redirect to={`${url}/workflow`} /></Route>
+          <Route path='/ds/:username/:name/components/:component'><DatasetComponents /></Route>
+          <Route path='/ds/:username/:name/components'><Redirect to={`${url}/components/body`} /></Route>
+          <Route path='/ds/:username/:name/history'><DatasetActivityFeed /></Route>
+        </Switch>
         <DeployingScreen qriRef={qriRef} />
       </div>
     </div>

--- a/frontend/src/features/dataset/DatasetComponents.tsx
+++ b/frontend/src/features/dataset/DatasetComponents.tsx
@@ -1,16 +1,25 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { push } from 'connected-react-router'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import { ComponentName } from '../../qri/dataset'
+import { newQriRef } from '../../qri/ref'
+import DSComponents from '../ds_components/DatasetComponents'
+import { pathToDatasetViewer } from './state/datasetPaths'
 import { selectDataset } from './state/datasetState'
 
 const DatasetComponents: React.FC<any> = () => {
+  const dispatch = useDispatch()
   const dataset = useSelector(selectDataset)
-
-  return (
-    <div className='text-left p-6'>
-      <p>Dataset Components View Goes Here</p>
-      {JSON.stringify(dataset, null, 2)}
-    </div>
-  )
+  const { username, name, component } = newQriRef(useParams())
+  const setSelectedComponent = (component: ComponentName) => {
+    dispatch(push(pathToDatasetViewer(username, name, component)))
+  }
+  return <DSComponents 
+    dataset={dataset} 
+    selectedComponent={component as ComponentName || 'body'} 
+    setSelectedComponent={setSelectedComponent} 
+  /> 
 }
 
 export default DatasetComponents;

--- a/frontend/src/features/dataset/DatasetComponents.tsx
+++ b/frontend/src/features/dataset/DatasetComponents.tsx
@@ -6,7 +6,7 @@ import { ComponentName } from '../../qri/dataset'
 import { newQriRef } from '../../qri/ref'
 import DSComponents from '../ds_components/DatasetComponents'
 import { pathToDatasetViewer } from './state/datasetPaths'
-import { selectDataset } from './state/datasetState'
+import { selectDataset, selectIsDatasetLoading } from './state/datasetState'
 
 const DatasetComponents: React.FC<any> = () => {
   const dispatch = useDispatch()
@@ -15,8 +15,11 @@ const DatasetComponents: React.FC<any> = () => {
   const setSelectedComponent = (component: ComponentName) => {
     dispatch(push(pathToDatasetViewer(username, name, component)))
   }
+  const loading = useSelector(selectIsDatasetLoading)
+
   return <DSComponents 
     dataset={dataset} 
+    loading={loading}
     selectedComponent={component as ComponentName || 'body'} 
     setSelectedComponent={setSelectedComponent} 
   /> 

--- a/frontend/src/features/dataset/DatasetHeader.tsx
+++ b/frontend/src/features/dataset/DatasetHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { QriRef } from '../../qri/ref';
+import { pathToActivityFeed, pathToDatasetViewer, pathToWorkflowEditor } from './state/datasetPaths';
 
 export interface DatasetHeaderProps {
   qriRef: QriRef
@@ -15,9 +16,9 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({ qriRef }) => {
       </div>
       <div className='flex my-1'>
         {[
-          { name: 'Workflow', link: `/ds/${qriRef.username}/${qriRef.name}` },
-          { name: 'Components', link: `/ds/${qriRef.username}/${qriRef.name}/components` },
-          { name: 'History', link: `/ds/${qriRef.username}/${qriRef.name}/history` },
+          { name: 'Workflow', link: pathToWorkflowEditor(qriRef.username, qriRef.name) },
+          { name: 'Components', link: pathToDatasetViewer(qriRef.username, qriRef.name) },
+          { name: 'History', link: pathToActivityFeed(qriRef.username, qriRef.name) },
         ].map((d, i) => (
           <Link key={i} className='my-2 mr-5' to={d.link}>{d.name}</Link>
         ))}

--- a/frontend/src/features/dataset/DatasetNavSidebar.tsx
+++ b/frontend/src/features/dataset/DatasetNavSidebar.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 import { QriRef } from '../../qri/ref'
 import SideNavItem from './SideNavItem'
 import TooltipContent from '../../chrome/TooltipContent'
+import { 
+  pathToActivityFeed, 
+  pathToDatasetViewer, 
+  pathToWorkflowEditor 
+} from './state/datasetPaths'
 
 export interface DatasetNavSidebarProps {
   qriRef: QriRef
@@ -13,7 +18,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
     <SideNavItem
       id='workflow-editor'
       icon='code'
-      to={`/ds/${qriRef.username}/${qriRef.name}`}
+      to={pathToWorkflowEditor(qriRef.username, qriRef.name)}
       tooltip={
         <TooltipContent
           text='Workflow Editor'
@@ -24,7 +29,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
     <SideNavItem
       id='components'
       icon='table'
-      to={`/ds/${qriRef.username}/${qriRef.name}/components`}
+      to={pathToDatasetViewer(qriRef.username, qriRef.name)}
       tooltip={
         <TooltipContent
           text='Components'
@@ -35,7 +40,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
     <SideNavItem
       id='activity-feed'
       icon='clock'
-      to={`/ds/${qriRef.username}/${qriRef.name}/history`}
+      to={pathToActivityFeed(qriRef.username, qriRef.name)}
       tooltip={
         <TooltipContent
           text='Activity Feed'

--- a/frontend/src/features/dataset/SideNavItem.tsx
+++ b/frontend/src/features/dataset/SideNavItem.tsx
@@ -13,7 +13,7 @@ export interface SideNavItemProps {
 
 const SideNavItem: React.FC<SideNavItemProps> = ({ id, icon, to, tooltip }) => {
   const { pathname } = useLocation();
-  const active = pathname === to
+  const active = pathname.includes(to)
   return (
       <Link to={to} className=''>
         <div

--- a/frontend/src/features/dataset/SideNavItem.tsx
+++ b/frontend/src/features/dataset/SideNavItem.tsx
@@ -5,9 +5,9 @@ import ReactTooltip from 'react-tooltip'
 import Icon from '../../chrome/Icon';
 
 export interface SideNavItemProps {
-  id: string;
-  icon: string;
-  to: string;
+  id: string
+  icon: string
+  to: string
   tooltip?: React.ReactNode
 }
 

--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -2,8 +2,14 @@ import Dataset, { NewDataset } from "../../../qri/dataset";
 import { QriRef } from "../../../qri/ref";
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
 
+export const bodyPageSizeDefault = 50
+
 export function mapDataset(d: object | []): Dataset {
   return NewDataset((d as Record<string,any>).dataset)
+}
+
+export function mapBody (d: {data: Body}): Body {
+  return d.data
 }
 
 export function loadDataset(ref: QriRef): ApiActionThunk {
@@ -25,6 +31,32 @@ function fetchDataset (ref: QriRef): ApiAction {
         name: ref.name
       },
       map: mapDataset
+    }
+  }
+}
+
+export function loadBody(ref: QriRef, page: number = 1, pageSize: number = bodyPageSizeDefault): ApiActionThunk {
+  return async (dispatch) => {
+    return dispatch(fetchBody(ref, page, pageSize))
+  }
+}
+
+function fetchBody (ref: QriRef, page: number, pageSize: number): ApiAction {
+  return {
+    type: 'body',
+    ref,
+    [CALL_API]: {
+      endpoint: 'body',
+      method: 'GET',
+      pageInfo: {
+        page,
+        pageSize
+      },
+      segments: {
+        peername: ref.username,
+        name: ref.name
+      },
+      map: mapBody
     }
   }
 }

--- a/frontend/src/features/dataset/state/datasetPaths.ts
+++ b/frontend/src/features/dataset/state/datasetPaths.ts
@@ -1,0 +1,15 @@
+import { ComponentName } from "../../../qri/dataset";
+
+export function pathToDatasetViewer(username: string, name: string, componentName?: ComponentName): string {
+  return componentName
+    ? `/ds/${username}/${name}/components/${componentName}`
+    : `/ds/${username}/${name}/components`
+}
+
+export function pathToWorkflowEditor(username: string, name: string): string {
+  return `/ds/${username}/${name}/workflow`
+}
+
+export function pathToActivityFeed(username: string, name:string): string {
+  return `/ds/${username}/${name}/history`
+}

--- a/frontend/src/features/dataset/state/datasetState.ts
+++ b/frontend/src/features/dataset/state/datasetState.ts
@@ -16,4 +16,7 @@ export const datasetReducer = createReducer(initialState, {
   'API_DATASET_SUCCESS': (state, action) => {
     state.dataset = action.payload.data as Dataset
   },
+  'API_BODY_SUCCESS': (state, action) => {
+    state.dataset.body = action.payload.data as Body
+  }
 })

--- a/frontend/src/features/dataset/state/datasetState.ts
+++ b/frontend/src/features/dataset/state/datasetState.ts
@@ -4,17 +4,29 @@ import Dataset, { NewDataset } from '../../../qri/dataset';
 
 export const selectDataset = (state: RootState): Dataset => state.dataset.dataset
 
+export const selectIsDatasetLoading = (state: RootState): boolean => state.dataset.loading
+
 export interface DatasetState {
   dataset: Dataset
+  loading: boolean
 }
 
 const initialState: DatasetState = {
-  dataset: NewDataset({})
+  dataset: NewDataset({}),
+  loading: true
 }
 
 export const datasetReducer = createReducer(initialState, {
+  'API_DATASET_REQUEST': (state) => {
+    state.dataset = NewDataset({})
+    state.loading = true
+  },
   'API_DATASET_SUCCESS': (state, action) => {
     state.dataset = action.payload.data as Dataset
+    state.loading = false
+  },
+  'API_DATASET_FAILURE': (state) => {
+    state.loading = false
   },
   'API_BODY_SUCCESS': (state, action) => {
     state.dataset.body = action.payload.data as Body

--- a/frontend/src/features/ds_components/ComponentItem.tsx
+++ b/frontend/src/features/ds_components/ComponentItem.tsx
@@ -54,7 +54,7 @@ export const ComponentItem: React.FunctionComponent<ComponentItemProps> = (
         }
       }}
     >
-      <div className={`w-1 ${!disabled && 'group-hover:bg-qrilightblue'} transition-all duration-100 ${selected && 'bg-qrilightblue'}`}/>
+      <div className={`w-1 ${!disabled && 'group-hover:bg-qriblue'} transition-all duration-100 ${selected && 'bg-qriblue'}`}/>
       {icon && (
         <div className='w-8  text-center flex flex-col justify-center'>
           <Icon icon={icon} size='sm' color={disabled ? 'medium' : color} className='mx-auto'/>

--- a/frontend/src/features/ds_components/DatasetComponent.tsx
+++ b/frontend/src/features/ds_components/DatasetComponent.tsx
@@ -44,7 +44,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   }
 
   return (
-    <div className='flex-grow'>
+    <div className='flex-grow h-full w-full'>
       <ComponentHeader componentName={componentName} />
       {component}
     </div>

--- a/frontend/src/features/ds_components/DatasetComponents.tsx
+++ b/frontend/src/features/ds_components/DatasetComponents.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { SyncLoader } from 'react-spinners'
 // import { useLocation, useParams, useRouteMatch } from 'react-router'
 
-import Dataset, { ComponentName, isDatasetEmpty } from '../../qri/dataset'
+import Dataset, { ComponentName, isDatasetEmpty, NewDataset } from '../../qri/dataset'
 // import { QriRef } from '../../qri/ref'
 import ComponentList from './ComponentList'
 // import ComponentRouter from './ComponentRouter'
@@ -17,6 +17,7 @@ export interface DatasetProps {
   dataset: Dataset
   selectedComponent: ComponentName
   setSelectedComponent: (name: ComponentName) => void
+  loading: boolean
   // isPublished: boolean
   // inNamespace: boolean
   // fsiPath: string
@@ -25,7 +26,8 @@ export interface DatasetProps {
 }
 
 export const DatasetComponents: React.FC<DatasetProps> = ({
-  dataset,
+  dataset: ds,
+  loading,
   selectedComponent,
   setSelectedComponent
   // isPublished,
@@ -34,6 +36,15 @@ export const DatasetComponents: React.FC<DatasetProps> = ({
   // fetchWorkbench,
   // setModal
 }) => {
+  if (loading) {
+    return <div className='h-full w-full flex justify-center items-center'><SyncLoader color='#4FC7F3' /></div>
+  }
+
+  let dataset = ds
+
+  if (!ds || isDatasetEmpty(ds)) {
+    dataset = NewDataset({})
+  }
   // get selected component from route
 
   
@@ -99,9 +110,6 @@ export const DatasetComponents: React.FC<DatasetProps> = ({
   //   />
   // )
 
-  if (!dataset || !dataset.body || isDatasetEmpty(dataset)) {
-    return <div className='h-full w-full flex justify-center items-center'><SyncLoader color='#4FC7F3' /></div>
-  }
   return (
     <div className='flex h-full w-full'>
       <ComponentList

--- a/frontend/src/features/ds_components/DatasetComponents.tsx
+++ b/frontend/src/features/ds_components/DatasetComponents.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
+import { SyncLoader } from 'react-spinners'
 // import { useLocation, useParams, useRouteMatch } from 'react-router'
 
-import Dataset, { ComponentName } from '../../qri/dataset'
+import Dataset, { ComponentName, isDatasetEmpty } from '../../qri/dataset'
 // import { QriRef } from '../../qri/ref'
 import ComponentList from './ComponentList'
 // import ComponentRouter from './ComponentRouter'
@@ -9,12 +10,13 @@ import ComponentList from './ComponentList'
 // import DatasetLayout from './DatasetLayout'
 // import Layout from './Layout'
 // import LogList from './LogList'
-import Resizable from '../../chrome/Resizable'
 import DatasetComponent from './DatasetComponent'
 
 // export interface DatasetProps extends RouteProps {
 export interface DatasetProps {
   dataset: Dataset
+  selectedComponent: ComponentName
+  setSelectedComponent: (name: ComponentName) => void
   // isPublished: boolean
   // inNamespace: boolean
   // fsiPath: string
@@ -23,14 +25,18 @@ export interface DatasetProps {
 }
 
 export const DatasetComponents: React.FC<DatasetProps> = ({
-  dataset
+  dataset,
+  selectedComponent,
+  setSelectedComponent
   // isPublished,
   // fsiPath,
   // inNamespace,
   // fetchWorkbench,
   // setModal
 }) => {
-  const [selectedComponent, setSelectedComponent] = useState<ComponentName>('body')
+  // get selected component from route
+
+  
   // const publishUnpublishDataset = () => {
   //   inNamespace && isPublished
   //     ? setModal({
@@ -92,8 +98,12 @@ export const DatasetComponents: React.FC<DatasetProps> = ({
   //     sidebarContent={<LogList qriRef={qriRef}/>}
   //   />
   // )
+
+  if (!dataset || !dataset.body || isDatasetEmpty(dataset)) {
+    return <div className='h-full w-full flex justify-center items-center'><SyncLoader color='#4FC7F3' /></div>
+  }
   return (
-    <div className='flex h-full w-full overflow-hidden'>
+    <div className='flex h-full w-full'>
       <ComponentList
         dataset={dataset}
         onClick={setSelectedComponent}

--- a/frontend/src/features/ds_components/datasetComponents/Body.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Body.tsx
@@ -68,8 +68,23 @@ export const Body: React.FunctionComponent<BodyProps> = (props) => {
 
   const { body, structure } = data
 
-  if (!structure || !body) {
-    return <div>Error cannot show body</div>
+  if (!body) {
+    return (
+      <div className='h-full w-full flex justify-center items-center'>
+        <div>
+          There's nothing here yet!
+        </div>
+      </div>
+    )
+  }
+  if (!structure) {
+    return (
+      <div className='h-full w-full flex justify-center items-center'>
+        <div>
+          Error cannot show body without a structure
+        </div>
+      </div>
+    )
   }
 
   // const makeStatsDetails = (stats: IStatTypes, title: string, index: number): StatsDetails => {

--- a/frontend/src/features/ds_components/datasetComponents/BodyJson.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/BodyJson.tsx
@@ -24,7 +24,7 @@ const BodyJson: React.FunctionComponent<BodyJsonProps> = (props) => {
   return (
     <div
       id='body-json-container'
-      style={{ height: '100%', overflowY: 'scroll' }}
+      className='h-full w-full overflow-auto pb-8'
     >
       {/* {previewWarning && <div className='preview-warning'><FontAwesomeIcon icon={faExclamationTriangle} size='xs' /> This is a preview of the first 50 items in this json array</div>} */}
       <div id='body-json-array'>

--- a/frontend/src/features/ds_components/datasetComponents/BodyTable.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/BodyTable.tsx
@@ -138,6 +138,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
     return (
       <div
         id='body-table-container'
+        className='overflow-auto h-full w-full pb-8'
         onScroll={() => { this.handleVerticalScrollThrottled() } }
       >
         <table className='table text-xs'>

--- a/frontend/src/features/ds_components/datasetComponents/Commit.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Commit.tsx
@@ -25,7 +25,7 @@ export const CommitComponent: React.FunctionComponent<CommitProps> = ({
   if (!data) return null
 
   return (
-    <div className='p-3'>
+    <div className='p-3 h-full w-full overflow-auto pb-8'>
       <div className='font-semibold mb-2'>{data.title}</div>
       <div className='text-sm mb-2'>{moment(data.timestamp).format('MMMM Do YYYY, h:mm:ss a')}</div>
       <div className='text-sm'>{data.message}</div>

--- a/frontend/src/features/ds_components/datasetComponents/Meta.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Meta.tsx
@@ -64,7 +64,6 @@ const renderTable = (keys: string[], data: Meta) => {
       <table className='keyvalue-table'>
         <tbody>
           {keys.map((key) => {
-            console.log('key', key)
             const value = data[key]
             let cellContent
             switch (key) {
@@ -116,7 +115,7 @@ export const MetaComponent: React.FunctionComponent<MetaProps> = ({ data }) => {
   })
 
   return (
-    <div className='p-3'>
+    <div className='p-3 h-full w-full overflow-auto pb-8'>
       <div className='text-sm font-semibold mb-2'>Standard Metadata</div>
       {renderTable(standard, data)}
 

--- a/frontend/src/features/ds_components/datasetComponents/Readme.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Readme.tsx
@@ -15,14 +15,14 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
 
   const refCallback = useCallback((el: HTMLDivElement) =>{
     if (el !== null) {
-      // fetch(`${API_BASE_URL}/render/${qriRefStr}`)
-      //   .then(async (res) => {
-      //     return res.text()
-      //   })
-      //   .then((render) => {
-      //     if (!render) { setHasReadme(false) }
-      //     el.innerHTML = render
-      //   })
+      fetch(`${API_BASE_URL}/render/${qriRefStr}`)
+        .then(async (res) => {
+          return res.text()
+        })
+        .then((render) => {
+          if (!render) { setHasReadme(false) }
+          el.innerHTML = render
+        })
 
       const render = "<h1>Heading</h1><p>Lorem Ipsum Dolor</p><p><strong>bold text</strong></p><h2>Heading 2</h2>"
       el.innerHTML = render
@@ -33,7 +33,7 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
     return null
   }
   return (
-    <div className='p-3'>
+    <div className='p-3 h-full w-full overflow-auto pb-8'>
       <div
         // use "editor-preview" class to piggie-back off the simplemde styling
         className="markdown-body"

--- a/frontend/src/features/ds_components/datasetComponents/Structure.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Structure.tsx
@@ -83,7 +83,7 @@ export const StructureComponent: React.FunctionComponent<StructureProps> = ({dat
   }
 
   return (
-    <div>
+    <div className='h-full w-full overflow-auto pb-8'>
       <div className='p-3'>
         <LabeledStats data={getStats(data)} size='lg' />
         <FormatConfigHistory structure={data} />

--- a/frontend/src/features/ds_components/datasetComponents/Transform.tsx
+++ b/frontend/src/features/ds_components/datasetComponents/Transform.tsx
@@ -19,7 +19,7 @@ export const TransformComponent: React.FunctionComponent<TransformProps> = ({ da
   // if (loading) {
   //   return <SpinnerWithIcon loading />
   // }
-  return <Code data={scriptFromTransform(data)} />
+  return <div className='h-full w-full overflow-auto pb-8'><Code data={scriptFromTransform(data)} /></div>
 }
 
 export default TransformComponent 

--- a/frontend/src/features/ds_components/stories/DatasetComponents.stories.tsx
+++ b/frontend/src/features/ds_components/stories/DatasetComponents.stories.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Provider } from 'react-redux';
 import { Story, Meta } from '@storybook/react';
 
 import { configureStore, history } from '../../../store/store';
 import { ConnectedRouter } from 'connected-react-router';
 import DatasetComponents from '../DatasetComponents';
-import { NewDataset } from '../../../qri/dataset';
+import { ComponentName, NewDataset } from '../../../qri/dataset';
 import earthquakes from './data/earthquakes.json'
 
 // import './styles.css'
@@ -16,13 +16,18 @@ export default {
   argTypes: {},
 } as Meta;
 
-const Template: Story<any> = (args) => (
-  <Provider store={configureStore()}>
-    <ConnectedRouter history={history}>
-      <DatasetComponents dataset={NewDataset(earthquakes)} />
-    </ConnectedRouter>
-  </Provider>
-);
+const Template: Story<any> = (args) => {
+  const [component, setComponent] = useState<ComponentName>('body')
+  return (<Provider store={configureStore()}>
+      <ConnectedRouter history={history}>
+        <DatasetComponents 
+          selectedComponent={component}
+          setSelectedComponent={setComponent}
+          dataset={NewDataset(earthquakes)} 
+        />
+      </ConnectedRouter>
+    </Provider>)
+}
 
 export const Basic = Template.bind({})
 Basic.args = {

--- a/frontend/src/qri/dataset.ts
+++ b/frontend/src/qri/dataset.ts
@@ -26,6 +26,22 @@ export function qriRefFromDataset(dataset: Dataset): QriRef {
   }
 }
 
+export function isDatasetEmpty(ds: Dataset): boolean {
+  return (
+    !ds.peername &&
+    !ds.name &&
+    !ds.path &&
+    !ds.commit &&
+    !ds.meta &&
+    !ds.structure &&
+    !ds.body &&
+    !ds.bodyPath &&
+    !ds.readme &&
+    !ds.transform &&
+    !ds.stats &&
+    !ds.viz)
+}
+
 export function NewDataset(d: Record<string,any>): Dataset {
   const dataset: Dataset = {
     peername: d.peername || '',

--- a/frontend/src/qri/ref.ts
+++ b/frontend/src/qri/ref.ts
@@ -1,5 +1,7 @@
 // import { RouteComponentProps } from 'react-router-dom'
 
+import { ComponentName } from "./dataset"
+
 // QriRef models a reference to a user, dataset, or part of a dataset within Qri
 // We use "QriRef" instead of "Ref" to disambiguate with the react "ref"
 // property.
@@ -45,7 +47,7 @@ export interface QriRef {
   // commit hash, eg: /ipfs/QmY9WcXXUnHJbYRA28LRctiL4qu4y...
   path?: string
   // optional: a specific component the user is trying to index into component
-  component?: string
+  component?: ComponentName 
   // address into dataset structure
   selector?: string
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -17,7 +17,7 @@ import Dataset from './features/dataset/Dataset';
 
 export default function Routes () {
   return (
-    <div className='route-content h-full'>
+    <div className='route-content h-full w-full'>
       <Switch>
         <Route path='/login'><Login /></Route>
         <Route path='/signup'><Signup /></Route>

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -36,7 +36,7 @@ export interface ApiAction extends AnyAction {
     pageInfo?: ApiPagination
     // map is a function
     // map defaults to the identity function
-    map?: (data: object|[]) => any
+    map?: (data: any) => any
   }
 }
 


### PR DESCRIPTION
closes #77 

Decided the cleanest/fastest way to port the `ds_components/DatasetComponents` component was to isolate it from the logic of fetching the dataset or setting the selected component, for now.

We may decide that we want it to encapsulate all the logic needed to work on its own, (especially when we get pagination involved and then need to pass down a function that allows us to fetch new pages of the body, and/or how to do editing although I have some thoughts about that). However, isolating it this way means we open an easier path to using the Component Viewer in different parts of the app or porting it to other projects in the future.

Some other changes:
- We needed to align the names of the `qriRef` refs and the `params` that we use in our router, otherwise our pattern of using `NewQriRef(useParams())` to get a `qriRef` from the route will not work
- adding a `datasetPath` file that contains a `pathToWorkflowEditor`, `pathToDatasetViewer`, `pathToActivityFeed`, used these functions to abstract the paths whenever we have to link to the dataset
-  any calls to `/ds/:username/:name` have been changed to `/ds/:username/:name/workflow` to keep the same functionality, but allow the path matching we need to show ui in other parts of the app. We are going to switch to having the Component Viewer as the default route that we navigated to when clicking on a dataset, but in order to isolate changes, this pr just doubles down on Workflow Editor as the default route
- adds `loadBody`, `fetchBody`, and adds the `API_BODY_SUCCESS` action to the reducer