### PR TITLE
feat(`/collection`): func `scheduler.ListWorkflowInfos`

### DIFF
--- a/qrimatic/api/cron.go
+++ b/qrimatic/api/cron.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -8,10 +9,12 @@ import (
 	"github.com/qri-io/qrimatic/scheduler"
 )
 
+// StatusHandler is the qrimatic heath check
 func (s *Server) StatusHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// WorkflowsHandler returns a list of workflows
 func (s *Server) WorkflowsHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -126,4 +129,17 @@ func (s *Server) RunHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte("not finished"))
 	// c.runWorkflow(r.Context(), nil)
+}
+
+// WorkflowListHandler returns a list of WorkflowInfos, which include workflows
+// that do and do not include runs
+func (s *Server) WorkflowListHandler(w http.ResponseWriter, r *http.Request) {
+	data, err := s.sched.ListWorkflowInfos(context.Background(), s.inst, 25, 0)
+	if err != nil {
+		log.Errorf("error listing workflowInfos: %w", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	apiutil.WriteResponse(w, data)
 }

--- a/qrimatic/api/cron.go
+++ b/qrimatic/api/cron.go
@@ -24,7 +24,7 @@ func (s *Server) WorkflowsHandler(w http.ResponseWriter, r *http.Request) {
 
 		js, err := s.sched.ListWorkflows(r.Context(), offset, limit)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
 			return
 		}
 
@@ -58,8 +58,7 @@ func (s *Server) WorkflowsHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		name := r.FormValue("name")
 		if err := s.sched.Unschedule(r.Context(), name); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
+			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
 			return
 		}
 	}
@@ -70,9 +69,9 @@ func (s *Server) WorkflowHandler(w http.ResponseWriter, r *http.Request) {
 	workflow, err := s.sched.WorkflowForDataset(r.Context(), dsID)
 	if err != nil {
 		if err == scheduler.ErrNotFound {
-			w.WriteHeader(http.StatusNotFound)
+			apiutil.WriteErrResponse(w, http.StatusNotFound, err)
 		} else {
-			w.WriteHeader(http.StatusInternalServerError)
+			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
 		}
 		w.Write([]byte(err.Error()))
 		return
@@ -104,8 +103,7 @@ func (s *Server) GetRunHandler(w http.ResponseWriter, r *http.Request) {
 	runNumber := apiutil.ReqParamInt(r, "number", 0)
 	run, err := s.sched.GetRun(r.Context(), datasetID, runNumber)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
+		apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -138,8 +136,7 @@ func (s *Server) CollectionHandler(w http.ResponseWriter, r *http.Request) {
 	data, err := s.sched.ListCollection(context.Background(), s.inst, time.Now(), time.Now())
 	if err != nil {
 		log.Errorf("error listing collection: %w", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
+		apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
 		return
 	}
 	apiutil.WriteResponse(w, data)

--- a/qrimatic/api/cron.go
+++ b/qrimatic/api/cron.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	apiutil "github.com/qri-io/apiutil"
 	"github.com/qri-io/qrimatic/scheduler"
@@ -131,12 +132,12 @@ func (s *Server) RunHandler(w http.ResponseWriter, r *http.Request) {
 	// c.runWorkflow(r.Context(), nil)
 }
 
-// WorkflowListHandler returns a list of WorkflowInfos, which include workflows
-// that do and do not include runs
-func (s *Server) WorkflowListHandler(w http.ResponseWriter, r *http.Request) {
-	data, err := s.sched.ListWorkflowInfos(context.Background(), s.inst, 25, 0)
+// CollectionHandler returns a list of `WorkflowInfo`s, which include a union of
+// datasets and workflows
+func (s *Server) CollectionHandler(w http.ResponseWriter, r *http.Request) {
+	data, err := s.sched.ListCollection(context.Background(), s.inst, time.Now(), time.Now())
 	if err != nil {
-		log.Errorf("error listing workflowInfos: %w", err)
+		log.Errorf("error listing collection: %w", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return

--- a/qrimatic/api/routes.go
+++ b/qrimatic/api/routes.go
@@ -22,7 +22,7 @@ func (s *Server) AddRoutes(m *http.ServeMux, prefix string, mw func(http.Handler
 func (s *Server) AddCronRoutes(m *http.ServeMux, mw func(http.HandlerFunc) http.HandlerFunc) {
 	m.HandleFunc("/cron", mw(s.StatusHandler))
 	m.HandleFunc("/workflows", mw(s.WorkflowsHandler))
-	m.HandleFunc("/workflow/list", mw(s.WorkflowListHandler))
+	m.HandleFunc("/collection", mw(s.CollectionHandler))
 	m.HandleFunc("/workflow", mw(s.WorkflowHandler))
 	m.HandleFunc("/runs", mw(s.RunsHandler))
 	m.HandleFunc("/run", mw(s.GetRunHandler))

--- a/qrimatic/api/routes.go
+++ b/qrimatic/api/routes.go
@@ -22,6 +22,7 @@ func (s *Server) AddRoutes(m *http.ServeMux, prefix string, mw func(http.Handler
 func (s *Server) AddCronRoutes(m *http.ServeMux, mw func(http.HandlerFunc) http.HandlerFunc) {
 	m.HandleFunc("/cron", mw(s.StatusHandler))
 	m.HandleFunc("/workflows", mw(s.WorkflowsHandler))
+	m.HandleFunc("/workflow/list", mw(s.WorkflowListHandler))
 	m.HandleFunc("/workflow", mw(s.WorkflowHandler))
 	m.HandleFunc("/runs", mw(s.RunsHandler))
 	m.HandleFunc("/run", mw(s.GetRunHandler))

--- a/qrimatic/go.mod
+++ b/qrimatic/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/qri-io/ioes v0.1.1
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f
-	github.com/qri-io/qri v0.9.14-0.20210128202211-63fadf8339de
+	github.com/qri-io/qri v0.9.14-0.20210212175009-9ec032942d9a
 	github.com/spf13/cobra v1.0.0
 )

--- a/qrimatic/go.sum
+++ b/qrimatic/go.sum
@@ -283,6 +283,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -972,6 +974,8 @@ github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u
 github.com/multiformats/go-multiaddr v0.3.0/go.mod h1:dF9kph9wfJ+3VLAaeBqo9Of8x4fJxp6ggJGteB8HQTI=
 github.com/multiformats/go-multiaddr v0.3.1 h1:1bxa+W7j9wZKTZREySx1vPMs2TqrYWjVZ7zE6/XLG1I=
 github.com/multiformats/go-multiaddr v0.3.1/go.mod h1:uPbspcUPd5AfaP6ql3ujFY+QWzmBD8uLLL4bXW0XfGc=
+github.com/multiformats/go-multiaddr v0.3.2-0.20210122024440-7274874c78df h1:4y6jJdqKIPS07xHjIFu/YAJNYi4XYLESBB5LhOUnjss=
+github.com/multiformats/go-multiaddr v0.3.2-0.20210122024440-7274874c78df/go.mod h1:uPbspcUPd5AfaP6ql3ujFY+QWzmBD8uLLL4bXW0XfGc=
 github.com/multiformats/go-multiaddr-dns v0.0.1/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.0.2/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.0.3/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
@@ -1127,6 +1131,8 @@ github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f h1:Oj2N/HRGMcs2NDZWl1
 github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f/go.mod h1:SU+DUq8+BfHNod1SXzmD8FrNLgPt42aKyQuO3fnFEQI=
 github.com/qri-io/qri v0.9.14-0.20210128202211-63fadf8339de h1:l4WTS9K/4z5UAd2qoAbcj8lkyERN9DYdF9sa+bT4044=
 github.com/qri-io/qri v0.9.14-0.20210128202211-63fadf8339de/go.mod h1:b4gXn+uYJyWKFKxwc4dy5zdxb3a7OWQn4yYfSTnX5BM=
+github.com/qri-io/qri v0.9.14-0.20210212175009-9ec032942d9a h1:rBpkhuKQAdpGt2jwHgYG9sWdAv2h8/0HhOYnk0JuXTE=
+github.com/qri-io/qri v0.9.14-0.20210212175009-9ec032942d9a/go.mod h1:vtstK0l2VE7hJPE4oHX2mH/R0JZgemXJ+ma+cOKioaU=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/qrimatic/scheduler/workflow.go
+++ b/qrimatic/scheduler/workflow.go
@@ -50,7 +50,9 @@ var zero iso8601.RepeatingInterval
 // Workflow represents a "cron workflow" that can be scheduled for repeated execution at
 // a specified Periodicity (time interval)
 type Workflow struct {
-	ID        string     `json:"id"`                // CID string
+	ID string `json:"id"` // CID string0
+	// TODO (ramfox): `DatasetID` is currently expected to be the `username/name` combination
+	// when the infrastructure supports it, we want to switch this over to the dataset's `InitID`
 	DatasetID string     `json:"datasetID"`         // dataset identifier
 	OwnerID   string     `json:"ownerID"`           // user that created this workflow
 	Name      string     `json:"name"`              // human dataset name eg: "b5/world_bank_population"

--- a/qrimatic/scheduler/workflow_info.go
+++ b/qrimatic/scheduler/workflow_info.go
@@ -1,0 +1,108 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qri-io/qri/dsref"
+	"github.com/qri-io/qri/lib"
+)
+
+// WorkflowInfo is a simplified data structure that can be built from a Workflow
+// It is primarily used for the `workflow/list` endpoint
+type WorkflowInfo struct {
+	dsref.VersionInfo
+	ID string `json:"id"` // CID string
+}
+
+func WorkflowInfoFromVersionInfo(vi dsref.VersionInfo, WorkflowID string) *WorkflowInfo {
+	return &WorkflowInfo{
+		VersionInfo: dsref.VersionInfo{
+			InitID:      vi.InitID,
+			Username:    vi.Username,
+			ProfileID:   vi.ProfileID,
+			Name:        vi.Name,
+			Path:        vi.Path,
+			Published:   vi.Published,
+			Foreign:     vi.Foreign,
+			MetaTitle:   vi.MetaTitle,
+			ThemeList:   vi.ThemeList,
+			BodySize:    vi.BodySize,
+			BodyRows:    vi.BodyRows,
+			BodyFormat:  vi.BodyFormat,
+			NumErrors:   vi.NumErrors,
+			FSIPath:     vi.FSIPath,
+			RunID:       vi.RunID,
+			RunStatus:   vi.RunStatus,
+			RunDuration: vi.RunDuration,
+		},
+		ID: WorkflowID,
+	}
+}
+
+// ListWorkflowInfos returns all the WorkflowInfos (including datasets that have
+// been converted to WorkflowInfos). Future iterations will include pagination
+func (c *Cron) ListWorkflowInfos(ctx context.Context, inst *lib.Instance, after, before int) ([]*WorkflowInfo, error) {
+	m := lib.NewDatasetMethods(inst)
+	// TODO (ramfox): for now we are fetching everything.
+	p := &lib.ListParams{
+		Limit:  100,
+		Offset: 0,
+	}
+
+	// TODO (ramfox): when we add in pagination, we should be using `after` and `before`
+	// as our metrics. We should use those to search for the correct interval of datasets
+	// and the correct interval of workflows
+
+	// TODO (ramfox): goal is eventually to get version infos list in reverse
+	// chronological order by activity
+	// However dataset list does not have the ability to sort in a specified way
+	vis := []dsref.VersionInfo{}
+	fetchNext := true
+	for fetchNext {
+		v, err := m.List(ctx, p)
+		if err != nil {
+			log.Errorf("error getting datasets: %w", err)
+			return nil, fmt.Errorf("error getting datasets: %w", err)
+		}
+		vis = append(vis, v...)
+		if len(v) < p.Limit {
+			fetchNext = false
+		}
+		p.Offset++
+	}
+
+	// -1 limit returns all workflows
+	ws, err := c.store.ListWorkflows(ctx, 0, -1)
+	if err != nil {
+		log.Errorf("error getting workflows: %w", err)
+		return nil, fmt.Errorf("error getting workflows: %w", err)
+	}
+
+	wiMap := map[string]*Workflow{}
+
+	for _, w := range ws {
+		wiMap[w.DatasetID] = w
+	}
+
+	wis := []*WorkflowInfo{}
+	for _, vi := range vis {
+		// DatasetID is currently `username/name`
+		viID := fmt.Sprintf("%s/%s", vi.Username, vi.Name)
+		w, ok := wiMap[viID]
+		if ok {
+			wis = append(wis, WorkflowInfoFromVersionInfo(vi, w.ID))
+			continue
+		}
+		// TODO (ramfox): HACK - because frontend has no concept of identity yet
+		// all workflows created by the frontend are sent with `Username='me'`
+		w, ok = wiMap[fmt.Sprintf("me/%s", vi.Name)]
+		if ok {
+			wis = append(wis, WorkflowInfoFromVersionInfo(vi, w.ID))
+			continue
+		}
+		wis = append(wis, WorkflowInfoFromVersionInfo(vi, ""))
+	}
+
+	return wis, nil
+}

--- a/qrimatic/scheduler/workflow_info.go
+++ b/qrimatic/scheduler/workflow_info.go
@@ -17,32 +17,10 @@ type WorkflowInfo struct {
 	ID string `json:"id"` // CID string
 }
 
-func WorkflowInfoFromVersionInfo(vi dsref.VersionInfo, WorkflowID string) *WorkflowInfo {
+func workflowInfoFromVersionInfo(vi dsref.VersionInfo, workflowID string) *WorkflowInfo {
 	return &WorkflowInfo{
-		VersionInfo: dsref.VersionInfo{
-			InitID:        vi.InitID,
-			Username:      vi.Username,
-			ProfileID:     vi.ProfileID,
-			Name:          vi.Name,
-			Path:          vi.Path,
-			Published:     vi.Published,
-			Foreign:       vi.Foreign,
-			MetaTitle:     vi.MetaTitle,
-			ThemeList:     vi.ThemeList,
-			BodySize:      vi.BodySize,
-			BodyRows:      vi.BodyRows,
-			BodyFormat:    vi.BodyFormat,
-			NumErrors:     vi.NumErrors,
-			CommitTime:    vi.CommitTime,
-			CommitTitle:   vi.CommitTitle,
-			CommitMessage: vi.CommitMessage,
-			NumVersions:   vi.NumVersions,
-			FSIPath:       vi.FSIPath,
-			RunID:         vi.RunID,
-			RunStatus:     vi.RunStatus,
-			RunDuration:   vi.RunDuration,
-		},
-		ID: WorkflowID,
+		VersionInfo: vi,
+		ID:          workflowID,
 	}
 }
 
@@ -53,7 +31,7 @@ func (c *Cron) ListCollection(ctx context.Context, inst *lib.Instance, before, a
 	// TODO (ramfox): for now we are fetching everything.
 	p := &lib.ListParams{
 		Offset: 0,
-		Limit:  100,
+		Limit:  100000000000,
 	}
 
 	// TODO (ramfox): when we add in pagination, we should be using `after` and `before`
@@ -94,20 +72,20 @@ func (c *Cron) ListCollection(ctx context.Context, inst *lib.Instance, before, a
 	wis := []*WorkflowInfo{}
 	for _, vi := range vis {
 		// DatasetID is currently `username/name`
-		viID := fmt.Sprintf("%s/%s", vi.Username, vi.Name)
+		viID := vi.Alias()
 		w, ok := wiMap[viID]
 		if ok {
-			wis = append(wis, WorkflowInfoFromVersionInfo(vi, w.ID))
+			wis = append(wis, workflowInfoFromVersionInfo(vi, w.ID))
 			continue
 		}
 		// TODO (ramfox): HACK - because frontend has no concept of identity yet
 		// all workflows created by the frontend are sent with `Username='me'`
 		w, ok = wiMap[fmt.Sprintf("me/%s", vi.Name)]
 		if ok {
-			wis = append(wis, WorkflowInfoFromVersionInfo(vi, w.ID))
+			wis = append(wis, workflowInfoFromVersionInfo(vi, w.ID))
 			continue
 		}
-		wis = append(wis, WorkflowInfoFromVersionInfo(vi, ""))
+		wis = append(wis, workflowInfoFromVersionInfo(vi, ""))
 	}
 
 	sort.Slice(wis, func(i, j int) bool {

--- a/qrimatic/scheduler/workflow_info.go
+++ b/qrimatic/scheduler/workflow_info.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
@@ -18,23 +19,27 @@ type WorkflowInfo struct {
 func WorkflowInfoFromVersionInfo(vi dsref.VersionInfo, WorkflowID string) *WorkflowInfo {
 	return &WorkflowInfo{
 		VersionInfo: dsref.VersionInfo{
-			InitID:      vi.InitID,
-			Username:    vi.Username,
-			ProfileID:   vi.ProfileID,
-			Name:        vi.Name,
-			Path:        vi.Path,
-			Published:   vi.Published,
-			Foreign:     vi.Foreign,
-			MetaTitle:   vi.MetaTitle,
-			ThemeList:   vi.ThemeList,
-			BodySize:    vi.BodySize,
-			BodyRows:    vi.BodyRows,
-			BodyFormat:  vi.BodyFormat,
-			NumErrors:   vi.NumErrors,
-			FSIPath:     vi.FSIPath,
-			RunID:       vi.RunID,
-			RunStatus:   vi.RunStatus,
-			RunDuration: vi.RunDuration,
+			InitID:        vi.InitID,
+			Username:      vi.Username,
+			ProfileID:     vi.ProfileID,
+			Name:          vi.Name,
+			Path:          vi.Path,
+			Published:     vi.Published,
+			Foreign:       vi.Foreign,
+			MetaTitle:     vi.MetaTitle,
+			ThemeList:     vi.ThemeList,
+			BodySize:      vi.BodySize,
+			BodyRows:      vi.BodyRows,
+			BodyFormat:    vi.BodyFormat,
+			NumErrors:     vi.NumErrors,
+			CommitTime:    vi.CommitTime,
+			CommitTitle:   vi.CommitTitle,
+			CommitMessage: vi.CommitMessage,
+			NumVersions:   vi.NumVersions,
+			FSIPath:       vi.FSIPath,
+			RunID:         vi.RunID,
+			RunStatus:     vi.RunStatus,
+			RunDuration:   vi.RunDuration,
 		},
 		ID: WorkflowID,
 	}
@@ -103,6 +108,13 @@ func (c *Cron) ListWorkflowInfos(ctx context.Context, inst *lib.Instance, after,
 		}
 		wis = append(wis, WorkflowInfoFromVersionInfo(vi, ""))
 	}
+
+	sort.Slice(wis, func(i, j int) bool {
+		// sort by commit time in reverse chronological order
+		// TODO (ramfox): when `activity time` is surfaced, we would prefer to sort
+		// by that metric
+		return wis[i].CommitTime.After(wis[j].CommitTime)
+	})
 
 	return wis, nil
 }

--- a/qrimatic/scheduler/workflow_info.go
+++ b/qrimatic/scheduler/workflow_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/qri-io/qri/dsref"
 	"github.com/qri-io/qri/lib"
@@ -45,14 +46,14 @@ func WorkflowInfoFromVersionInfo(vi dsref.VersionInfo, WorkflowID string) *Workf
 	}
 }
 
-// ListWorkflowInfos returns all the WorkflowInfos (including datasets that have
-// been converted to WorkflowInfos). Future iterations will include pagination
-func (c *Cron) ListWorkflowInfos(ctx context.Context, inst *lib.Instance, after, before int) ([]*WorkflowInfo, error) {
+// ListCollection returns a union of datasets and workflows in the form of `WorkflowInfo`s
+// TODO (ramfox): add pagination by timestamp
+func (c *Cron) ListCollection(ctx context.Context, inst *lib.Instance, before, after time.Time) ([]*WorkflowInfo, error) {
 	m := lib.NewDatasetMethods(inst)
 	// TODO (ramfox): for now we are fetching everything.
 	p := &lib.ListParams{
-		Limit:  100,
 		Offset: 0,
+		Limit:  100,
 	}
 
 	// TODO (ramfox): when we add in pagination, we should be using `after` and `before`


### PR DESCRIPTION
The `/workflows/list` route returns the entire set of datasets and workflows, in a combined list of `WorkflowInfos`. `WorkflowInfos` are essentially `VersionInfos` with an added `ID` field that specifies the associated workflow id, if one exists.

TODO:
- [ ] add `ListWorkflowInfos` test. Not sure if this makes sense at this point, we would essentially be testing for behavior we know we want to change and isn't what we are working toward in the long run.
- [ ] add service when a run starts to keep track of runs
- [ ] `/workflows/running` - add cron.GetRunningWorkflows()
- [ ] add ability to return workflows in reverse chronological order based on commit time (so we can match up with datasets returned from qri core)
- [ ] this is a qri update but, we want the ability to return datasets in reverse chronological order based on activity time 
- [ ] how is qrimatic dealing with scope on the qrimatic side? Is adding a "username" param to the listing function enough scope for now? Locally this does not make sense because you can have datasets in your list that don't have your peername, but can we assume (for now) that qrimatic scopes based on "username" & you don' thave access to workflows that aren't in your namespace?

```go
// psuedo code for structure to keep track of when a run starts/ends
// struct should be created/exist on `cron`
type RunningWorkflows struct {
  bus event.Bus
  lock mutex.lock
  // stored in chronological order
  running []*Workflow
}

// Must be created before whatever runs the workflows starts, so we don't miss any events
// add running service to w/e struct 
New(ctx context): RunningWorkflows {
  // create bus from context
  // subscribe to ETWorkflowStarted & ETWorkflowCompleted events
    // ETWorkflowStarted calls addRunning
    // ETWorkflowCompleted calls removeRunning
  return rs
}

// addRun adds given run to END of list rs.runs & uses mutex lock O(c)
(rs) addRunning

// removeRun removes given run from list of rs.runs & uses mutex lock O(n)
(rs) removeRunning

// getRuns returns list of running workflows in reverse chronological order (aka latest running first) 0(n)
(rs) getRunningWorkflows()
// iterate through list, last first return reversed list (think it's overkill to create a Sort)
```

### things noticed/bugs:
- because frontend has no concept of session or identity yet, all workflows are returning
  as "me/datasetName". When we create the workflows, we use this as the datasetID
- currently frontend removes a dataset but not a workflow. Does "unschedule" mean delete? It looks like it does, but the language is confusing. This also does not delete the underlying dataset. Should we be relying on the qri endpoints for that, and have frontend send requests to "unschedule workflow" and "remove dataset", or should "unschedule workflow" auto remove any associated dataset?
- we have limit, offset in some places and offset, limit in others, what wins? 

change to `/collection`