### PR TITLE
feat: style SessionUserMenu

### DIFF
--- a/frontend/src/chrome/ButtonGroup.tsx
+++ b/frontend/src/chrome/ButtonGroup.tsx
@@ -23,7 +23,7 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({
     {items.map(({ text, icon, link }, i) => {
       const selected = selectedIndex === i
       return (
-        <Link className={classNames('my-2 mx-4 font-medium text-qrinavy', {
+        <Link className={classNames('my-2 mx-4 font-medium text-qrinavy transition-100 transition-all hover:text-qripink', {
           'text-qripink': selected
         })} key={i} to={link}>
           <div className='flex items-center'>

--- a/frontend/src/chrome/DropdownMenu.tsx
+++ b/frontend/src/chrome/DropdownMenu.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom'
-import ExternalLink from './ExternalLink'
+import classNames from 'classnames'
 
+import ExternalLink from './ExternalLink'
 import Icon from './Icon'
 
 export interface DropDownMenuItem {
@@ -19,10 +20,16 @@ export interface DropDownMenuItem {
 interface DropdownMenuProps {
   items: DropDownMenuItem[]
   alignLeft?: boolean
+  className?: string
 }
 
 // itemProps will be passed into the onClick handler for each item in the dropdown
-const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, items, alignLeft=false }) => {
+const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  children,
+  items,
+  alignLeft=false,
+  className=''
+}) => {
   const ref = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
 
@@ -41,8 +48,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, items, alignLeft=
   }, [handleClickOutside])
 
   return (
-    <div ref={ref} className='relative inline-block text-left'>
-      <div onClick={() => { setOpen(!open) }} className='cursor-pointer'>
+    <div ref={ref} className={classNames('relative inline-block text-left', className)}>
+      <div onClick={() => { setOpen(!open) }} className='cursor-pointer flex items-center'>
         {children}
       </div>
       {open && (

--- a/frontend/src/chrome/QriLogo.tsx
+++ b/frontend/src/chrome/QriLogo.tsx
@@ -5,7 +5,7 @@ interface QriLogoProps {
   size?: 'sm' | 'md'
 }
 
-const QriLogo: React.FC<QriLogoProps> = ({ size }) => (
+const QriLogo: React.FC<QriLogoProps> = ({ size='md' }) => (
   <div className={classNames('m-1', {
     'w-11 h-11': size === 'md',
     'w-9 h-9': size === 'sm',

--- a/frontend/src/features/dataset/DatasetNavSidebar.tsx
+++ b/frontend/src/features/dataset/DatasetNavSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import classNames from 'classnames'
 
 import { QriRef } from '../../qri/ref'
 import DatasetSideNavItem from './DatasetSideNavItem'
@@ -30,7 +31,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
 
   return (
     <div className={`side-nav pl-9 h-full bg-white relative pt-9 flex-shrink-0 ${expanded ? 'w-52' : 'w-24'}`}>
-      <div className='mb-9 flex align-center flex'>
+      <div className='mb-9 flex align-center items-center'>
         <div
           className='text-gray-400 text-sm font-medium mr-4 leading-6 transition-all duration-700'
           style={{
@@ -40,7 +41,13 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
         >
           DATASET MENU
         </div>
-        <div className='cursor-pointer flex items-center w-6' onClick={toggleExpanded}>
+        <div
+          className={classNames('cursor-pointer flex items-center w-6 transition duration-300 ease-in-out transform', {
+            'hover:-translate-x-1': expanded,
+            'hover:translate-x-1': !expanded,
+          })}
+          onClick={toggleExpanded}
+        >
           <Icon className='m-auto' icon={expanded ? 'caretLeft' : 'caretRight'} size='xs' />
         </div>
       </div>

--- a/frontend/src/features/dataset/DatasetSideNavItem.tsx
+++ b/frontend/src/features/dataset/DatasetSideNavItem.tsx
@@ -23,7 +23,7 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({ id, icon, label
         'text-qripink': active
       })}>
         <span data-tip data-for={id}>
-          <div className='flex'>
+          <div className='flex items-center'>
             <Icon className='mr-2' size='md' icon={icon} />
             <span style={{
               fontSize: '16px',

--- a/frontend/src/features/navbar/SessionUserMenu.tsx
+++ b/frontend/src/features/navbar/SessionUserMenu.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import Icon from '../../chrome/Icon'
 import DropdownMenu from '../../chrome/DropdownMenu'
 import { AnonUser, selectSessionUser } from '../session/state/sessionState'
 import { logOut } from '../session/state/sessionActions'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import Button from '../../chrome/Button'
+import ExternalLink from '../../chrome/ExternalLink'
+
+const navbarLinkClassNames = 'text-qriblue font-medium hover:text-qriblue-800 hover:cursor-pointer transition-all duration-100'
 
 const SessionUserMenu: React.FC<{}> = () => {
   const user = useSelector(selectSessionUser)
@@ -17,18 +19,17 @@ const SessionUserMenu: React.FC<{}> = () => {
     const handleLogInClick = () => {
       dispatch(showModal(ModalType.logIn))
     }
-  
+
     const handleSignUpClick = () => {
       dispatch(showModal(ModalType.signUp))
     }
 
     return (
       <>
-        <div
-          className='mr-4 hover:text-qriblue-200 hover:cursor-pointer transition-all duration-100'
+        <div className={navbarLinkClassNames}
           onClick={handleLogInClick}
         >Log In</div>
-        <Button onClick={handleSignUpClick}>
+        <Button onClick={handleSignUpClick} size='sm' className='ml-8'>
           Sign Up
         </Button>
       </>
@@ -37,8 +38,8 @@ const SessionUserMenu: React.FC<{}> = () => {
 
   const menuItems = [
     {
-      text: 'Documentation',
-      link: 'https://qri.io/docs'
+      text: 'Profile',
+      link: '/profile'
     },
     {
       text: 'Send Feedback',
@@ -51,11 +52,17 @@ const SessionUserMenu: React.FC<{}> = () => {
   ]
 
   return (
-    <div className="relative">
-      <DropdownMenu items={menuItems}>
-        <p className=' font-bold text-white relative flex items-baseline group hover:text'>
-          {user.username} <Icon icon='sortDown' className='ml-3'/>
-        </p>
+    <div className="relative flex items-center">
+      <ExternalLink
+        to='https://qri.io/docs'
+        className={navbarLinkClassNames}
+      >Help</ExternalLink>
+      <DropdownMenu items={menuItems} className='ml-8'>
+        <div className='rounded-2xl inline-block bg-cover flex-shrink-0' style={{
+          height: '30px',
+          width: '30px',
+          backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
+        }}></div>
       </DropdownMenu>
     </div>
   )


### PR DESCRIPTION
- styles the sign up and log in buttons for anonymous users
- styles the user menu icon for logged in users
- updates the user menu items
- changes navbar link styles
- adds a default size to `QriLogo` which was not displaying in the navbar due to a missing `size prop`
- adds hover styles to `ButtonGroup` (top my datasets and dashboard buttons)
- animates the caret that is used to expand the dataset nav

Closes #147 