### PR TITLE
feat(frontend): clicking a commit in dataset components displays that commit

### DIFF
--- a/frontend/src/features/commits/DatasetCommitItem.tsx
+++ b/frontend/src/features/commits/DatasetCommitItem.tsx
@@ -1,26 +1,32 @@
 import React from 'react'
-import RelativeTimestamp from '../../chrome/RelativeTimestamp';
+import { Link } from 'react-router-dom';
+import classNames from 'classnames';
 
 import { LogItem } from '../../qri/log';
+import { newQriRef } from '../../qri/ref';
+import { pathToDatasetViewer } from '../dataset/state/datasetPaths';
 import ComponentChangeIndicatorGroup from './ComponentChangeIndicatorGroup';
+import RelativeTimestamp from '../../chrome/RelativeTimestamp';
 
 export interface DatasetCommitItemProps {
   logItem: LogItem
+  active?: boolean
 }
 
 const DatasetCommitItem: React.FC<DatasetCommitItemProps> = ({
   logItem,
+  active = false
 }) => (
-  <li className='relative block pl-4 mt-7 mb-6'>
+  <li className='relative block pl-4 mt-5 mb-6'>
     <div className='absolute top-0 -left-1.5 h-full'>
       <div className='w-3 h-3 rounded-3xl bg-gray-300'>&nbsp;</div>
       <div className='w-0.5 ml-1 mt-2 h-full bg-gray-300'>&nbsp;</div>
     </div>
-    <div>
+    <Link className={classNames('block rounded-md p-2', active && 'bg-white')} to={pathToDatasetViewer(newQriRef(logItem))}>
       <RelativeTimestamp className='font-bold' timestamp={new Date(logItem.timestamp)} />
       <p className='truncate overflow-ellipsis'>{logItem.title || ' '}</p>
       <ComponentChangeIndicatorGroup status={[2,1,2,3,4,0]} />
-    </div>
+    </Link>
   </li>
 )
 

--- a/frontend/src/features/commits/DatasetCommits.tsx
+++ b/frontend/src/features/commits/DatasetCommits.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
 import { SyncLoader } from 'react-spinners';
 
 import Icon from '../../chrome/Icon';
@@ -18,6 +19,8 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
   const dispatch = useDispatch()
   const commits = useSelector(newDatasetCommitsSelector(qriRef))
   const loading = useSelector(selectDatasetCommitsLoading)
+  const { fs, hash } = useParams()
+  const path = `/${fs}/${hash}`
 
   useEffect(() => {
     dispatch(loadDatasetCommits(qriRef))
@@ -30,7 +33,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
         <h3 className='text-lg font-bold'>History</h3>
       </header>
       <ul className='block flex-grow overflow-y-auto pl-4 pr-2 pb-40'>
-        {commits.map((logItem, i) => <DatasetCommitItem key={i} logItem={logItem} />)}
+        {commits.map((logItem, i) => <DatasetCommitItem key={i} logItem={logItem} active={logItem.path === path} />)}
       </ul>
       {loading && <SyncLoader color='#fff' size={6} />}
     </div>

--- a/frontend/src/features/dataset/DatasetNavSidebar.tsx
+++ b/frontend/src/features/dataset/DatasetNavSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { QriRef } from '../../qri/ref'
-import SideNavItem from './SideNavItem'
+import DatasetSideNavItem from './DatasetSideNavItem'
 import TooltipContent from '../../chrome/TooltipContent'
 import {
   pathToWorkflowEditor,
@@ -22,7 +22,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
         <path d="M4.19108e-05 180V0H180C72 0 3.05176e-05 86 4.19108e-05 180Z" fill="white"/>
       </svg>
     </div>
-    <SideNavItem
+    <DatasetSideNavItem
       id='preview'
       icon='eye'
       to={pathToDatasetPreview(qriRef)}
@@ -33,7 +33,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
         />
       }
     />
-    <SideNavItem
+    <DatasetSideNavItem
       id='components'
       icon='table'
       to={pathToDatasetViewer(qriRef)}
@@ -44,7 +44,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
         />
       }
     />
-    <SideNavItem
+    <DatasetSideNavItem
       id='workflow-editor'
       icon='code'
       to={pathToWorkflowEditor(qriRef.username, qriRef.name)}
@@ -55,7 +55,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
         />
       }
     />
-    <SideNavItem
+    <DatasetSideNavItem
       id='activity-feed'
       icon='clock'
       to={pathToActivityFeed(qriRef.username, qriRef.name)}
@@ -67,7 +67,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => (
       }
     />
     {process.env.REACT_APP_FEATURE_WIREFRAMES &&
-      <SideNavItem
+      <DatasetSideNavItem
         id='issues'
         icon='exclamationTriangle'
         to={pathToDatasetIssues(qriRef)}

--- a/frontend/src/features/dataset/DatasetPage.tsx
+++ b/frontend/src/features/dataset/DatasetPage.tsx
@@ -1,39 +1,32 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { Redirect, Route, Switch, useRouteMatch } from 'react-router';
 import { useParams } from 'react-router-dom';
 
-import { newQriRef } from '../../qri/ref';
-import Workflow from '../workflow/Workflow';
-import DatasetComponents from '../dsComponents/DatasetComponents';
-import { loadDataset } from './state/datasetActions'
 import NavBar from '../navbar/NavBar';
+import { newQriRef } from '../../qri/ref';
+import { loadDataset } from './state/datasetActions'
 import DatasetNavSidebar from './DatasetNavSidebar';
-import DeployingScreen from '../deploy/DeployingScreen';
-import DatasetActivityFeed from '../activityFeed/DatasetActivityFeed';
 import { selectSessionUser } from '../session/state/sessionState';
 import { selectSessionUserCanEditDataset } from './state/datasetState';
 import DatasetHeader from './DatasetHeader';
-import DatasetPreview from '../dsPreview/DatasetPreview';
-import DatasetIssues from '../issues/DatasetIssues';
+import DeployingScreen from '../deploy/DeployingScreen'
 
-export interface DatasetProps {
-  isNew?: boolean
-}
 
-const Dataset: React.FC<DatasetProps> = ({ isNew = false }) => {
+const DatasetPage: React.FC<{}> = ({ 
+  children
+}) => {
   const qriRef = newQriRef(useParams())
   const user = useSelector(selectSessionUser)
   const editable = useSelector(selectSessionUserCanEditDataset)
   const dispatch = useDispatch()
-  const { url } = useRouteMatch()
+  const isNew = (qriRef.username === 'new')
 
   // This covers the case where a user created a new workflow before logging in.
   // If they login while working on the workflow, the `user` will change, but the
   // params used to generate the `qriRef` will not (because they are generated
   // from the url, which has not changed). This check ensures that the correct 
   // username is propagated after login/signup.
-  if (qriRef.username === 'new') {
+  if (isNew) {
     qriRef.username = user.username
   }
 
@@ -50,16 +43,7 @@ const Dataset: React.FC<DatasetProps> = ({ isNew = false }) => {
         <DatasetNavSidebar qriRef={qriRef} />
         <div className='flex flex-col flex-grow'>
           <DatasetHeader qriRef={qriRef} editable={editable} />
-          <Switch>
-            <Route path='/ds/:username/:name/workflow'><Workflow qriRef={qriRef} /></Route>
-            <Route path='/ds/:username/:name/components/:component'><DatasetComponents /></Route>
-            <Route path='/ds/:username/:name/components'><Redirect to={`${url}/components/body`} /></Route>
-            <Route path='/ds/:username/:name/history'><DatasetActivityFeed qriRef={qriRef} /></Route>
-            <Route path='/ds/:username/:name/preview' exact><DatasetPreview /></Route>
-            {process.env.REACT_APP_FEATURE_WIREFRAMES && <Route path='/ds/:username/:name/issues'><DatasetIssues qriRef={qriRef} /></Route>}
-
-            <Route path='/ds/:username/:name' exact><Redirect to={`${url}/preview`} /></Route>
-          </Switch>
+          {children}
         </div>
         <DeployingScreen qriRef={qriRef} />
       </div>
@@ -67,4 +51,4 @@ const Dataset: React.FC<DatasetProps> = ({ isNew = false }) => {
   )
 }
 
-export default Dataset;
+export default DatasetPage

--- a/frontend/src/features/dataset/DatasetRoutes.tsx
+++ b/frontend/src/features/dataset/DatasetRoutes.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router';
+
+import Workflow from '../workflow/Workflow';
+import DatasetComponents from '../dsComponents/DatasetComponents';
+import DatasetActivityFeed from '../activityFeed/DatasetActivityFeed';
+import DatasetPreview from '../dsPreview/DatasetPreview';
+import DatasetIssues from '../issues/DatasetIssues';
+import DatasetPage from './DatasetPage';
+import { newQriRef } from '../../qri/ref';
+
+const DatasetRoutes: React.FC<{}> = () => {
+  const { url } = useRouteMatch()
+  // TODO(b5): this qriRef is missing all params after /:username/:name b/c
+  // params are dictated by the route that loaded this component.
+  // This ref can only be used to load HEAD because DatasetRoutes defines
+  // params like :fs and :hash, which are used to construct a commit-specific
+  // ref. Move all ref constructino into container components to avoid potential
+  // bugs
+  const qriRef = newQriRef(useParams())
+
+  return (
+    <Switch>
+      <Route path='/ds/:username/:name' exact>
+        <Redirect to={`${url}/preview`} />
+      </Route>
+
+      <Route path='/ds/:username/:name/workflow'>
+        <DatasetPage>
+          <Workflow qriRef={qriRef} />
+        </DatasetPage>
+      </Route>
+      <Route path='/ds/:username/:name/history'>
+        <DatasetPage>
+          <DatasetActivityFeed qriRef={qriRef} />
+        </DatasetPage>
+      </Route>
+      <Route path='/ds/:username/:name/preview' exact>
+        <DatasetPage>
+          <DatasetPreview />
+        </DatasetPage>
+      </Route>
+      {process.env.REACT_APP_FEATURE_WIREFRAMES && 
+        <Route path='/ds/:username/:name/issues'>
+          <DatasetPage>
+            <DatasetIssues qriRef={qriRef} />
+          </DatasetPage>
+        </Route>
+      }
+      
+      <Route path='/ds/:username/:name/at/:fs/:hash/components'>
+        <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/at/${qriRef.path}/body`} />
+      </Route>
+      <Route path='/ds/:username/:name/at/:fs/:hash/:component'>
+        <DatasetPage>
+          <DatasetComponents />
+        </DatasetPage>
+      </Route>
+      <Route path='/ds/:username/:name/components'>
+        <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/body`} />
+      </Route>
+      <Route path='/ds/:username/:name/:component'>
+        <DatasetPage>
+          <DatasetComponents />
+        </DatasetPage>
+      </Route>
+    </Switch>
+  )
+}
+
+export default DatasetRoutes;

--- a/frontend/src/features/dataset/DatasetSideNavItem.tsx
+++ b/frontend/src/features/dataset/DatasetSideNavItem.tsx
@@ -4,14 +4,14 @@ import ReactTooltip from 'react-tooltip'
 
 import Icon from '../../chrome/Icon';
 
-export interface SideNavItemProps {
+export interface DatasetSideNavItemProps {
   id: string
   icon: string
   to: string
   tooltip?: React.ReactNode
 }
 
-const SideNavItem: React.FC<SideNavItemProps> = ({ id, icon, to, tooltip }) => {
+const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({ id, icon, to, tooltip }) => {
   const { pathname } = useLocation();
   const active = pathname.includes(to)
   return (
@@ -39,4 +39,4 @@ const SideNavItem: React.FC<SideNavItemProps> = ({ id, icon, to, tooltip }) => {
   )
 }
 
-export default SideNavItem
+export default DatasetSideNavItem

--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -21,6 +21,7 @@ export function loadDataset(ref: QriRef): ApiActionThunk {
 }
 
 function fetchDataset (ref: QriRef): ApiAction {
+  console.log(`fetch dataset`, ref)
   return {
     type: 'dataset',
     ref,
@@ -29,7 +30,8 @@ function fetchDataset (ref: QriRef): ApiAction {
       method: 'GET',
       segments: {
         peername: ref.username,
-        name: ref.name
+        name: ref.name,
+        path: ref.path,
       },
       map: mapDataset
     }
@@ -56,6 +58,7 @@ function fetchBody (ref: QriRef, page: number, pageSize: number): ApiAction {
       segments: {
         peername: ref.username,
         name: ref.name,
+        path: ref.path,
         selector: 'body'
       },
       map: mapBody
@@ -72,7 +75,8 @@ export function removeDataset (ref: QriRef): ApiActionThunk {
         method: 'DELETE',
         segments: {
           peername: ref.username,
-          name: ref.name
+          name: ref.name,
+          path: ref.path
         }
       }
     }

--- a/frontend/src/features/dataset/state/datasetPaths.ts
+++ b/frontend/src/features/dataset/state/datasetPaths.ts
@@ -9,9 +9,13 @@ export function pathToDatasetPreview(ref: QriRef): string {
 }
 
 export function pathToDatasetViewer(ref: QriRef): string {
-  return ref.component
-    ? `/ds/${ref.username}/${ref.name}/components/${ref.component}`
-    : `/ds/${ref.username}/${ref.name}/components`
+  let path = `/ds/${ref.username}/${ref.name}`
+  if (ref.path) {
+    path += `/at${ref.path}`
+  }
+  path += ref.component || "/body"
+
+  return path
 }
 
 export function pathToWorkflowEditor(username: string, name: string): string {

--- a/frontend/src/features/dsComponents/DatasetComponents.tsx
+++ b/frontend/src/features/dsComponents/DatasetComponents.tsx
@@ -19,7 +19,7 @@ const DatasetComponents: React.FC<{}> = () => {
   const loading = useSelector(selectIsDatasetLoading)
 
   const setSelectedComponent = (component: ComponentName) => {
-    const dest = newQriRef(Object.assign({}, qriRef, { component }))
+    const dest = newQriRef(Object.assign({}, qriRef, { component : `/${component}` }))
     dispatch(push(pathToDatasetViewer(dest)))
   }
 

--- a/frontend/src/qri/ref.ts
+++ b/frontend/src/qri/ref.ts
@@ -53,11 +53,16 @@ export interface QriRef {
 }
 
 export function newQriRef(d: Record<string,any>): QriRef {
+  let path = d.path
+  if (!path && d.fs && d.hash) {
+    path = `/${d.fs}/${d.hash}`
+  }
+
   return {
     username: d.username || d.peername,
     profileId: d.profileId,
     name: d.name,
-    path: d.path,
+    path,
     component: d.component,
     selector: d.selector,
   }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -14,7 +14,7 @@ import ForgotPassword from './features/session/ForgotPassword';
 import Run from './features/run/Run';
 import Collection from './features/collection/Collection';
 import Dashboard from './features/dashboard/Dashboard';
-import Dataset from './features/dataset/Dataset';
+import DatasetRoutes from './features/dataset/DatasetRoutes';
 import { AnonUser, selectSessionUser } from './features/session/state/sessionState'
 
 const PrivateRoute: React.FC<any>  = ({ path, children }) => {
@@ -41,9 +41,8 @@ export default function Routes () {
         <PrivateRoute path='/collection'><Collection /></PrivateRoute>
         <PrivateRoute path='/activity'><CollectionActivityFeed /></PrivateRoute>
 
-        <Route path='/ds/new/:name'><Dataset /></Route>
         <Route path='/ds/new'><TemplateList /></Route>
-        <Route path='/ds/:username/:name'><Dataset /></Route>
+        <Route path='/ds/:username/:name'><DatasetRoutes /></Route>
 
         <Route path='/run'><Run /></Route>
         <Route path='/changes'><ChangeReport /></Route>


### PR DESCRIPTION
Re-work Dataset routes to support URLS to specific commits & fix a bug inthe process:

`react-router.useParams()` will only yeild the route params for the route the current component is loaded within. Because of this we can't dispatch `loadDataset` until we're in a component that has *all* route parameters, including things like `/:fs` and `/:hash`.