### PR TITLE
feat: add web scraping template

### DIFF
--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -37,7 +37,7 @@ const TemplateList: React.FC<any> = () => {
             templates.map(({ name, id }) => (
               <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
                 <Link id={id} to={{
-                  pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}`,
+                  pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}/workflow`,
                   state: { template: id }
                 }}>
                   <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm px-10 py-16 text-center'>

--- a/frontend/src/features/template/templates.ts
+++ b/frontend/src/features/template/templates.ts
@@ -49,7 +49,7 @@ export const APICall: Workflow = {
   onComplete: [
     { type: 'push', remote: 'https://registry.qri.cloud' }
   ]
-} 
+}
 
 export const DatabaseQuery: Workflow = {
   id: 'DatabaseQuery',
@@ -68,26 +68,65 @@ export const DatabaseQuery: Workflow = {
   onComplete: [
     { type: 'push', remote: 'https://registry.qri.cloud' }
   ]
-} 
+}
 
 export const Webscrape: Workflow = {
   id: 'Webscrape',
   runCount: 0,
   disabled: false,
-  
+
   triggers: [
     // repeat every hour
     { id: '', workflowID: '', type: 'cron', periodicity: 'R/PT1H' }
   ],
   steps: [
-    { syntax: 'starlark', category: 'setup', name: 'setup', script: `# load_ds("b5/webscrape")` },
-    { syntax: 'starlark', category: 'download', name: 'download', script: `def download(ctx):\n\treturn "your download here"` },
-    { syntax: 'starlark', category: 'transform', name: 'transform', script: 'def transform(ds,ctx):\n\tds.set_body([[1,2,3],[4,5,6]])' }
+    { syntax: 'starlark', category: 'setup', name: 'setup', script: '# load starlark dependencies\nload("http.star", "http")\nload("encoding/csv.star", "csv")\nload("bsoup.star", "bsoup")\nload("time.star", "time")' },
+    { syntax: 'starlark', category: 'download', name: 'download', script: '# get some html to scrape\ndef download(ctx):\n  url = "https://www.epochconverter.com/"\n  return http.get(url).body()' },
+    { syntax: 'starlark', category: 'transform', name: 'transform', script: `# leftPad() pads input with zeroes, takes int or string as input
+def leftPad(input, length):
+  # convert int to string
+  if type(input) == 'int':
+    input = str(input)
+  padded = input
+  for i in range(len(input), length):
+    padded = '0' + padded
+  return padded
+
+# given a time struct, returns an ISO8601 date+time string
+def getISOTimestamp(t):
+  year = leftPad(t.year(), 4)
+  month = leftPad(t.month(), 2)
+  day = leftPad(t.day(), 2)
+  hour = leftPad(t.hour(), 2)
+  minute = leftPad(t.minute(), 2)
+  second = leftPad(t.second(), 2)
+  return '{}-{}-{}T{}:{}:{}'.format(year, month, day, hour, minute, second)
+
+def transform(ds, ctx):
+  # parse body with bsoup
+  soup = bsoup.parseHtml(ctx.download)
+
+  # find element with id "ecclock", its contents are a unix timestamp for now
+  epoch = soup.find(id="ecclock").get_text()
+
+  # timestamp is a time struct
+  timestamp = time.fromtimestamp(int(epoch))
+
+  # convert time struct into ISO8601 string
+  humanReadable = getISOTimestamp(timestamp)
+
+  # create a header row, append a single row of data
+  csv = 'unix_epoch, timestamp\\n'
+  csv += epoch + ',' + humanReadable
+
+  # use the csv string to set the body of the qri dataset
+  ds.set_body(csv, parse_as='csv')
+          ` }
   ],
   onComplete: [
     { type: 'push', remote: 'https://registry.qri.cloud' }
   ]
-} 
+}
 
 export const Templates: Record<string, Workflow> = {
   'CSVDownload': CSVDownload,


### PR DESCRIPTION
- updates the `Link` for template buttons to go to `/ds/me/dataset_xxx/workflow.  This needs to happen because the workflow editor is no longer the default dataset route, and the templates were not loading properly.
- modifies the "web scrape" template to include a simple example of scraping a unix timestamp from a website, parsing it, and creating a simple single-row dataset
![image](https://user-images.githubusercontent.com/1833820/109364356-9eb63e00-785c-11eb-9948-b531494cd13a.png)
