### PR TITLE
Previews, Navbar Search, readmes

### DIFF
--- a/frontend/src/features/commits/state/commitActions.ts
+++ b/frontend/src/features/commits/state/commitActions.ts
@@ -13,7 +13,6 @@ export function loadDatasetCommits(qriRef: QriRef): ApiActionThunk {
 }
 
 function fetchDatasetCommits(qriRef: QriRef): ApiAction {
-  console.log('loading dataset commits', qriRef.username, qriRef.name)
   return {
     type: 'dataset_commits',
     qriRef,

--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -6,7 +6,7 @@ import { RENAME_NEW_DATASET } from "./datasetState";
 export const bodyPageSizeDefault = 50
 
 export function mapDataset(d: object | []): Dataset {
-  return NewDataset((d as Record<string,any>).dataset)
+  return NewDataset((d as Record<string,any>))
 }
 
 export function mapBody (d: {data: Body}): Body {
@@ -25,7 +25,7 @@ function fetchDataset (ref: QriRef): ApiAction {
     type: 'dataset',
     ref,
     [CALL_API]: {
-      endpoint: 'get',
+      endpoint: 'dataset_summary',
       method: 'GET',
       segments: ref,
       map: mapDataset

--- a/frontend/src/features/dsComponents/body/Body.tsx
+++ b/frontend/src/features/dsComponents/body/Body.tsx
@@ -1,26 +1,26 @@
 import React, { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
 // import { Action } from 'redux'
 
+import Dataset,  { Structure, schemaToColumns, ColumnProperties } from '../../../qri/dataset'
+import BodyTable from './BodyTable'
+import BodyJson from './BodyJson'
+import { loadBody } from '../../dataset/state/datasetActions'
+import { newQriRef } from '../../../qri/ref'
 // import { ApiActionThunk } from '../../../store/api'
 // import { DetailsType, StatsDetails, Details } from '../../../models/details'
-import Dataset,  { Structure, schemaToColumns, ColumnProperties } from '../../../qri/dataset'
 // import { RouteProps } from '../../../models/store'
 // import { fetchBody, fetchCommitBody } from '../../../actions/api'
 // import { setDetailsBar } from '../../../actions/ui'
 // import { selectDataset, selectWorkingDataset, selectDatasetStats, selectWorkingStats, selectDetails, selectDatasetBodyPageInfo, selectWorkingDatasetBodyPageInfo, selectWorkingStatusInfo } from '../../../selections'
 // import { QriRef, qriRefFromRoute } from '../../../models/qriRef'
-
-import BodyTable from './BodyTable'
-import BodyJson from './BodyJson'
-import { useDispatch } from 'react-redux'
-import { loadBody } from '../../dataset/state/datasetActions'
-import { newQriRef } from '../../../qri/ref'
 // import ParseError from '../ParseError'
 // import hasParseError from '../../../utils/hasParseError'
 // import { connectComponentToProps } from '../../../utils/connectComponentToProps'
 
 export interface BodyProps {
   data: Dataset
+  preview?: boolean
   // stats: IStatTypes[]
   // details: Details
   // pageInfo: PageInfo
@@ -49,8 +49,9 @@ const extractColumnHeaders = (structure: Structure, value: any[]): ColumnPropert
   return schemaToColumns(schema)
 }
 
-const Body: React.FunctionComponent<BodyProps> = ({
+const Body: React.FC<BodyProps> = ({
   data,
+  preview = false
 }) => {
   const dispatch = useDispatch()
   const { body, structure } = data
@@ -58,8 +59,9 @@ const Body: React.FunctionComponent<BodyProps> = ({
 
   // list out dependencies on dataset body individually for proper memoization
   useEffect(() => {
+    if (preview) { return }
     dispatch(loadBody(newQriRef({ path, name, username }), 1, 100))
-  }, [dispatch, path, name, username])
+  }, [preview, dispatch, path, name, username])
 
   if (!body) {
     return (

--- a/frontend/src/features/dsComponents/readme/Readme.tsx
+++ b/frontend/src/features/dsComponents/readme/Readme.tsx
@@ -15,7 +15,7 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
 
   const refCallback = useCallback((el: HTMLDivElement) =>{
     if (el !== null) {
-      fetch(`${API_BASE_URL}/render/${qriRefStr}`)
+      fetch(`${API_BASE_URL}/dataset_summary/readme?path=${qriRef.path}`)
         .then(async (res) => {
           return res.text()
         })

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import React, { useState, useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 import useDimensions from 'react-use-dimensions'
 
-import { selectDataset, selectIsDatasetLoading } from '../dataset/state/datasetState'
+import { newQriRef } from '../../qri/ref';
+import { selectDsPreview, selectIsDsPreviewLoading } from './state/dsPreviewState'
+import { loadDsPreview } from './state/dsPreviewActions'
 import DatasetComponent from '../dsComponents/DatasetComponent'
 import Spinner from '../../chrome/Spinner'
 import ContentBox from '../../chrome/ContentBox'
@@ -18,6 +20,7 @@ import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 import DeployingScreen from '../deploy/DeployingScreen'
 import commitishFromPath from '../../utils/commitishFromPath'
 
+
 import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState';
 import { QriRef } from '../../qri/ref'
 
@@ -28,9 +31,10 @@ interface DatasetPreviewPageProps {
 const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   qriRef
 }) => {
-  const dataset = useSelector(selectDataset)
-  const loading = useSelector(selectIsDatasetLoading)
+  const dataset = useSelector(selectDsPreview)
+  const loading = useSelector(selectIsDsPreviewLoading)
   const editable = useSelector(selectSessionUserCanEditDataset)
+  const dispatch = useDispatch()
 
   const [versionInfoContainer, { height: versionInfoContainerHeight }] = useDimensions();
   const [expandReadme, setExpandReadme] = useState(false)
@@ -40,6 +44,12 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   if (expandReadme) {
     readmeContainerHeight = 'auto'
   }
+
+  useEffect(() => {
+    const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
+    dispatch(loadDsPreview(ref))
+  }, [dispatch, qriRef.username, qriRef.name, qriRef.path ])
+
 
   return (
     <div className='flex flex-col h-full w-full bg-qrigray-100'>

--- a/frontend/src/features/dsPreview/state/dsPreviewActions.ts
+++ b/frontend/src/features/dsPreview/state/dsPreviewActions.ts
@@ -1,0 +1,20 @@
+import { QriRef } from "../../../qri/ref";
+import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
+
+export function loadDsPreview(ref: QriRef): ApiActionThunk {
+  return async (dispatch, getState) => {
+    return dispatch(fetchDsPreview(ref))
+  }
+}
+
+function fetchDsPreview (ref: QriRef): ApiAction {
+  return {
+    type: 'datasetpreview',
+    ref,
+    [CALL_API]: {
+      endpoint: 'dataset_summary',
+      method: 'GET',
+      segments: ref
+    }
+  }
+}

--- a/frontend/src/features/dsPreview/state/dsPreviewState.ts
+++ b/frontend/src/features/dsPreview/state/dsPreviewState.ts
@@ -1,0 +1,31 @@
+import { createReducer } from '@reduxjs/toolkit'
+
+import { RootState } from '../../../store/store';
+
+export const selectDsPreview = (state: RootState): any => state.dsPreview.preview
+
+export const selectIsDsPreviewLoading = (state: RootState): boolean => state.dsPreview.loading
+
+export interface DsPreviewState {
+  preview: any
+  loading: boolean
+}
+
+const initialState: DsPreviewState = {
+  preview: {},
+  loading: true
+}
+
+export const dsPreviewReducer = createReducer(initialState, {
+  'API_DATASETPREVIEW_REQUEST': (state) => {
+    state.preview = {}
+    state.loading = true
+  },
+  'API_DATASETPREVIEW_SUCCESS': (state, action) => {
+    state.preview = action.payload.data
+    state.loading = false
+  },
+  'API_DATASETPREVIEW_FAILURE': (state) => {
+    state.preview = false
+  }
+})

--- a/frontend/src/features/dsPreview/state/dsPreviewState.ts
+++ b/frontend/src/features/dsPreview/state/dsPreviewState.ts
@@ -1,24 +1,24 @@
 import { createReducer } from '@reduxjs/toolkit'
 
-import { RootState } from '../../../store/store';
+import { RootState } from '../../../store/store'
+import { Dataset } from '../../../qri/dataset'
 
 export const selectDsPreview = (state: RootState): any => state.dsPreview.preview
 
 export const selectIsDsPreviewLoading = (state: RootState): boolean => state.dsPreview.loading
 
 export interface DsPreviewState {
-  preview: any
+  preview?: Dataset
   loading: boolean
 }
 
 const initialState: DsPreviewState = {
-  preview: {},
-  loading: true
+  loading: false
 }
 
 export const dsPreviewReducer = createReducer(initialState, {
   'API_DATASETPREVIEW_REQUEST': (state) => {
-    state.preview = {}
+    state.preview = undefined
     state.loading = true
   },
   'API_DATASETPREVIEW_SUCCESS': (state, action) => {
@@ -26,6 +26,6 @@ export const dsPreviewReducer = createReducer(initialState, {
     state.loading = false
   },
   'API_DATASETPREVIEW_FAILURE': (state) => {
-    state.preview = false
+    state.loading = false
   }
 })

--- a/frontend/src/features/navbar/NavBar.tsx
+++ b/frontend/src/features/navbar/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useHistory } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 
 import SessionUserMenu from './SessionUserMenu'
@@ -10,16 +10,27 @@ import { selectNavExpanded } from '../app/state/appState'
 
 export interface NavBarProps {
   minimal?: boolean
+  showSearch?: boolean
 }
 
-const NavBar: React.FC<NavBarProps> = ({ minimal = false }) => {
+const NavBar: React.FC<NavBarProps> = ({
+  minimal = false,
+  showSearch = true
+}) => {
   const expanded = useSelector(selectNavExpanded)
   const location = useLocation()
+  const history = useHistory()
+
 
   const buttonItems = [
     { text: 'Dashboard', link: '/dashboard', icon: 'dashboard'},
     { text: 'My Datasets', link: '/collection', icon: 'myDatasets'}
   ]
+
+  const handleSearchSubmit = (query:string) => {
+    const newParams = new URLSearchParams(`q=${query}`)
+    history.push(`/search?${newParams.toString()}`)
+  }
 
   return (
     <div className='bg-white text-qrinavy-700 text-bold flex items-center pr-8' style={{
@@ -33,7 +44,7 @@ const NavBar: React.FC<NavBarProps> = ({ minimal = false }) => {
           <div className={`font-medium text-2xl ml-2 ${expanded ? 'block' : 'hidden'}`}>Qri</div>
         </div>
       </Link>
-      {!minimal && <SearchBox />}
+      {!minimal && showSearch && <SearchBox onSubmit={handleSearchSubmit} />}
       <div className='flex m-auto items-center'>
         {!minimal && (
           <ButtonGroup

--- a/frontend/src/features/search/BigSearchBox.tsx
+++ b/frontend/src/features/search/BigSearchBox.tsx
@@ -21,6 +21,9 @@ const BigSearchBox: React.FC<BigSearchBoxProps> = ({ onSubmit, value='', classNa
     onSubmit(stateValue)
   }
 
+  // updates state if the value prop changes in parent components
+  // allows a user to search for a term using the global search box and have it show up
+  // in this search box after navigation to /search
   React.useEffect(() => {
     setStateValue(value)
   }, [value])

--- a/frontend/src/features/search/BigSearchBox.tsx
+++ b/frontend/src/features/search/BigSearchBox.tsx
@@ -21,6 +21,10 @@ const BigSearchBox: React.FC<BigSearchBoxProps> = ({ onSubmit, value='', classNa
     onSubmit(stateValue)
   }
 
+  React.useEffect(() => {
+    setStateValue(value)
+  }, [value])
+
   return (
     <form className={classNames("relative rounded-md shadow-sm w-full", className)} onSubmit={handleSubmit}>
       <input

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -48,7 +48,7 @@ const Search: React.FC<{}> = () => {
 
   return (
     <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
-      <NavBar />
+      <NavBar showSearch={false} />
       <div className='flex-grow w-full py-9'>
         <div className='w-4/5 max-w-screen-lg mx-auto mb-2'>
           <div className='text-qrinavy text-4xl font-bold mb-3'>Dataset Search</div>

--- a/frontend/src/features/search/SearchBox.tsx
+++ b/frontend/src/features/search/SearchBox.tsx
@@ -2,15 +2,25 @@ import React from 'react'
 
 import Icon from '../../chrome/Icon'
 
-const SearchBox: React.FC<{}> = () => {
+interface SearchBoxProps {
+  onSubmit: (q: string) => void
+}
+
+const SearchBox: React.FC<SearchBoxProps> = ({ onSubmit }) => {
   const [stateValue, setStateValue] = React.useState('')
 
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setStateValue(e.target.value)
   }
 
+  const handleSubmit = (e: React.FormEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    onSubmit(stateValue)
+  }
+
+
   return (
-    <form className="my-1 mx-2 relative rounded-md shadow-sm w-48" >
+    <form className="my-1 mx-2 relative rounded-md shadow-sm w-48" onSubmit={handleSubmit}>
       <input
         className="focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-xs border-gray-400 rounded-lg tracking-wider placeholder-gray-600 placeholder-opacity-50"
         style={{
@@ -21,7 +31,7 @@ const SearchBox: React.FC<{}> = () => {
         type='text'
         placeholder='Search'
         value={stateValue || ''}
-        onChange={handleOnChange}
+        onChange={handleChange}
       />
       <span className='absolute inset-y-0 right-0 flex items-center pr-2 text-gray-400'>
         <Icon size='sm' icon='skinnySearch' />

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -11,6 +11,7 @@ import { workflowReducer, WorkflowState } from '../features/workflow/state/workf
 import { AppState, appReducer } from '../features/app/state/appState';
 import { CollectionState, collectionReducer } from '../features/collection/state/collectionState';
 import { datasetReducer, DatasetState } from '../features/dataset/state/datasetState';
+import { dsPreviewReducer, DsPreviewState } from '../features/dsPreview/state/dsPreviewState';
 import { scrollerReducer, ScrollerState } from '../features/scroller/state/scrollerState';
 import { searchReducer, SearchState } from '../features/search/state/searchState';
 import { deployReducer, DeployState } from '../features/deploy/state/deployState';
@@ -28,6 +29,7 @@ export interface RootState {
   collection: CollectionState
   commits: CommitsState
   dataset: DatasetState
+  dsPreview: DsPreviewState
   deploy: DeployState
   router: RouterState
   scroller: ScrollerState
@@ -46,6 +48,7 @@ const rootReducer = (h: History) => combineReducers({
   commits: commitsReducer,
   dataset: datasetReducer,
   deploy: deployReducer,
+  dsPreview: dsPreviewReducer,
   // apparently connected-router's types are no good.
   // https://github.com/reduxjs/redux-toolkit/issues/506#issuecomment-614295927
   // router: connectRouter(h) as any as Reducer<RouterState>,


### PR DESCRIPTION
- hydrates dataset previews
- enables navbar search (hides navbar search when on `/search`)
- ensures that a search term passed in from an external route via query params is populated in the `/search` text input
- removes an unused API call for paginated body (to be used later)
- refactors the API call for a rendered body.