### PR TITLE
refactor(`session`): remove "me" from the app, add the next layer of identity to frontend

### DIFF
--- a/frontend/src/features/collection/state/collectionActions.ts
+++ b/frontend/src/features/collection/state/collectionActions.ts
@@ -1,6 +1,6 @@
 import { AnyAction, Dispatch } from "@reduxjs/toolkit"
 import { NewWorkflow, newWorkflowInfo, WorkflowInfo, workflowInfoFromWorkflow } from "../../../qrimatic/workflow"
-import { ApiAction, ApiActionThunk, CALL_API, getActionType } from "../../../store/api"
+import { ACTION_FAILURE, ApiAction, ApiActionThunk, CALL_API, getActionType } from "../../../store/api"
 import { WORKFLOW_COMPLETED, WORKFLOW_STARTED } from "./collectionState"
 
 function mapWorkflowInfo (data: object | []): WorkflowInfo[] {
@@ -10,13 +10,13 @@ function mapWorkflowInfo (data: object | []): WorkflowInfo[] {
 export function loadCollection(dispatch: Dispatch, offset: number, limit: number) {
   loadCollectionWorkflows(1, 50)(dispatch)
   .then(async (action: AnyAction) => {
-    if (getActionType(action) === 'failure') {
+    if (getActionType(action) === ACTION_FAILURE) {
       console.log("load collection failed:", action.payload.err.message)
     }
     return await loadRunningCollection()(dispatch)
   })
   .then((action: AnyAction) => {
-    if (getActionType(action) === 'failure') {
+    if (getActionType(action) === ACTION_FAILURE) {
       console.log("loading running collection failed:", action.payload.err.message)
     }
   })

--- a/frontend/src/features/dataset/Dataset.tsx
+++ b/frontend/src/features/dataset/Dataset.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router';
 import { useParams } from 'react-router-dom';
 
@@ -12,6 +12,7 @@ import DatasetNavSidebar from './DatasetNavSidebar';
 import DatasetTitleMenu from './DatasetTitleMenu';
 import DeployingScreen from '../deploy/DeployingScreen';
 import DatasetActivityFeed from '../activityFeed/DatasetActivityFeed';
+import { selectSessionUser } from '../session/state/sessionState';
 
 export interface DatasetMenuItem {
   text: string
@@ -21,6 +22,8 @@ export interface DatasetMenuItem {
 
 const Dataset: React.FC<any> = () => {
   const qriRef = newQriRef(useParams())
+  const username = useSelector(selectSessionUser)?.username || 'new'
+  qriRef.username = username
   const dispatch = useDispatch()
   const { url } = useRouteMatch()
 

--- a/frontend/src/features/dataset/Dataset.tsx
+++ b/frontend/src/features/dataset/Dataset.tsx
@@ -22,8 +22,16 @@ export interface DatasetMenuItem {
 
 const Dataset: React.FC<any> = () => {
   const qriRef = newQriRef(useParams())
-  const username = useSelector(selectSessionUser)?.username || 'new'
-  qriRef.username = username
+  const user = useSelector(selectSessionUser)
+
+  // This covers the case where a user created a new workflow before logging in.
+  // If they login while working on the workflow, the `user` will change, but the
+  // params used to generate the `qriRef` will not (because they are generated
+  // from the url, which has not changed). This check ensures that the correct 
+  // username is propagated after login/signup.
+  if (qriRef.username === 'new') {
+    qriRef.username = user.username
+  }
   const dispatch = useDispatch()
   const { url } = useRouteMatch()
 

--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -53,10 +53,7 @@ function fetchBody (ref: QriRef, page: number, pageSize: number): ApiAction {
         pageSize
       },
       segments: {
-        // TODO(b5): this is a hack for now while we don't have session support,
-        // restore ASAP
-        // peername: ref.username,
-        peername: 'me',
+        peername: ref.username,
         name: ref.name
       },
       map: mapBody

--- a/frontend/src/features/deploy/DeployStatusDescriptionButton.tsx
+++ b/frontend/src/features/deploy/DeployStatusDescriptionButton.tsx
@@ -7,7 +7,7 @@ import { Workflow } from '../../qrimatic/workflow'
 import { deployStatusInfoMap } from './deployStatus'
 import { deployWorkflow } from './state/deployActions'
 import { newDeployStatusSelector } from './state/deployState'
-import { selectSessionUser } from '../session/state/sessionState'
+import { NewUser, selectSessionUser } from '../session/state/sessionState'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 
@@ -22,7 +22,7 @@ const DeployButtonWithStatusDescription: React.FC<DeployStatusDescriptionButtonP
   const { statusIcon, statusIconClass, statusText, message, buttonIcon, buttonClass, buttonText } = deployStatusInfoMap[status]
 
   const handleButtonClick = () => {
-    if (!user) {
+    if (user === NewUser) {
       dispatch(showModal(ModalType.signUp))
       return
     }

--- a/frontend/src/features/navbar/SessionUserMenu.tsx
+++ b/frontend/src/features/navbar/SessionUserMenu.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import Icon from '../../chrome/Icon'
 import DropdownMenu from '../../chrome/DropdownMenu'
-import { selectSessionUser } from '../session/state/sessionState'
+import { NewUser, selectSessionUser } from '../session/state/sessionState'
 import { logOut } from '../session/state/sessionActions'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
@@ -13,7 +13,7 @@ const SessionUserMenu: React.FC<{}> = () => {
   const user = useSelector(selectSessionUser)
   const dispatch = useDispatch()
 
-  if (!user) {
+  if (user === NewUser) {
     const handleLogInClick = () => {
       dispatch(showModal(ModalType.logIn))
     }

--- a/frontend/src/features/session/modal/LogInModal.tsx
+++ b/frontend/src/features/session/modal/LogInModal.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { SyncLoader } from 'react-spinners'
-import { getActionType } from '../../../store/api'
 import { AnyAction } from '@reduxjs/toolkit'
 
+import { ACTION_FAILURE, getActionType } from '../../../store/api'
 import ExternalLink from '../../../chrome/ExternalLink'
 import Button from '../../../chrome/Button'
 import TextInput from '../../../chrome/forms/TextInput'
@@ -30,7 +30,7 @@ const LogInModal: React.FC = () => {
   const handleButtonClick = () => {
     logIn(username, password)(dispatch)
       .then((action: AnyAction) => {
-        if (getActionType(action) === 'failure') {
+        if (getActionType(action) === ACTION_FAILURE) {
           setLoginError(action.payload.err.message)
           return
         }

--- a/frontend/src/features/session/modal/LogInModal.tsx
+++ b/frontend/src/features/session/modal/LogInModal.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { SyncLoader } from 'react-spinners'
+import { getActionType } from '../../../store/api'
+import { AnyAction } from '@reduxjs/toolkit'
 
 import ExternalLink from '../../../chrome/ExternalLink'
 import Button from '../../../chrome/Button'
@@ -16,6 +18,7 @@ const LogInModal: React.FC = () => {
 
   const [ username, setUsername ] = useState('')
   const [ password, setPassword ] = useState('')
+  const [ loginError, setLoginError ] = useState('')
 
   const dispatch = useDispatch()
   const loading = useSelector(selectIsSessionLoading)
@@ -25,9 +28,14 @@ const LogInModal: React.FC = () => {
   }
 
   const handleButtonClick = () => {
-    dispatch(logIn(username, password)).then(() => {
-      dispatch(clearModal())
-    })
+    logIn(username, password)(dispatch)
+      .then((action: AnyAction) => {
+        if (getActionType(action) === 'failure') {
+          setLoginError(action.payload.err.message)
+          return
+        }
+        dispatch(clearModal())
+      })
   }
 
   return (
@@ -51,6 +59,9 @@ const LogInModal: React.FC = () => {
           />
           <Link to='/forgot-password'><div className='text-left text-xs font-semibold'>Forgot your Password?</div></Link>
         </div>
+
+        {loginError && <div className='text-xs text-red-500 text-left mb-2'>{loginError}</div>}
+
         <Button size='lg' className='w-full mb-6' onClick={handleButtonClick}>
           {loading ? <SyncLoader color='#fff' size='6' /> : 'Log In'}
         </Button>

--- a/frontend/src/features/session/modal/SignUpModal.tsx
+++ b/frontend/src/features/session/modal/SignUpModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { SyncLoader } from 'react-spinners'
-import { getActionType } from '../../../store/api';
 import { AnyAction } from '@reduxjs/toolkit';
 
+import { ACTION_FAILURE, getActionType } from '../../../store/api';
 import ExternalLink from '../../../chrome/ExternalLink'
 import Button from '../../../chrome/Button'
 import TextInput from '../../../chrome/forms/TextInput'
@@ -49,7 +49,7 @@ const SignUpModal: React.FC = () => {
     if (!emailError && !usernameError && !passwordError) {
       signUp(email, username, password)(dispatch)
         .then((action: AnyAction) => {
-          if (getActionType(action) === 'failure') {
+          if (getActionType(action) === ACTION_FAILURE) {
             setSignupError(action.payload.err.message)
             return
           }

--- a/frontend/src/features/session/modal/SignUpModal.tsx
+++ b/frontend/src/features/session/modal/SignUpModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { SyncLoader } from 'react-spinners'
+import { getActionType } from '../../../store/api';
+import { AnyAction } from '@reduxjs/toolkit';
 
 import ExternalLink from '../../../chrome/ExternalLink'
 import Button from '../../../chrome/Button'
@@ -9,18 +11,20 @@ import { showModal, clearModal } from '../../app/state/appActions'
 import { ModalType } from '../../app/state/appState'
 import { signUp } from '../state/sessionActions'
 import { selectIsSessionLoading } from '../state/sessionState'
-import { validateEmail, validateUsername, validatePassword } from '../state/formValidation'
+import { validateEmail, validateUsername, validatePassword, ValidationError } from '../state/formValidation'
 
 const SignUpModal: React.FC = () => {
 
-  const [ email, setEmail ] = useState('')
-  const [ emailError, setEmailError ] = useState(null)
+  const [email, setEmail] = useState('')
+  const [emailError, setEmailError] = useState<ValidationError>(null)
 
-  const [ username, setUsername ] = useState('')
-  const [ usernameError, setUsernameError ] = useState(null)
+  const [username, setUsername] = useState('')
+  const [usernameError, setUsernameError] = useState<ValidationError>(null)
 
-  const [ password, setPassword ] = useState('')
-  const [ passwordError, setPasswordError] = useState(null)
+  const [password, setPassword] = useState('')
+  const [passwordError, setPasswordError] = useState<ValidationError>(null)
+
+  const [signupError, setSignupError] = useState('')
 
   const dispatch = useDispatch()
   const loading = useSelector(selectIsSessionLoading)
@@ -43,9 +47,14 @@ const SignUpModal: React.FC = () => {
     setPasswordError(passwordError)
 
     if (!emailError && !usernameError && !passwordError) {
-      dispatch(signUp(email, username, password)).then((action) => {
-        dispatch(clearModal())
-      })
+      signUp(email, username, password)(dispatch)
+        .then((action: AnyAction) => {
+          if (getActionType(action) === 'failure') {
+            setSignupError(action.payload.err.message)
+            return
+          }
+          dispatch(clearModal())
+        })
     }
   }
 
@@ -78,6 +87,7 @@ const SignUpModal: React.FC = () => {
             error={passwordError}
           />
         </div>
+        {signupError && <div className='text-xs text-red-500 text-left mb-2'>{signupError}</div>}
         <Button size='lg' className='w-full mb-6' onClick={handleButtonClick}>
           {loading ? <SyncLoader color='#fff' size='6' /> : 'Continue'}
         </Button>

--- a/frontend/src/features/session/state/sessionActions.ts
+++ b/frontend/src/features/session/state/sessionActions.ts
@@ -1,4 +1,5 @@
 import { AnyAction } from '@reduxjs/toolkit'
+
 import { ApiAction, ApiActionThunk, CALL_API} from '../../../store/api'
 
 export function logIn (username: string, password: string): ApiActionThunk {

--- a/frontend/src/features/session/state/sessionActions.ts
+++ b/frontend/src/features/session/state/sessionActions.ts
@@ -1,4 +1,5 @@
-import { ApiActionThunk} from '../../../store/api'
+import { AnyAction } from '@reduxjs/toolkit'
+import { ApiAction, ApiActionThunk, CALL_API} from '../../../store/api'
 
 export function logIn (username: string, password: string): ApiActionThunk {
   return async (dispatch) => {
@@ -6,12 +7,34 @@ export function logIn (username: string, password: string): ApiActionThunk {
       type: 'API_LOGIN_REQUEST'
     })
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    // TODO (ramfox): we want the frontend to have some sense of identity that
+    // is tied to the backend, and until we have an actual login/signup process
+    // we are hijacking this to use the actual username that is recognized by
+    // the backend
+    // if the username typed into the login is not the username the qri node
+    // goes by, we error
+    // this should be replaced by an actual login process that validates the
+    // password and gives the browser a token it can use to properly communicate
+    // with the backend
+    var peername = ''
+    await dispatch(fetchUsername()).then((action: AnyAction) => {
+      peername = action.payload.data
+    })
+    if (peername !== username) {
+      return (dispatch({
+        type: 'API_LOGIN_FAILURE',
+        payload: {
+          err: {
+            message: `unrecognized username "${username}"`
+          }
+        }
+      }))
+    }
 
     return dispatch({
       type: 'API_LOGIN_SUCCESS',
       payload: {
-        username
+        username: peername
       }
     })
   }
@@ -27,18 +50,34 @@ export function logOut (): ApiActionThunk {
 }
 
 export function signUp (email: string, username: string, password: string): ApiActionThunk {
+  // TODO (ramfox): until we have a proper sign up process (that takes a password)
+  // and allows the user to have its own identity on the qri node that is separate
+  // from the id assocaited with the qri node itself, let's disable this 
+  // the failure dispatches a message to the user saying that there is no
+  // way to currently signup
   return async (dispatch) => {
-    dispatch({
-      type: 'API_SIGNUP_REQUEST'
-    })
-
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     return dispatch({
-      type: 'API_SIGNUP_SUCCESS',
+      type: 'API_SIGNUP_FAILURE',
       payload: {
-        username
+        err: {
+          message: "signup is currently disabled"
+        }
       }
     })
+  }
+}
+
+function mapUsername(profile: Record<string, any>): string {
+  return profile.peername
+}
+
+export function fetchUsername(): ApiAction {
+  return {
+    type: 'session',
+    [CALL_API]: {
+      endpoint: 'me',
+      method: 'GET',
+      map: mapUsername
+    }
   }
 }

--- a/frontend/src/features/session/state/sessionState.ts
+++ b/frontend/src/features/session/state/sessionState.ts
@@ -1,7 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { RootState } from '../../../store/store';
 
-export const selectSessionUser = (state: RootState): User | undefined => state.session.user
+export const selectSessionUser = (state: RootState): User => state.session.user
 export const selectIsSessionLoading = (state: RootState): boolean => state.session.loading
 
 export interface User {
@@ -9,12 +9,16 @@ export interface User {
 }
 
 export interface SessionState {
-  user?: User
+  user: User
   loading: boolean
 }
 
+export const NewUser: User = {
+  username: 'new'
+}
+
 const initialState: SessionState = {
-  user: undefined,
+  user: NewUser,
   loading: false
 }
 
@@ -32,7 +36,7 @@ export const sessionReducer = createReducer(initialState, {
     state.loading = false
   },
   'API_LOGOUT_SUCCESS': (state, action) => {
-    state.user = undefined
+    state.user = NewUser
   },
   'API_SIGNUP_REQUEST': (state, action) => {
     state.loading = true

--- a/frontend/src/features/session/state/sessionState.ts
+++ b/frontend/src/features/session/state/sessionState.ts
@@ -28,6 +28,9 @@ export const sessionReducer = createReducer(initialState, {
     }
     state.loading = false
   },
+  'API_LOGIN_FAILURE': (state, action) => {
+    state.loading = false
+  },
   'API_LOGOUT_SUCCESS': (state, action) => {
     state.user = undefined
   },
@@ -38,6 +41,9 @@ export const sessionReducer = createReducer(initialState, {
     state.user = {
       username: action.payload.username
     }
+    state.loading = false
+  },
+  'API_SIGNUP_FAILURE': (state, action) => {
     state.loading = false
   },
 })

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -25,7 +25,7 @@ const templates = [
 ]
 
 const TemplateList: React.FC<any> = () => {
-  const username = useSelector(selectSessionUser)?.username || 'new'
+  const username = useSelector(selectSessionUser)?.username
   return (
     <div className='flex flex-col h-full bg-gray-100'>
       <NavBar />

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import NavBar from '../navbar/NavBar'
+import { selectSessionUser } from '../session/state/sessionState'
 
 const templates = [
   {
@@ -23,6 +25,7 @@ const templates = [
 ]
 
 const TemplateList: React.FC<any> = () => {
+  const username = useSelector(selectSessionUser)?.username || 'new'
   return (
     <div className='flex flex-col h-full bg-gray-100'>
       <NavBar />
@@ -37,7 +40,7 @@ const TemplateList: React.FC<any> = () => {
             templates.map(({ name, id }) => (
               <div key={name} className='my-2 px-2 overflow-hidden w-full md:w-1/2 lg:w-1/3 xl:w-1/3'>
                 <Link id={id} to={{
-                  pathname: `/ds/me/dataset_${Math.floor(Math.random() * 1000)}`,
+                  pathname: `/ds/${username}/dataset_${Math.floor(Math.random() * 1000)}`,
                   state: { template: id }
                 }}>
                   <div className='border border-gray-300 hover:border-blue-500 rounded bg-white text-sm px-10 py-16 text-center'>

--- a/frontend/src/features/template/templates.ts
+++ b/frontend/src/features/template/templates.ts
@@ -4,7 +4,6 @@ import { Workflow } from '../../qrimatic/workflow'
 
 export const CSVDownload: Workflow = {
   id: 'CSVDownload',
-  datasetID: 'me/csv_download_template',
   runCount: 0,
   disabled: false,
 

--- a/frontend/src/features/workflow/state/workflowActions.ts
+++ b/frontend/src/features/workflow/state/workflowActions.ts
@@ -28,7 +28,7 @@ function fetchWorkflowByDatasetRef(qriRef: QriRef): ApiAction {
     type: 'workflow',
     qriRef,
     [CALL_API]: {
-      endpoint: `workflow?dataset_id=me/${qriRef.name}`,
+      endpoint: `workflow?dataset_id=${qriRef.username}/${qriRef.name}`,
       method: 'GET',
       map: mapWorkflow
     }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -41,6 +41,7 @@ export default function Routes () {
         <PrivateRoute path='/collection'><Collection /></PrivateRoute>
         <PrivateRoute path='/activity'><CollectionActivityFeed /></PrivateRoute>
 
+        <Route path='/ds/new/:name'><Dataset /></Route>
         <Route path='/ds/new'><TemplateList /></Route>
         <Route path='/ds/:username/:name'><Dataset /></Route>
 

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -15,13 +15,13 @@ import Run from './features/run/Run';
 import Collection from './features/collection/Collection';
 import Dashboard from './features/dashboard/Dashboard';
 import Dataset from './features/dataset/Dataset';
-import { selectSessionUser } from './features/session/state/sessionState'
+import { NewUser, selectSessionUser } from './features/session/state/sessionState'
 
 const PrivateRoute: React.FC<any>  = ({ path, children }) => {
   const user = useSelector(selectSessionUser)
   return (
     <Route path={path}>
-      { user ? <>{children}</> : <Redirect to={{ pathname: '/splash' }} /> }
+      { user !== NewUser ? <>{children}</> : <Redirect to={{ pathname: '/splash' }} /> }
     </Route>
   )
 }
@@ -53,7 +53,7 @@ export default function Routes () {
 
         <Route path='/'>
           {
-            user ? <Redirect to='/dashboard' /> : <Splash />
+            user !== NewUser ? <Redirect to='/dashboard' /> : <Splash />
           }
         </Route>
       </Switch>

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -48,10 +48,14 @@ export function apiActionTypes (endpoint: string): [string, string, string] {
   return [`API_${name}_REQUEST`, `API_${name}_SUCCESS`, `API_${name}_FAILURE`]
 }
 
+export const ACTION_REQUEST = 'request'
+export const ACTION_SUCCESS = 'success'
+export const ACTION_FAILURE = 'failure'
+
 export const getActionType = (action = { type: '' }): string => {
-  if (action.type.endsWith('REQUEST')) return 'request'
-  if (action.type.endsWith('SUCCESS')) return 'success'
-  if (action.type.endsWith('FAILURE')) return 'failure'
+  if (action.type.endsWith('REQUEST')) return ACTION_REQUEST
+  if (action.type.endsWith('SUCCESS')) return ACTION_SUCCESS
+  if (action.type.endsWith('FAILURE')) return ACTION_FAILURE
   return ''
 }
 


### PR DESCRIPTION
* [x] session reducer
* [x] fetch from 'me' endpoint - `fetchUsername()` => takes the profile & returns the username of the node
* [x] disable signup & add error to inform the username
* [x] fetch the username inside the login action. If the username the user used to sign in is not the same as the one expected by the node, error
* [x] make sure there are TODOs saying that this is temporary
* [x] pull "username" from session & ensure we are using "username" everywhere instead of "me"
- TemplateList
- templates.ts
- workflowActions.ts
- NotificationsSettings.tsx
- datasetActions.ts

* [x] we need a new stand-in username for workflows that get created before the user has logged in. Using "new" for now. Eventually, when we keep track of the workflow inside the app, so that a user can refresh or navigate away without loosing changes, we should be changing the route from "new" to the given username after the user signs up. Right now, if we navigate to a new route, the page would refresh and any work that the user has done in the page will be erased.