### PR TITLE
Wire up Signup and Login

### DIFF
--- a/frontend/e2e/utils/specHelpers.ts
+++ b/frontend/e2e/utils/specHelpers.ts
@@ -4,7 +4,7 @@ import TestQrimaticBackend from './testQrimaticServe'
 import TestQrimaticFrontend from './testFrontendServe'
 
 const FRONTEND_URL_BASE = process.env.FRONTEND_URL_BASE || 'http://localhost:3000'
-const BACKEND_URL_BASE = process.env.BACKEND_URL_BASE || 'http://localhost:2503'
+const BACKEND_URL_BASE = process.env.BACKEND_URL_BASE || 'http://localhost:3002'
 
 const confirmServiceIsLive = async (url: string) => {
   let backoffMilliseconds = 1000

--- a/frontend/src/features/navbar/SessionUserMenu.tsx
+++ b/frontend/src/features/navbar/SessionUserMenu.tsx
@@ -61,7 +61,7 @@ const SessionUserMenu: React.FC<{}> = () => {
         <div className='rounded-2xl inline-block bg-cover flex-shrink-0' style={{
           height: '30px',
           width: '30px',
-          backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
+          backgroundImage: `url(${user.profile})`
         }}></div>
       </DropdownMenu>
     </div>

--- a/frontend/src/features/session/modal/LogInModal.tsx
+++ b/frontend/src/features/session/modal/LogInModal.tsx
@@ -32,7 +32,7 @@ const LogInModal: React.FC = () => {
     logIn(username, password)(dispatch)
       .then((action: AnyAction) => {
         if (getActionType(action) === ACTION_FAILURE) {
-          setLoginError(action.payload.err.message)
+          setLoginError(action.error)
           return
         }
         dispatch(clearModal())

--- a/frontend/src/features/session/modal/SignUpModal.tsx
+++ b/frontend/src/features/session/modal/SignUpModal.tsx
@@ -51,7 +51,7 @@ const SignUpModal: React.FC = () => {
       signUp(email, username, password)(dispatch)
         .then((action: AnyAction) => {
           if (getActionType(action) === ACTION_FAILURE) {
-            setSignupError(action.payload.err.message)
+            setSignupError(action.error)
             return
           }
           dispatch(clearModal())

--- a/frontend/src/features/session/state/sessionState.ts
+++ b/frontend/src/features/session/state/sessionState.ts
@@ -2,52 +2,85 @@ import { createReducer } from '@reduxjs/toolkit'
 import { RootState } from '../../../store/store';
 
 export const selectSessionUser = (state: RootState): User => state.session.user
+export const selectSessionToken = (state: RootState): string => state.session.token
 export const selectIsSessionLoading = (state: RootState): boolean => state.session.loading
 
 export interface User {
+  name?: string
+  profile?: string
   username: string
+  description?: string
 }
 
 export interface SessionState {
   user: User
   loading: boolean
+  token: string
 }
 
 export const AnonUser: User = {
   username: 'new'
 }
 
-const initialState: SessionState = {
-  user: AnonUser,
-  loading: false
+function getAuthState(): SessionState {
+  try {
+    const token = JSON.parse(localStorage.getItem('state.auth.token')) || '';
+    const user = JSON.parse(localStorage.getItem('state.auth.user')) || AnonUser;
+
+    return {
+      token,
+      user,
+      loading: false
+    }
+  } catch (err) {
+    return {
+      token: '',
+      user: AnonUser,
+      loading: false
+    };
+  }
+}
+
+
+const initialState: SessionState = getAuthState()
+
+// same state changes on successful login or signup
+const loginOrSignupSuccess = (state, action) => {
+  const {
+    name,
+    profile,
+    username,
+    description,
+  } = action.user
+
+  state.user = {
+    name,
+    profile,
+    username,
+    description,
+  }
+  state.loading = false
+
+  state.token = action.token
 }
 
 export const sessionReducer = createReducer(initialState, {
-  'API_LOGIN_REQUEST': (state, action) => {
+  'LOGIN_REQUEST': (state) => {
     state.loading = true
   },
-  'API_LOGIN_SUCCESS': (state, action) => {
-    state.user = {
-      username: action.payload.username
-    }
+  'LOGIN_SUCCESS': loginOrSignupSuccess,
+  'LOGIN_FAILURE': (state) => {
     state.loading = false
   },
-  'API_LOGIN_FAILURE': (state, action) => {
+  'SIGNUP_REQUEST': (state) => {
+    state.loading = true
+  },
+  'SIGNUP_FAILURE': (state) => {
     state.loading = false
   },
-  'API_LOGOUT_SUCCESS': (state, action) => {
+  'SIGNUP_SUCCESS': loginOrSignupSuccess,
+  'LOGOUT_SUCCESS': (state) => {
     state.user = AnonUser
-  },
-  'API_SIGNUP_REQUEST': (state, action) => {
-    state.loading = true
-  },
-  'API_SIGNUP_SUCCESS': (state, action) => {
-    state.user = {
-      username: action.payload.username
-    }
-    state.loading = false
-  },
-  'API_SIGNUP_FAILURE': (state, action) => {
-    state.loading = false
-  },
+    state.token = ''
+  }
 })

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -16,7 +16,7 @@ import { scrollerReducer, ScrollerState } from '../features/scroller/state/scrol
 import { searchReducer, SearchState } from '../features/search/state/searchState';
 import { deployReducer, DeployState } from '../features/deploy/state/deployState';
 import { activityFeedReducer, ActivityFeedState } from '../features/activityFeed/state/activityFeedState';
-import { sessionReducer, SessionState } from '../features/session/state/sessionState';
+import { sessionReducer, SessionState, AnonUser } from '../features/session/state/sessionState';
 import { commitsReducer, CommitsState } from '../features/commits/state/commitState';
 import { datasetEditsReducer, DatasetEditsState } from '../features/dataset/state/editDatasetState';
 import { WebsocketState, websocketReducer } from '../features/websocket/state/websocketState';
@@ -62,6 +62,23 @@ const rootReducer = (h: History) => combineReducers({
   websocket: websocketReducer
 })
 
+function setAuthState(state: any) {
+  try {
+    if (state.session.token) {
+      localStorage.setItem('state.auth.token', JSON.stringify((state.session || {}).token));
+    } else {
+      localStorage.removeItem('state.auth.token')
+    }
+
+
+    if (state.session.token && (state.session.token !== AnonUser)) {
+      localStorage.setItem('state.auth.user', JSON.stringify((state.session || {}).user));
+    } else {
+      localStorage.removeItem('state.auth.user')
+    }
+  } catch (err) { return undefined; }
+}
+
 export function configureStore(preloadedState?: any) {
   const composeEnhancer: typeof compose = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
   const store = createStore(
@@ -76,6 +93,11 @@ export function configureStore(preloadedState?: any) {
       ),
     ),
   )
+
+  // automatically sync store.session.token with localstorage
+  store.subscribe(() => {
+    setAuthState(store.getState())
+  });
 
   // // Hot reloading
   // if (module.hot) {


### PR DESCRIPTION
Merge #161 first.

- Wires up login and signup actions and reducers
- Uses `store.subscribe` to keep localstorage in sync with `store.session`, so user data and token persist
- Handles errors, shows the user an error in each respective modal.
- Does not handle token refresh, this will be implemented later