### PR TITLE
feat(frontend): websocket connection healing

### DIFF
--- a/frontend/src/chrome/StatusDot.tsx
+++ b/frontend/src/chrome/StatusDot.tsx
@@ -10,11 +10,10 @@ export interface StatusDotProps {
   showNoChanges?: boolean
 }
 
-export const StatusDot: React.FunctionComponent<StatusDotProps> = (props) => {
-  const {
-    status,
-    showNoChanges = false
-  } = props
+export const StatusDot: React.FC<StatusDotProps> = ({
+  status,
+  showNoChanges = false
+}) => {
   let statusTooltip
   let statusColor = ''
   switch (status) {

--- a/frontend/src/features/app/App.tsx
+++ b/frontend/src/features/app/App.tsx
@@ -5,9 +5,10 @@ import { useDispatch } from 'react-redux';
 import { history } from '../../store/store'
 import Routes from '../../routes'
 import Modal from './modal/Modal'
-import { wsConnect } from '../websocket/middleware/websocket'
+import { wsConnect } from '../websocket/state/websocketActions';
 
 import './App.css';
+import SnackBar from '../snackBar/SnackBar';
 
 const App: React.FC<any> = () => {
   const dispatch = useDispatch()
@@ -21,6 +22,7 @@ const App: React.FC<any> = () => {
       <ConnectedRouter history={history}>
         <Modal />
         <Routes />
+        <SnackBar />
       </ConnectedRouter>
     </div>
   );

--- a/frontend/src/features/snackBar/SnackBar.tsx
+++ b/frontend/src/features/snackBar/SnackBar.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
+import ConnectionStatus from '../websocket/ConnectionStatus'
 
 // import SnackBarMessage from './SnackBarMessage'
 
 const SnackBar: React.FC<{}> = () => {
   // TODO(b5): build a reducer the snack bar, use it to show messages here
   // TODO(b5): actions for dismissing snack bar messages
-  return (<div className="py-4 pl-4"></div>)
+  return (<div className="absolute bottom-0 right-0 py-4 pl-4">
+    <ConnectionStatus />
+  </div>)
 }
 
 export default SnackBar

--- a/frontend/src/features/websocket/ConnectionStatus.tsx
+++ b/frontend/src/features/websocket/ConnectionStatus.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import StatusDot from '../../chrome/StatusDot'
+import { ComponentStatus } from '../../qri/dataset'
+import { selectWebsocketState, WSConnectionStatus } from './state/websocketState'
+
+const ConnectionStatus: React.FC<{}> = () => {
+  const state = useSelector(selectWebsocketState)
+
+  if (state.status === WSConnectionStatus.connected) {
+    return null
+  }
+
+  return (
+    <div className='flex'>
+      <div className='mt-1'>
+        <StatusDot showNoChanges status={componentStatusFromWSConnectionStatus(state.status)} />
+      </div>
+      <div className='ml-2'>
+        {(() => {
+          switch (state.status) {
+            case WSConnectionStatus.disconnected:
+              return "Disconnected"
+            // case WSConnectionStatus.connected:
+            //   return "Connected"
+            case WSConnectionStatus.connecting:
+              return "Connecting"
+            case WSConnectionStatus.interrupted:
+              return "Reconnecting..."
+            default: 
+              return null
+          }
+        })()}
+      </div>
+    </div>
+  )
+}
+
+export default ConnectionStatus
+
+function componentStatusFromWSConnectionStatus(s: WSConnectionStatus): ComponentStatus {
+  switch (s) {
+    case WSConnectionStatus.disconnected:
+      return 'removed'
+    case WSConnectionStatus.connected:
+      return 'added'
+    case WSConnectionStatus.connecting:
+      return 'modified'
+    case WSConnectionStatus.interrupted:
+      return 'removed'
+    default:
+      return 'unmodified'
+  }
+}

--- a/frontend/src/features/websocket/state/websocketActions.ts
+++ b/frontend/src/features/websocket/state/websocketActions.ts
@@ -1,0 +1,31 @@
+import { Action } from "redux";
+import {
+  WS_CONNECT,
+  WS_DISCONNECT,
+  WS_CONNECTION_CHANGE,
+  WebsocketState,
+} from './websocketState'
+
+// tell websocket to connect
+export function wsConnect(): Action {
+  return { type: WS_CONNECT }
+}
+
+// tell websocket to disconnect
+export function wsDisconnect(): Action {
+  return { type: WS_DISCONNECT }
+}
+
+// WebsocketAction broadcasts connection state changes. connection state is 
+// owned by websocket middlware
+export interface WebsocketAction extends Action {
+  wsState: WebsocketState
+}
+
+// wsConnectionChange actions must only be dispatched by websocket middleware
+export function wsConnectionChange(wsState: WebsocketState): WebsocketAction {
+  return {
+    type: WS_CONNECTION_CHANGE,
+    wsState,
+  }
+}

--- a/frontend/src/features/websocket/state/websocketState.ts
+++ b/frontend/src/features/websocket/state/websocketState.ts
@@ -1,0 +1,44 @@
+import { createReducer } from '@reduxjs/toolkit'
+
+import { RootState } from '../../../store/store';
+import { WebsocketAction } from './websocketActions';
+
+export const WS_CONNECT = 'WS_CONNECT'
+export const WS_DISCONNECT = 'WS_DISCONNECT'
+export const WS_CONNECTION_CHANGE = 'WS_CONNECTION_CHANGE'
+
+export const selectWebsocketState = (state: RootState): WebsocketState => state.websocket
+
+export enum WSConnectionStatus {
+  disconnected, // no connection
+  connecting,   // constructing connection
+  connected,    // OK
+  interrupted,  // disconnected, but want a connection
+}
+
+export interface WebsocketState {
+  status: WSConnectionStatus,
+  reconnectTime?: Date, // when disconnected, the time to wait until reconnecting
+  reconnectAttemptsRemaining?: number
+}
+
+export function NewWebsocketState(status: WSConnectionStatus, reconnectAttemptsRemaining?: number, reconnectTime?: Date): WebsocketState {
+  return {
+    status,
+    reconnectTime,
+    reconnectAttemptsRemaining: reconnectAttemptsRemaining || 0
+  }
+}
+
+const initialState: WebsocketState = {
+  status: WSConnectionStatus.disconnected,
+  reconnectAttemptsRemaining: 0
+}
+
+export const websocketReducer = createReducer(initialState, {
+  WS_CONNECTION_CHANGE: (state: WebsocketState, action: WebsocketAction) => {
+    state.status = action.wsState.status
+    state.reconnectTime = action.wsState.reconnectTime
+    state.reconnectAttemptsRemaining = action.wsState.reconnectAttemptsRemaining
+  }
+})

--- a/frontend/src/qri/events.ts
+++ b/frontend/src/qri/events.ts
@@ -1,0 +1,47 @@
+
+// ETCreatedNewFile is the event for creating a new file
+export const ETCreatedNewFile = "watchfs:CreatedNewFile"
+// ETModifiedFile is the event for modifying a file
+export const ETModifiedFile = "watchfs:ModifiedFile"
+// ETDeletedFile is the event for deleting a file
+export const ETDeletedFile = "watchfs:DeletedFile"
+// ETRemoteClientPushVersionProgress indicates a change in progress of a
+// dataset version push. Progress can fire as much as once-per-block.
+// subscriptions do not block the publisher
+// payload will be a RemoteEvent
+export const ETRemoteClientPushVersionProgress = "remoteClient:PushVersionProgress"
+// ETRemoteClientPushVersionCompleted indicates a version successfully pushed
+// to a remote.
+// payload will be a RemoteEvent
+export const ETRemoteClientPushVersionCompleted = "remoteClient:PushVersionCompleted"
+// ETRemoteClientPushDatasetCompleted indicates pushing a dataset
+// (logbook + versions) completed
+// payload will be a RemoteEvent
+export const ETRemoteClientPushDatasetCompleted = "remoteClient:PushDatasetCompleted"
+// ETRemoteClientPullVersionProgress indicates a change in progress of a
+// dataset version pull. Progress can fire as much as once-per-block.
+// subscriptions do not block the publisher
+// payload will be a RemoteEvent
+export const ETRemoteClientPullVersionProgress = "remoteClient:PullVersionProgress"
+// ETRemoteClientPullVersionCompleted indicates a version successfully pulled
+// from a remote.
+// payload will be a RemoteEvent
+export const ETRemoteClientPullVersionCompleted = "remoteClient:PullVersionCompleted"
+// ETRemoteClientPullDatasetCompleted indicates pulling a dataset
+// (logbook + versions) completed
+// payload will be a RemoteEvent
+export const ETRemoteClientPullDatasetCompleted = "remoteClient:PullDatasetCompleted"
+// ETRemoteClientRemoveDatasetCompleted indicates removing a dataset
+// (logbook + versions) remove completed
+// payload will be a RemoteEvent
+export const ETRemoteClientRemoveDatasetCompleted = "remoteClient:RemoveDatasetCompleted"
+
+// ETWorkflowStarted fires when a workflow has started running
+// payload is a Workflow
+export const ETWorkflowStarted = "wf:Started"
+// ETWorkflowCompleted fires when a workflow has finished running
+// payload is a Workflow
+export const ETWorkflowCompleted = "wf:Completed"
+
+export const ETWorklowDeployStarted = "wf:DeployStarted"
+export const ETWorklowDeployStopped = "wf:DeployStopped"

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -17,6 +17,7 @@ import { activityFeedReducer, ActivityFeedState } from '../features/activityFeed
 import { sessionReducer, SessionState } from '../features/session/state/sessionState';
 import { commitsReducer, CommitsState } from '../features/commits/state/commitState';
 import { datasetEditsReducer, DatasetEditsState } from '../features/dataset/state/editDatasetState';
+import { WebsocketState, websocketReducer } from '../features/websocket/state/websocketState';
 
 export const history = createBrowserHistory()
 
@@ -33,6 +34,7 @@ export interface RootState {
   transfers: RemoteEvents
   workflow: WorkflowState
   edits: DatasetEditsState
+  websocket: WebsocketState
 }
 
 const rootReducer = (h: History) => combineReducers({
@@ -51,6 +53,7 @@ const rootReducer = (h: History) => combineReducers({
   transfers: transfersReducer,
   workflow: workflowReducer,
   edits: datasetEditsReducer,
+  websocket: websocketReducer
 })
 
 export function configureStore(preloadedState?: any) {


### PR DESCRIPTION
I ended up re-writing this four times, each with a slightly different apprach.

The first factoring had all websocket state in the app reducer. Having an "app" reducer very similar to global state, and made it tempting to call the connection a "backend connection" instead of a "websocket connection".

On the second factoring I moved all websocket-related code into the websocket feature folder, and wrote a set of actions that used a "data" payload to manipulate state in a reducer. All actions were of type "WS_CONNECTION_CHANGE", and the change info was part of the data. I wasn't a fan of having the actions themselves dictate business logic like the number of retries to attempt, etc.

Third factoring moved all of this logic into the reducer, and thinned the actions to just a set of event constants without any payload ("WS_CONNECTED", "WS_CONNECT_FAIL", etc), and the reducer owned how to update state according
to each action type. My plan was to have the websocket middleware fire these actions, and keep state management in the reducer. But, the way redux middlware integrates with reducers makes it difficult/impossible to fire actions & listen for those actions within the same middlware (which, in hindsight, makes sense), which meant the websocket middlware couldn't make use of state changes in the websocket reducer.

So on the fourth go-round I ended up making the websocket middlware the owner of websocket connection state, and used the approach from the second factoring to store a copy of that state in the reducer. In this arrangement redux handles a reducer that UI can listen to, and middlware doesn't have the additional burden of state coordination with an external reducer.