### PR TITLE
test(`SchedulerTestRunner`): create test runner for `scheduler` package tests

### DIFF
--- a/qrimatic/go.mod
+++ b/qrimatic/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/qri-io/apiutil v0.2.0
-	github.com/qri-io/dataset v0.2.1-0.20210128201320-3b1209495e96
+	github.com/qri-io/dataset v0.2.1-0.20210304141850-a4a809d46350
 	github.com/qri-io/ioes v0.1.1
 	github.com/qri-io/iso8601 v0.1.1-0.20201221213213-f31ee4cdc38b
 	github.com/qri-io/qfs v0.5.1-0.20201119141805-fb13393b2d1f

--- a/qrimatic/go.sum
+++ b/qrimatic/go.sum
@@ -1113,6 +1113,8 @@ github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48 h1:6fTW2iHGbaEKQt9u8+
 github.com/qri-io/dag v0.2.2-0.20201208212257-ae00241c4b48/go.mod h1:1AwOy3yhcZTAXzaF4wGSdnrp87u3PBOrsWXUjOtQCXo=
 github.com/qri-io/dataset v0.2.1-0.20210128201320-3b1209495e96 h1:SiP48nzhKLJbvM6SA+5wK53PKUs0FY0DWDylMPyi8S4=
 github.com/qri-io/dataset v0.2.1-0.20210128201320-3b1209495e96/go.mod h1:vlq9+Nu37koO3mrp25QGNOt68CLe2d2rAtB9cnDLV6E=
+github.com/qri-io/dataset v0.2.1-0.20210304141850-a4a809d46350 h1:uXvx2/y+eqV5o77HLmw51S1aiskOvlq+b6WNTtXHAGk=
+github.com/qri-io/dataset v0.2.1-0.20210304141850-a4a809d46350/go.mod h1:vlq9+Nu37koO3mrp25QGNOt68CLe2d2rAtB9cnDLV6E=
 github.com/qri-io/deepdiff v0.2.1-0.20200807143746-d02d9f531f5b h1:T8qEIv+qLi5mVWvSS329wJ+HbN7cfMwCWjRVzh/+upo=
 github.com/qri-io/deepdiff v0.2.1-0.20200807143746-d02d9f531f5b/go.mod h1:NrL/b7YvexgpGb4HEO3Rlx5RrMLDfxuKDf/XDAq5ac0=
 github.com/qri-io/didmod v0.0.0-20201123165422-8b2e224c993a h1:40BIa59lae2xZ7iieb3UU4/X57jZsWZ6QgqwdjDQhig=

--- a/qrimatic/scheduler/integration_test.go
+++ b/qrimatic/scheduler/integration_test.go
@@ -1,0 +1,158 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/ioes"
+	"github.com/qri-io/qri/lib"
+	"github.com/qri-io/qri/repo/gen"
+	repotest "github.com/qri-io/qri/repo/test"
+	"github.com/qri-io/qri/transform"
+)
+
+func TestScheduleWorkflowIntegration(t *testing.T) {
+
+	username := "integration_test"
+	tr := NewSchedulerTestRunner(t, username)
+	defer tr.Cleanup()
+	workflowName := "workflowName"
+	ownerID := "ownerID"
+	// TODO (ramfox): until we replace `datasetID` with `InitID`, qrimatic
+	// expects the datasetID to be the dataset alias.
+	// TODO (ramfox): until we get multi tenancy the only "username" that
+	// qri will expect is the username of the repo
+	datasetID := fmt.Sprintf("%s/dataset_name", username)
+	w, err := NewCronWorkflow(workflowName, ownerID, datasetID, "R/PT1H")
+	if err != nil {
+		t.Fatalf("creating workflow: %s", err)
+	}
+	dp := &DeployParams{
+		Apply:    true,
+		Workflow: w,
+		Transform: &dataset.Transform{
+			Steps: []*dataset.TransformStep{
+				{
+					Name:   "transform",
+					Syntax: "starlark",
+					Script: "def transform(ds,ctx):\n  ds.set_body([[1,2,3],[4,5,6]])",
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	dr, err := tr.cron.Deploy(ctx, tr.inst, dp)
+	if err != nil {
+		t.Fatalf("deploying workflow: %s", err)
+	}
+	t.Log(dr)
+	_, err = tr.cron.Workflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("getting workflow from cron: %s", err)
+	}
+	// deploy workflow
+	// check that the workflow is in the store
+	// manually trigger workflow
+	// check that the workflow updates & dataset is different in expected way
+	// adjust trigger time
+	// check that trigger time has updated in store
+	// wait until trigger is supposed to run
+	// check that workflow events are firing in correct time
+	// check that after workflow has run it has updated as expected
+	// update transform & deploy
+}
+
+// copy pasted from `api` (can't be imported b/c of circular import issues):
+// newInstanceRunnerFactory returns a factory function that produces a workflow
+// runner from a qri instance
+func newInstanceRunnerFactory(inst *lib.Instance) func(ctx context.Context) RunWorkflowFunc {
+	return func(ctx context.Context) RunWorkflowFunc {
+		dsm := lib.NewDatasetMethods(inst)
+
+		return func(ctx context.Context, streams ioes.IOStreams, workflow *Workflow) error {
+			runID := transform.NewRunID()
+
+			// runState = run.NewState(runID)
+			// m.inst.bus.SubscribeID(func(ctx context.Context, e event.Event) error {
+			// 	runState.AddTransformEvent(e)
+			// 	return nil
+			// }, runID)
+
+			p := &lib.SaveParams{
+				Ref: workflow.DatasetID,
+				Dataset: &dataset.Dataset{
+					Commit: &dataset.Commit{
+						RunID: runID,
+					},
+				},
+				Apply: true,
+			}
+			_, err := dsm.Save(ctx, p)
+			return err
+		}
+	}
+}
+
+type SchedulerTestRunner struct {
+	cancel     context.CancelFunc
+	TestCrypto gen.CryptoGenerator
+	repo       *repotest.TempRepo
+	inst       *lib.Instance
+	store      *Store
+	cron       *Cron
+	storePath  string
+	// when we get identity that is separate from the qri repo identity
+	// we need to keep track of the different users creating workflows in the
+	// test runner
+	// maybe with some `User` struct that keeps a username and a generated
+	// private key, that gets connected correctly to the qrimatic and qri instances
+	// beth &User
+}
+
+func (tr *SchedulerTestRunner) Cleanup() {
+	tr.cancel()
+	if tr.storePath != "" {
+		os.RemoveAll(tr.storePath)
+	}
+	if tr.repo != nil {
+		tr.repo.Delete()
+	}
+}
+
+func NewSchedulerTestRunner(t *testing.T, prefix string) *SchedulerTestRunner {
+	ctx, cancel := context.WithCancel(context.Background())
+	tr := &SchedulerTestRunner{
+		cancel:     cancel,
+		TestCrypto: repotest.NewTestCrypto(),
+	}
+	repo, err := repotest.NewTempRepo(prefix, fmt.Sprintf("%s_scheduler_test_runner_repo", prefix), tr.TestCrypto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr.repo = &repo
+
+	tr.inst, err = lib.NewInstance(ctx, tr.repo.QriPath, lib.OptIOStreams(ioes.NewDiscardIOStreams()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr.storePath, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("%s_scheduler_test_runner_store", prefix))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewFileStore(filepath.Join(tr.storePath, "workflows.json"), tr.inst.Bus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr.store = &store
+
+	f := newInstanceRunnerFactory(tr.inst)
+	tr.cron = NewCron(*tr.store, f, tr.inst.Bus())
+	return tr
+}

--- a/qrimatic/scheduler/run.go
+++ b/qrimatic/scheduler/run.go
@@ -57,6 +57,8 @@ func (r *RunInfo) Copy() *RunInfo {
 		return nil
 	}
 	return &RunInfo{
+		ID:          r.ID,
+		WorkflowID:  r.WorkflowID,
 		Number:      r.Number,
 		Start:       r.Start,
 		Stop:        r.Stop,

--- a/qrimatic/scheduler/workflow.go
+++ b/qrimatic/scheduler/workflow.go
@@ -117,8 +117,6 @@ func (workflow *Workflow) Complete(ds *dsref.Ref, ownerID string) error {
 	workflow.Name = ds.Human()
 	//TODO (arqu): expand this as this version info is very shallow
 	workflow.VersionInfo = ds.VersionInfo()
-	now := time.Now()
-	workflow.Created = &now
 	workflow.Type = JTDataset
 	workflow.OwnerID = ownerID
 	return nil


### PR DESCRIPTION
And creates a `TestScheduleWorkflowIntegration` test.

The test runner should also shift closer to something like the `NetworkIntegrationTestRunner` in `qri/lib`, as we get a better idea of representing users in qri and qrimatic.

relies on https://github.com/qri-io/dataset/pull/251

There is a bug in dataset that is causing workflows without previous versions to segfault when attempting to `ds.get_body()`

