### PR TITLE
refactor run button & add unsaved changes warning

### DIFF
--- a/frontend/src/chrome/Button.tsx
+++ b/frontend/src/chrome/Button.tsx
@@ -22,14 +22,14 @@ const Button: React.FC<ButtonProps> = ({
 
   // primary type
   let colorClasses = 'text-white bg-qriblue-600 hover:bg-qriblue-700 focus:ring-qriblue-500'
-  let sizeClasses = 'text-sm px-4 py-2'
+  let sizeClasses = 'font-semibold text-sm px-4 py-2'
 
   switch(type) {
     case 'light':
       colorClasses = 'text-gray-700 hover:bg-gray-50 border border-gray-300 focus:ring-indigo-500'
       break
     case 'dark':
-      colorClasses = 'text-white bg-qrinavy-400 hover:bg-qrinavy-500  focus:ring-qrinavy-400'
+      colorClasses = 'text-white bg-qrinavy-400 hover:bg-qrinavy-500 focus:ring-qrinavy-400'
       break
     case 'danger':
       colorClasses = 'text-white bg-red-600 hover:bg-red-700 focus:ring-red-500'
@@ -45,7 +45,7 @@ const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type="button"
-      className={`flex items-center inline-flex justify-center rounded-sm shadow-sm bg-white font-medium focus:outline-none focus:ring focus:ring-offset ring-offset-transparent mt-0 w-auto transition-all duration-100 ${colorClasses} ${sizeClasses} ${className}`}
+      className={`flex items-center inline-flex justify-center rounded-sm shadow-sm bg-white font-medium focus:outline-none focus:ring focus:ring-offset ring-offset-transparent mt-0 transition-all duration-100 ${colorClasses} ${sizeClasses} ${className}`}
       onClick={onClick}
     >
     { children }

--- a/frontend/src/chrome/Button.tsx
+++ b/frontend/src/chrome/Button.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 export type ButtonType = 'primary'
   | 'light'
+  | 'warning'
   | 'danger'
   | 'dark'
 
@@ -30,6 +31,9 @@ const Button: React.FC<ButtonProps> = ({
       break
     case 'dark':
       colorClasses = 'text-white bg-qrinavy-400 hover:bg-qrinavy-500 focus:ring-qrinavy-400'
+      break
+    case 'warning':
+      colorClasses = 'text-gray-700 bg-yellow-300 hover:bg-yellow-400 focus:ring-yellow-400'
       break
     case 'danger':
       colorClasses = 'text-white bg-red-600 hover:bg-red-700 focus:ring-red-500'

--- a/frontend/src/features/app/modal/Modal.tsx
+++ b/frontend/src/features/app/modal/Modal.tsx
@@ -5,6 +5,7 @@ import { ModalType, selectModal } from '../state/appState'
 import DeployWorkflowModal from '../../deploy/DeployWorkflowModal'
 import RemoveDatasetModal, { RemoveDatasetModalProps } from '../../dataset/modal/RemoveDatasetModal'
 import ScheduleModal from '../../workflow/modal/ScheduleModal'
+import UnsavedChangesModal from '../../workflow/modal/UnsavedChangesModal'
 import LogInModal from '../../session/modal/LogInModal'
 import SignUpModal from '../../session/modal/SignUpModal'
 
@@ -54,6 +55,8 @@ const Modal: React.FC<any> = () => {
               switch (modal.type) {
                 case ModalType.schedulePicker:
                   return <ScheduleModal {...modal.props} />
+                case ModalType.unsavedChanges:
+                    return <UnsavedChangesModal {...modal.props} />
                 case ModalType.deployWorkflow:
                     return <DeployWorkflowModal {...modal.props} />
                 case ModalType.removeDataset:

--- a/frontend/src/features/app/modal/ModalLayout.tsx
+++ b/frontend/src/features/app/modal/ModalLayout.tsx
@@ -17,15 +17,14 @@ export interface ModalLayoutProps {
 }
 
 const ModalLayout: React.FC<ModalLayoutProps> = ({
-    title,
-    type='info',
-    icon,
-    actionButtonText,
-    action,
-    cancelButtonText='Cancel',
-    children
-  }) => {
-
+  title,
+  type='info',
+  icon,
+  actionButtonText,
+  action,
+  cancelButtonText='Cancel',
+  children
+}) => {
   const dispatch = useDispatch()
 
   const handleCancelButtonClick = () => {
@@ -37,34 +36,14 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
     dispatch(clearModal())
   }
 
-  let displayIcon = 'info'
-  let actionButtonType: ButtonType = 'primary'
-  let iconBgColorClass = 'bg-qriblue-100'
-  let iconColorClass = 'text-qriblue-600'
-
-  if (type === 'warning') {
-    actionButtonType = 'warning'
-    displayIcon = 'exclamationTriangle'
-    iconBgColorClass = 'bg-yellow-100'
-    iconColorClass = 'text-yellow-400'
-  }
-
-  if (type === 'danger') {
-    actionButtonType = 'danger'
-    displayIcon = 'exclamationTriangle'
-    iconBgColorClass = 'bg-red-100'
-    iconColorClass = 'text-red-600'
-  }
-
-  // allow icon override
-  if (icon) displayIcon = icon
+  let { displayIcon, actionButtonType, iconBgColorClass, iconColorClass } = typeSettings(type)
 
   return (
     <>
       <div className='bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4'>
         <div className='sm:flex sm:items-start'>
           <div className={`mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full sm:mx-0 sm:h-10 sm:w-10 ${iconBgColorClass}`}>
-            <Icon icon={displayIcon} className={`${iconColorClass}`} />
+            <Icon icon={icon || displayIcon} className={iconColorClass} />
           </div>
           <div className="mt-3 sm:mt-0 sm:ml-4 sm:text-left">
             <h3 className="text-lg leading-6 font-medium text-gray-900">{title}</h3>
@@ -91,6 +70,40 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
       </div>
     </>
   )
+}
+
+interface modalTypeConfig {
+  displayIcon: string
+  actionButtonType: ButtonType
+  iconBgColorClass: string
+  iconColorClass: string
+}
+
+function typeSettings(type: ModalLayoutType): modalTypeConfig {
+  switch (type) {
+    case 'warning':
+      return {
+        actionButtonType: 'warning',
+        displayIcon: 'exclamationTriangle',
+        iconBgColorClass: 'bg-yellow-100',
+        iconColorClass: 'text-yellow-400'
+      }
+   case 'danger':
+     return {
+        actionButtonType: 'danger',
+        displayIcon: 'exclamationTriangle',
+        iconBgColorClass: 'bg-red-100',
+        iconColorClass: 'text-red-600'
+     }
+   default:
+     return {
+        displayIcon: 'info',
+        actionButtonType: 'primary',
+        iconBgColorClass: 'bg-qriblue-100',
+        iconColorClass: 'text-qriblue-600'
+     }
+  }
+
 }
 
 export default ModalLayout

--- a/frontend/src/features/app/modal/ModalLayout.tsx
+++ b/frontend/src/features/app/modal/ModalLayout.tsx
@@ -5,7 +5,7 @@ import Icon from '../../../chrome/Icon'
 import Button, { ButtonType } from '../../../chrome/Button'
 import { clearModal } from '../state/appActions'
 
-export type ModalLayoutType = 'info' | 'danger'
+export type ModalLayoutType = 'info' | 'warning' | 'danger'
 
 export interface ModalLayoutProps {
   title: string
@@ -13,6 +13,7 @@ export interface ModalLayoutProps {
   icon?: string
   actionButtonText: string
   action: () => void
+  cancelButtonText?: string
 }
 
 const ModalLayout: React.FC<ModalLayoutProps> = ({
@@ -21,6 +22,7 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
     icon,
     actionButtonText,
     action,
+    cancelButtonText='Cancel',
     children
   }) => {
 
@@ -39,6 +41,13 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
   let actionButtonType: ButtonType = 'primary'
   let iconBgColorClass = 'bg-qriblue-100'
   let iconColorClass = 'text-qriblue-600'
+
+  if (type === 'warning') {
+    actionButtonType = 'warning'
+    displayIcon = 'exclamationTriangle'
+    iconBgColorClass = 'bg-yellow-100'
+    iconColorClass = 'text-yellow-400'
+  }
 
   if (type === 'danger') {
     actionButtonType = 'danger'
@@ -77,7 +86,7 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
           onClick={handleCancelButtonClick}
           className='mr-2'
         >
-        Cancel
+         {cancelButtonText}
         </Button>
       </div>
     </>

--- a/frontend/src/features/app/state/appState.ts
+++ b/frontend/src/features/app/state/appState.ts
@@ -9,6 +9,7 @@ export const selectModal = (state: RootState): Modal => state.app.modal
 export enum ModalType {
   none = '',
   schedulePicker = 'schedulePicker',
+  unsavedChanges = 'unsavedChanges',
   deployWorkflow = 'deployWorkflow',
   removeDataset = 'removeDataset',
   logIn = 'logIn',

--- a/frontend/src/features/deploy/deployStatus.ts
+++ b/frontend/src/features/deploy/deployStatus.ts
@@ -17,7 +17,7 @@ export const deployStatusInfoMap: Record<DeployStatus,DeployStatusInfo> = {
     statusIconClass: 'text-gray-500',
     message: 'This workflow is not deployed yet. Edit your script here, use a Dry Run to confirm that it is working, then Deploy it!',
     buttonIcon: 'playCircle',
-    buttonClass: 'bg-qriblue hover:bg-qriblue-300',
+    buttonClass: 'bg-qriblue-600 hover:bg-qriblue-700',
     buttonText: 'Deploy Workflow',
   },
   'deployed': {
@@ -44,7 +44,7 @@ export const deployStatusInfoMap: Record<DeployStatus,DeployStatusInfo> = {
     statusIconClass: 'text-gray-500',
     message: 'This version is deployed, but drafted changes to this script are not yet live.',
     buttonIcon: 'playCircle',
-    buttonClass: 'bg-qriblue hover:bg-qriblue-300',
+    buttonClass: 'bg-qriblue-600 hover:bg-qriblue-700',
     buttonText: 'Deploy Changes',
   },
   'paused': {

--- a/frontend/src/features/workflow/RunBar.tsx
+++ b/frontend/src/features/workflow/RunBar.tsx
@@ -1,21 +1,17 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import ReactTooltip from 'react-tooltip'
 
-import DropdownButton, { Option } from '../../chrome/DropdownButton'
+import Button from '../../chrome/Button'
 import { RunStatus } from '../../qri/run'
 import RunStatusIcon from '../run/RunStatusIcon'
-import { applyWorkflowTransform, saveAndApplyWorkflowTransform, setRunMode } from './state/workflowActions'
-import { RunMode, selectRunMode, selectWorkflow } from './state/workflowState'
+import { applyWorkflowTransform, saveAndApplyWorkflowTransform } from './state/workflowActions'
+import { selectRunMode, selectWorkflow } from './state/workflowState'
 
 export interface RunBarProps {
  status: RunStatus
  onRun?: () => void
 }
-
-const runModes: Option<RunMode>[] = [
-  { value: 'apply', title: 'Dry Run', description: 'apply transform & preview results without saving'},
-  { value: 'save', title: 'Run & Save', description: 'run script & save results to version history'},
-]
 
 const RunBar: React.FC<RunBarProps> = ({
   status,
@@ -38,25 +34,25 @@ const RunBar: React.FC<RunBarProps> = ({
 
   return (
     <div>
-      <div className='flex'>
-        <div className='flex-2 mr-2'>
+      <div className='flex w-36 items-center'>
+        <div className='mr-4'>
           <div className='inline-block align-middle'>
             <RunStatusIcon state={status} size='md' />
           </div>
         </div>
-        <div className='flex-1 text-right'>
+        <div className='w-36'>
           {(status === "running")
-            ? <button className='relative rounded-md bg-gray-500 font-bold text-white p-1 pr-5 pl-5' onClick={() => { handleCancel() }}>Cancel</button>
-            : <DropdownButton
-                id='dry-run'
-                value={(runMode === 'apply') ? runModes[0] : runModes[1]}
-                onClick={() => { handleRun() }}
-                onChangeValue={(opt: Option<RunMode>) => { dispatch(setRunMode(opt.value)) }}
-                options={runModes}
-                />
+            ? <Button className='w-24' onClick={() => { handleCancel() }}>Cancel</Button>
+            : <div data-tip data-for='dry-run'><Button className='w-24' onClick={() => { handleRun() }}>Dry Run</Button></div>
           }
         </div>
       </div>
+      <ReactTooltip
+        id='dry-run'
+        effect='solid'
+      >
+        Try this script and preview the results without saving
+      </ReactTooltip>
     </div>
   )
 }

--- a/frontend/src/features/workflow/Workflow.tsx
+++ b/frontend/src/features/workflow/Workflow.tsx
@@ -1,13 +1,17 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
+import { Prompt, Redirect } from 'react-router'
 import { useLocation } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux'
+import { Location } from 'history'
 
-import WorkflowOutline from './WorkflowOutline';
-import { selectLatestRun, selectRunMode, selectWorkflow } from './state/workflowState';
-import { loadWorkflowByDatasetRef, setWorkflow, setWorkflowRef } from './state/workflowActions';
-import { selectTemplate } from '../template/templates';
-import { QriRef } from '../../qri/ref';
-import WorkflowEditor from './WorkflowEditor';
+import WorkflowOutline from './WorkflowOutline'
+import { selectLatestRun, selectRunMode, selectWorkflow } from './state/workflowState'
+import { loadWorkflowByDatasetRef, setWorkflow, setWorkflowRef } from './state/workflowActions'
+import { selectTemplate } from '../template/templates'
+import { QriRef } from '../../qri/ref'
+import WorkflowEditor from './WorkflowEditor'
+import { showModal } from '../app/state/appActions'
+import { ModalType } from '../app/state/appState'
 
 interface WorkflowLocationState {
   template: string
@@ -24,6 +28,9 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const latestRun = useSelector(selectLatestRun)
   const runMode = useSelector(selectRunMode)
 
+  const [ shouldPrompt, setShouldPrompt ] = useState(true)
+  const [ redirectTo, setRedirectTo ] = useState('')
+
   useEffect(() => {
     if (location.state && location.state.template) {
       dispatch(setWorkflow(selectTemplate(location.state.template)))
@@ -37,11 +44,36 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
     dispatch(loadWorkflowByDatasetRef(qriRef))
   }, [dispatch, qriRef])
 
+  const handleBlockedNavigation = (nextLocation: Location ) => {
+    // TODO(chriswhong): actually use app state to determine if navigation should be blocked
+
+    // do nothing if user clicks the link for the active route
+    if (nextLocation.pathname === location.pathname) {
+      return true
+    }
+
+    if (shouldPrompt) {
+      setRedirectTo(nextLocation.pathname)
+      dispatch(showModal(ModalType.unsavedChanges, {
+        action: () => { setShouldPrompt(false)}
+      }))
+      return false
+    }
+    return true
+  }
+
   return (
-    <div id='workflow' className='flex h-full'>
-      <WorkflowOutline workflow={workflow} run={latestRun} runMode={runMode} />
-      <WorkflowEditor workflow={workflow} run={latestRun} runMode={runMode} />
-    </div>
+    <>
+      <div id='workflow' className='flex h-full'>
+        <Prompt
+          when={true}
+          message={handleBlockedNavigation}
+        />
+        <WorkflowOutline workflow={workflow} run={latestRun} runMode={runMode} />
+        <WorkflowEditor workflow={workflow} run={latestRun} runMode={runMode} />
+        { !shouldPrompt && redirectTo && <Redirect to={redirectTo} /> }
+      </div>
+    </>
   )
 }
 

--- a/frontend/src/features/workflow/modal/UnsavedChangesModal.tsx
+++ b/frontend/src/features/workflow/modal/UnsavedChangesModal.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import ModalLayout from '../../app/modal/ModalLayout'
+
+interface UnsavedChangesModalProps {
+  action: () => void
+}
+
+const UnsavedChangesModal: React.FC<UnsavedChangesModalProps> = ({ action }) => {
+
+
+  return (
+    <ModalLayout
+      title='This Workflow has undeployed changes'
+      type='warning'
+      actionButtonText='Discard Changes'
+      cancelButtonText='Stay'
+      action={action}
+    >
+      <p className='mb-4'>It looks like you've made changes to this workflow that have not been deployed.  These changes will be lost if you leave this page. </p>
+    </ModalLayout>
+  )
+}
+
+export default UnsavedChangesModal


### PR DESCRIPTION
- Refactors `RunBar` to remove the Dropdown (so it will only be a Dry Run Button)
- Adds a Prompt to warn the user when navigating away from the workflow editor.  This can be connected to a proper dirty state later, but for now will always show when the user attempts to navigate away.
- Adds `warning` types for modals and buttons which use a yellow color scheme.