### PR TITLE
refactor(frontend): simplify workflow editor

### DIFF
--- a/frontend/src/features/deploy/deployStatus.ts
+++ b/frontend/src/features/deploy/deployStatus.ts
@@ -15,7 +15,7 @@ export const deployStatusInfoMap: Record<DeployStatus,DeployStatusInfo> = {
     statusIcon: 'circle',
     statusText: 'Not Deployed',
     statusIconClass: 'text-gray-500',
-    message: 'This workflow is not deployed yet. Edit your script here, use a Dry Run to confirm that it is working, then Deploy it!',
+    message: 'This workflow is not deployed yet. Edit your script & use Dry Run to confirm that it is working, then Deploy it!',
     buttonIcon: 'playCircle',
     buttonClass: 'bg-qriblue-600 hover:bg-qriblue-700',
     buttonText: 'Deploy Workflow',

--- a/frontend/src/features/template/TemplateList.tsx
+++ b/frontend/src/features/template/TemplateList.tsx
@@ -21,6 +21,10 @@ const templates = [
   {
     name: 'Web Scrape',
     id: 'Webscrape'
+  },
+  {
+    name: "Blank",
+    id: "Blank"
   }
 ]
 

--- a/frontend/src/features/template/templates.ts
+++ b/frontend/src/features/template/templates.ts
@@ -2,6 +2,32 @@ import { Workflow } from '../../qrimatic/workflow'
 
 // TODO (ramfox): need to formalize possible trigger & on completion types
 
+export const Blank: Workflow = {
+  id: 'Blank',
+  runCount: 0,
+  disabled: false,
+
+  triggers: [
+    // repeat every hour
+    { id: '', workflowID: '', type: 'cron', periodicity: 'R/PT1H' }
+  ],
+  steps: [
+    { syntax: 'starlark', category: 'setup', name: 'setup', script: `# load starlark dependencies
+# load("http.star", "http")
+# load("encoding/csv.star", "csv")` },
+    { syntax: 'starlark', category: 'download', name: 'download', script: `# download web assets
+def download(ctx):
+  return None` },
+    { syntax: 'starlark', category: 'transform', name: 'transform', script: `# shape & clean data
+def transform(ds, ctx):
+  csv = ctx.download
+  ds.set_body(csv, parse_as='csv')`}
+  ],
+  onComplete: [
+    { type: 'push', remote: 'https://registry.qri.cloud' }
+  ]
+}
+
 export const CSVDownload: Workflow = {
   id: 'CSVDownload',
   runCount: 0,
@@ -92,7 +118,8 @@ export const Templates: Record<string, Workflow> = {
   'CSVDownload': CSVDownload,
   'APICall': APICall,
   'DatabaseQuery': DatabaseQuery,
-  'Webscrape': Webscrape
+  'Webscrape': Webscrape,
+  'Blank': Blank
 }
 
 export function selectTemplate(id: string): Workflow {

--- a/frontend/src/features/trigger/CronTriggerEditor.tsx
+++ b/frontend/src/features/trigger/CronTriggerEditor.tsx
@@ -7,9 +7,9 @@ const CronTriggerEditor: React.FC<TriggerEditorProps> = ({
   onChange
 }) => {
   return (
-    <div className='bg-gray-100 px-4 py-2 rounded mt-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100'>
+    <div className='bg-white px-4 py-2 w-2/3 rounded mt-1 border-b border-gray-300 cursor-pointer'>
       <h3 className='text-lg font-semibold'>Cron Interval</h3>
-      <span className="text-md leading-6 font-medium text-gray-700 mr-1" id="modal-headline">Run this script every</span>
+      <span className="text-sm leading-6 font-medium text-gray-700 mr-1" id="modal-headline">Run this script every</span>
       <select className='text-gray-800 font-semibold border-b bg-gray-100' value={trigger.periodicity} onChange={(e: any) => {
         onChange({
           type: trigger.type,

--- a/frontend/src/features/trigger/WorkflowTriggersEditor.tsx
+++ b/frontend/src/features/trigger/WorkflowTriggersEditor.tsx
@@ -38,7 +38,7 @@ const WorkflowTriggersEditor: React.FC<WorkflowTriggersEditorProps> = ({
 }) => {
   const dispatch = useDispatch();
   return (
-    <section className='p-4 bg-white shadow-sm mb-4'>
+    <section className='p-4 mb-4'>
         <ScrollAnchor id='triggers'/>
         <h2 className='text-2xl font-semibold text-gray-600 mb-1'>Triggers</h2>
         <div className='text-xs mb-3'>Customize your workflow to execute on a schedule, or based on other events</div>

--- a/frontend/src/features/workflow/Workflow.tsx
+++ b/frontend/src/features/workflow/Workflow.tsx
@@ -64,7 +64,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
 
   return (
     <>
-      <div id='workflow' className='flex h-full'>
+      <div id='workflow' className='flex h-full w-full'>
         <Prompt
           when={true}
           message={handleBlockedNavigation}

--- a/frontend/src/features/workflow/WorkflowCell.tsx
+++ b/frontend/src/features/workflow/WorkflowCell.tsx
@@ -58,15 +58,12 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
     <div id={`${step.name}-cell`} className='w-full my-4'>
         <ScrollAnchor id={step.name} />
         <header>
-          <div className='text-center w-10 h-100 py-3 float-left'>
-            <h1 className='font-black text-3xl text-gray-300' >{index + 1}</h1>
-          </div>
-          <div className='py-2 px-5'>
+          <div className='py-2 pr-5'>
             {run && <p className='float-right'>{run.duration}</p>}
-            <h3 className='text-lg text-gray-500 font-semibold cursor-pointer' onClick={() => {
+            <h3 className='text-lg text-gray-700 font-semibold cursor-pointer' onClick={() => {
               onChangeCollapse(collapseState === 'all' ? 'collapsed' : 'all')
             }}>{name}{run && <RunStatusIcon state={run.status} />}</h3>
-            <div className='text-xs mb-2'>{description}</div>
+            <div className='text-xs mb-2 text-gray-400'>{description}</div>
           </div>
         </header>
         {(collapseState === 'all' || collapseState === 'only-editor') && editor}

--- a/frontend/src/features/workflow/WorkflowEditor.tsx
+++ b/frontend/src/features/workflow/WorkflowEditor.tsx
@@ -6,6 +6,7 @@ import WorkflowTriggersEditor from '../trigger/WorkflowTriggersEditor';
 import OnComplete from './OnComplete';
 import { NewRunStep, Run, RunStep } from '../../qri/run';
 import { changeWorkflowTransformStep } from './state/workflowActions';
+import DeployButtonWithStatusDescription from '../deploy/DeployStatusDescriptionButton'
 import RunBar from './RunBar';
 import { Workflow } from '../../qrimatic/workflow';
 import Scroller from '../scroller/Scroller';
@@ -43,56 +44,61 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ runMode, run, workflow 
   }
 
   return (
-    <Scroller className='overflow-y-auto p-4 text-left h-full flex-grow'>
-      <WorkflowTriggersEditor triggers={workflow.triggers} />
-      <ScrollAnchor id='script' />
-      <section className='bg-white shadow-sm mb-4'>
-          <div className='bg-white sticky top-0 z-10 p-4 flex bg-opacity-90'>
-            <div className='flex-grow'>
-                <h2 className='text-2xl font-semibold text-gray-600 mb-1'>Script</h2>
-              <div className='text-xs'>Use code to download source data, transform it, and commit the next version of this dataset</div>
+    <Scroller className='overflow-y-auto w-full p-4 text-left'>
+      <div style={{ width: 820 }} className='m-auto'>
+        <WorkflowTriggersEditor triggers={workflow.triggers} />
+        <ScrollAnchor id='script' />
+        <section className='bg-white shadow-sm mb-4'>
+            <div className='bg-white sticky top-0 z-10 p-4 flex shadow-sm'>
+              <div className='flex-grow'>
+                  <h2 className='text-2xl font-semibold text-gray-600 mb-1'>Script</h2>
+                <div className='text-xs'>Use code to download source data, transform it, and commit the next version of this dataset</div>
+              </div>
+              <RunBar status={run ? run.status : "waiting" } onRun={() => {setCollapseStates({})}} />
             </div>
-            <RunBar status={run ? run.status : "waiting" } onRun={() => {setCollapseStates({})}} />
-          </div>
-        <div className='px-4'>
-          {workflow.steps && workflow.steps.map((step, i) => {
-            let r
-            if (run) {
-              r = (run?.steps && run?.steps.length >= i) ? run.steps[i] : NewRunStep({ status: "waiting" })
-            }
-            return (<WorkflowCell
-              key={i}
-              index={i}
-              step={step}
-              run={r}
-              collapseState={collapseState(step.name, r)}
+          <div className='px-4'>
+            {workflow.steps && workflow.steps.map((step, i) => {
+              let r
+              if (run) {
+                r = (run?.steps && run?.steps.length >= i) ? run.steps[i] : NewRunStep({ status: "waiting" })
+              }
+              return (<WorkflowCell
+                key={i}
+                index={i}
+                step={step}
+                run={r}
+                collapseState={collapseState(step.name, r)}
+                onChangeCollapse={(v) => {
+                  const update = Object.assign({}, collapseStates as any)
+                  update[step.name] = v
+                  setCollapseStates(update)
+                }}
+                onChangeScript={(i:number, script:string) => {
+                  if (workflow && workflow.steps) {
+                    dispatch(changeWorkflowTransformStep(i, script))
+                  }
+                }}
+              />)
+            })}
+            {/* TODO(b5) - hack for now. In the future we should make a component that trances & selects save results */}
+            {runMode === 'save' && <WorkflowCell 
+              index={(workflow.steps?.length || 1)}
+              step={{name: 'save', syntax: 'qri', category: 'save', script: ''}}
+              collapseState={collapseState('save')}
               onChangeCollapse={(v) => {
                 const update = Object.assign({}, collapseStates as any)
-                update[step.name] = v
+                update['save'] = v
                 setCollapseStates(update)
               }}
-              onChangeScript={(i:number, script:string) => {
-                if (workflow && workflow.steps) {
-                  dispatch(changeWorkflowTransformStep(i, script))
-                }
-              }}
-            />)
-          })}
-          {/* TODO(b5) - hack for now. In the future we should make a component that trances & selects save results */}
-          {runMode === 'save' && <WorkflowCell 
-            index={(workflow.steps?.length || 1)}
-            step={{name: 'save', syntax: 'qri', category: 'save', script: ''}}
-            collapseState={collapseState('save')}
-            onChangeCollapse={(v) => {
-              const update = Object.assign({}, collapseStates as any)
-              update['save'] = v
-              setCollapseStates(update)
-            }}
-            onChangeScript={() => {}}
-            />}
+              onChangeScript={() => {}}
+              />}
+          </div>
+        </section>
+        <OnComplete />
+        <div className="mb-20">
+          {workflow && <DeployButtonWithStatusDescription workflow={workflow} />}
         </div>
-      </section>
-      <OnComplete />
+      </div>
     </Scroller>
   )
 }

--- a/frontend/src/features/workflow/WorkflowOutline.tsx
+++ b/frontend/src/features/workflow/WorkflowOutline.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import Icon from '../../chrome/Icon'
 import { TransformStep } from '../../qri/dataset'
@@ -6,10 +6,8 @@ import { NewRunStep, Run } from '../../qri/run'
 import { Workflow } from '../../qrimatic/workflow'
 import ScrollTrigger from '../scroller/ScrollTrigger'
 import RunStatusIcon from '../run/RunStatusIcon'
-import DeployButtonWithStatusDescription from '../deploy/DeployStatusDescriptionButton'
 import SnackBar from '../snackBar/SnackBar'
 import { RunMode } from './state/workflowState'
-import SimpleActivityList from '../activityFeed/SimpleActivityList'
 
 export interface WorkflowOutlineProps {
   runMode: RunMode
@@ -21,9 +19,20 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
   runMode,
   workflow,
   run
-}) => (
-  <div className='outline h-full w-56 flex-none flex flex-col'>
+}) => {
+  const [showing, setShowing] = useState(true)
+
+  if (!showing) {
+    return (
+      <div className='outline h-full w-10 flex-none flex flex-col py-4 pl-4'>
+        <div className='opacity-20 cursor-pointer' onClick={() => { setShowing(!showing) }} ><Icon icon='arrowRight' /></div>
+      </div>
+    ) 
+  }
+
+  return (<div className='outline h-full w-56 flex-none flex flex-col'>
     <div className='py-4 pl-4 text-left'>
+      <div className='opacity-20 cursor-pointer mb-5' onClick={() => { setShowing(!showing) }} ><Icon icon='arrowLeft' /></div>
       <div className='mb-2'>
         <ScrollTrigger target='triggers'>
           <div className='font-semibold text-gray-900 mb-1 uppercase text-xs'>Triggers</div>
@@ -66,14 +75,8 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
         <Icon icon='cloudUpload' size='sm' className='mr-1'/> <span>push to cloud</span>
       </div>
     </div>
-    <hr />
-    <div>
-      {workflow && <DeployButtonWithStatusDescription workflow={workflow} />}
-    </div>
-    <hr />
-    <SimpleActivityList />
     <SnackBar />
-  </div>
-)
+  </div>)
+}
 
 export default WorkflowOutline

--- a/frontend/src/features/workflow/output/DatasetPreview.tsx
+++ b/frontend/src/features/workflow/output/DatasetPreview.tsx
@@ -36,13 +36,13 @@ export const DatasetPreview: React.FC<DatasetPreviewProps> = ({ data }) => {
   } else {
     const component = getComponentFromDatasetByName(data, componentTab) || `No content for ${componentTab} could be found` 
     content = <div className='p-4 border'>
-      <pre className='max-h-80 overflow-x-hidden overflow-y-auto '>
+      <pre className='max-h-80 overflow-x-hidden overflow-y-auto'>
         {typeof component === 'string'? component : JSON.stringify(component, null, 4)}
       </pre>
     </div>
   }
 
-  return <div id='dataset-preview' className='w-full bg-white'>
+  return <div id='dataset-preview' style={{ width: 1000 }}>
     <TabbedDisplay
       activeTab={componentTab}
       tabs={tabs}

--- a/frontend/src/features/workflow/output/LogLinePrint.tsx
+++ b/frontend/src/features/workflow/output/LogLinePrint.tsx
@@ -9,9 +9,9 @@ const LogLinePrint: React.FC<LogLineProps> = ({ line }) => {
   switch (line.type) {
     case EventLogLineType.ETPrint:
       // TODO (b5) - utilize line.data.lvl to set output colour
-     return <p className='text-gray-500'>{line.data.msg}</p>
+     return <p className='text-xs text-gray-500'>{line.data.msg}</p>
     case EventLogLineType.ETError:
-     return <p className='text-red-500'>{line.data.msg}</p>
+     return <p className='text-xs text-red-500'>{line.data.msg}</p>
     default:
       return <p>{line.data.msg}</p>
   }

--- a/frontend/src/features/workflow/output/Output.tsx
+++ b/frontend/src/features/workflow/output/Output.tsx
@@ -11,7 +11,7 @@ export interface OutputProps {
 
 const Output: React.FC<OutputProps> = ({ data }) => {
   return (
-  <div className='output text-sm font-mono p-2 rounded-sm overflow-auto'>
+  <div className='output text-sm font-mono p-2 rounded-sm overflow-x-hidden'>
     {data && data.map((line, i) => {
       switch (line.type) {
         case EventLogLineType.ETPrint:

--- a/frontend/src/features/workflow/output/SimpleTable.tsx
+++ b/frontend/src/features/workflow/output/SimpleTable.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 import { Structure } from '../../../qri/dataset'
 import { BodyDisplayProps } from './BodyDisplay'
@@ -24,21 +25,21 @@ export const SimpleTable: React.FC<BodyDisplayProps> = ({ structure, body }) => 
   }
 
   headers = [{"title":"", "type": ""}].concat(headers)
-  return <div className='overflow-auto max-h-100 border-t'>
-    <table className='table-auto border-collapse relative'>
+  return <div className='max-h-100 border-ts'>
+    <table className='table-auto border-collapse relative text-left bg-white'>
       <thead>
         <tr>
           {headers.map((header: Header, i: number) => ( 
-            <th className='border-b border-l border-r text-left p-2 whitespace-nowrap sticky top-0 bg-white shadow' key={i}>{header.title}</th>
+            <th className='border-b border-l border-r p-2 whitespace-nowrap sticky top-0 shadow text-xs' key={i}>{header.title}</th>
           ))}
         </tr>
       </thead>
-      <tbody>
+      <tbody className='text-xs border'>
         {body.map((row: any[], i: number) => (
-          <tr key={i}>
-            <td className='border text-center p-2'>{i+1}</td>
+          <tr key={i} className={classNames((i % 2 === 0) && 'bg-gray-100')}>
+            <td className='text-center px-2 py-1'>{i+1}</td>
             {row.map((el: any, j: number) => (
-              <td className='border text-left p-2 whitespace-nowrap' key={j}>{el}</td>
+              <td className='px-2 py-1 whitespace-nowrap' key={j}>{el}</td>
             ))}
           </tr>
         ))}

--- a/frontend/src/features/workflow/output/TabbedDisplay.tsx
+++ b/frontend/src/features/workflow/output/TabbedDisplay.tsx
@@ -20,8 +20,8 @@ export const TabbedDisplay: React.FC<TabbedDisplayProps> = (props) => {
     content
   } = props
 
-  return <div className='w-full'>
-    <div className='w-full border-b flex'>
+  return <div>
+    <div className='border-b flex'>
       {
         tabs.map((tab: Tab) => {
           if (tab.name === activeTab) {
@@ -42,7 +42,9 @@ export const TabbedDisplay: React.FC<TabbedDisplayProps> = (props) => {
         })
       }
     </div>
-    {content}
+    <div className='overflow-x-auto'>
+      {content}
+    </div>
 
   </div>
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -53,7 +53,7 @@ export default function Routes () {
 
         <Route path='/'>
           {
-            user !== NewUser ? <Redirect to='/dashboard' /> : <Splash />
+            user !== NewUser ? <Redirect to='/collection' /> : <Splash />
           }
         </Route>
       </Switch>


### PR DESCRIPTION

<img width="1467" alt="Screen Shot 2021-03-16 at 8 32 10 AM" src="https://user-images.githubusercontent.com/1154390/111309971-e1d12900-8632-11eb-85fe-02fe3f031b45.png">

* redirect to collection instead of dashboard
* strip a number of elements away from workflow editor
* switch workflow editor to fixed-width
* add a "collapse" button for outline view
* move deploy workflow component down blow completion hooks