### PR TITLE
Cw tweaks

### DIFF
--- a/frontend/src/chrome/UsernameWithIcon.tsx
+++ b/frontend/src/chrome/UsernameWithIcon.tsx
@@ -11,7 +11,7 @@ const UsernameWithIcon: React.FunctionComponent<UsernameWithIconProps> = ({
   username,
   className
 }) => (
-   <div className={classNames('flex text-xs tracking-wider leading-snug', className)}>
+   <div className={classNames('flex items-center text-xs tracking-wider leading-snug', className)}>
      <div className='rounded-xl inline-block mr-1 bg-cover flex-shrink-0' style={{
        height: '18px',
        width: '18px',

--- a/frontend/src/chrome/icon/Body.tsx
+++ b/frontend/src/chrome/icon/Body.tsx
@@ -3,15 +3,15 @@ import CustomIcon, { CustomIconProps } from '../CustomIcon'
 
 const Clock: React.FC<CustomIconProps> = (props) => (
   <CustomIcon {...props}>
-    <path d="M9.44678 10.8262H14.9787" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M9.44678 10.8262H14.9787" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
     <mask id="path-2-inside-1" fill="white">
     <rect x="2" y="4" width="20" height="4.25532" rx="1.02128"/>
     </mask>
-    <rect x="2" y="4" width="20" height="4.25532" rx="1.02128" stroke="currentColor" stroke-width="4" mask="url(#path-2-inside-1)"/>
+    <rect x="2" y="4" width="20" height="4.25532" rx="1.02128" stroke="currentColor" strokeWidth="4" mask="url(#path-2-inside-1)"/>
     <mask id="path-3-inside-2" fill="white">
     <path d="M3.27661 6.57092H20.7234V18.7411C20.7234 19.3052 20.2662 19.7624 19.7021 19.7624H4.29789C3.73385 19.7624 3.27661 19.3052 3.27661 18.7411V6.57092Z"/>
     </mask>
-    <path d="M3.27661 6.57092H20.7234V18.7411C20.7234 19.3052 20.2662 19.7624 19.7021 19.7624H4.29789C3.73385 19.7624 3.27661 19.3052 3.27661 18.7411V6.57092Z" stroke="currentColor" stroke-width="4" mask="url(#path-3-inside-2)"/>
+    <path d="M3.27661 6.57092H20.7234V18.7411C20.7234 19.3052 20.2662 19.7624 19.7021 19.7624H4.29789C3.73385 19.7624 3.27661 19.3052 3.27661 18.7411V6.57092Z" stroke="currentColor" strokeWidth="4" mask="url(#path-3-inside-2)"/>
   </CustomIcon>
 )
 

--- a/frontend/src/chrome/icon/Readme.tsx
+++ b/frontend/src/chrome/icon/Readme.tsx
@@ -3,11 +3,11 @@ import CustomIcon, { CustomIconProps } from '../CustomIcon'
 
 const Clock: React.FC<CustomIconProps> = (props) => (
   <CustomIcon {...props}>
-    <circle cx="6.16667" cy="13.8333" r="3.16667" stroke="currentColor" stroke-width="2"/>
-    <circle r="3.16667" transform="matrix(-1 0 0 1 17.8333 13.8333)" stroke="currentColor" stroke-width="2"/>
-    <path d="M10 13.6667H14" stroke="currentColor" stroke-width="2"/>
-    <path d="M2.33325 14V8.83333C2.33325 6.71624 4.04949 5 6.16659 5V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21.6667 14V8.83333C21.6667 6.71624 19.9505 5 17.8334 5V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="6.16667" cy="13.8333" r="3.16667" stroke="currentColor" strokeWidth="2"/>
+    <circle r="3.16667" transform="matrix(-1 0 0 1 17.8333 13.8333)" stroke="currentColor" strokeWidth="2"/>
+    <path d="M10 13.6667H14" stroke="currentColor" strokeWidth="2"/>
+    <path d="M2.33325 14V8.83333C2.33325 6.71624 4.04949 5 6.16659 5V5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M21.6667 14V8.83333C21.6667 6.71624 19.9505 5 17.8334 5V5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
   </CustomIcon>
 )
 

--- a/frontend/src/chrome/icon/Structure.tsx
+++ b/frontend/src/chrome/icon/Structure.tsx
@@ -3,15 +3,15 @@ import CustomIcon, { CustomIconProps } from '../CustomIcon'
 
 const Clock: React.FC<CustomIconProps> = (props) => (
   <CustomIcon {...props}>
-  <rect x="3" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="10.2727" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="17.5454" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="3" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="10.2727" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="17.5454" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="3" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="10.2727" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="17.5454" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" stroke-width="2"/>
+  <rect x="3" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="10.2727" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="17.5454" y="3" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="3" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="10.2727" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="17.5454" y="10.2728" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="3" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="10.2727" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
+  <rect x="17.5454" y="17.5454" width="3.45455" height="3.45455" rx="1" stroke="currentColor" strokeWidth="2"/>
   </CustomIcon>
 )
 

--- a/frontend/src/features/app/App.tsx
+++ b/frontend/src/features/app/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC<any> = () => {
   })
 
   return (
-    <div id='app' className='flex flex-col h-screen w-screen'>
+    <div id='app' className='flex flex-col h-screen w-screen' style={{ minWidth: '1100px' }}>
       <ConnectedRouter history={history}>
         <Modal />
         <Routes />

--- a/frontend/src/features/commits/DatasetCommitItem.tsx
+++ b/frontend/src/features/commits/DatasetCommitItem.tsx
@@ -33,7 +33,7 @@ const DatasetCommitItem: React.FC<DatasetCommitItemProps> = ({
         </div>
       </div>
       <Link className={classNames('block rounded-md p-4 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-gray-400 border border-gray-300')} to={pathToDatasetViewer(newQriRef(logItem))}>
-        <div className='flex mb-1'>
+        <div className='flex mb-1 justify-between'>
           <UsernameWithIcon username={logItem.username} />
           <div className='flex-grow-0 text-qrigreen'>
             <Icon icon='automationFilled' size='sm'/>

--- a/frontend/src/features/commits/DatasetCommits.tsx
+++ b/frontend/src/features/commits/DatasetCommits.tsx
@@ -33,7 +33,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
     <div className='pt-4 overflow-y-hidden flex flex-col text-xs flex-shrink-0' style={{ width: '325px'}}>
       <header className='flex-grow-0 mb-4'>
         <h3 className='text-2xl text-qrinavy-500 font-black'>History</h3>
-        <div className='text-xs text-gray-400 tracking-wider'>{commits.length} versions</div>
+        <div className='text-xs text-gray-400 tracking-wider'>{commits.length === 1 ? 'version' : 'versions'}</div>
       </header>
       <ul className='block flex-grow overflow-y-auto pb-40 pr-8'>
         <HistorySearchBox />

--- a/frontend/src/features/dataset/DatasetPage.tsx
+++ b/frontend/src/features/dataset/DatasetPage.tsx
@@ -41,7 +41,7 @@ const DatasetPage: React.FC<{}> = ({
       <NavBar />
       <div className='flex overflow-hidden w-full'>
         <DatasetNavSidebar qriRef={qriRef} />
-        <div className='flex flex-col flex-grow overflow-hidden px-7 py-9'>
+        <div className='flex flex-col flex-grow overflow-hidden px-7 pb-7 pt-9'>
           <DatasetHeader qriRef={qriRef} editable={editable} />
           {children}
         </div>

--- a/frontend/src/features/dsComponents/DatasetComponents.tsx
+++ b/frontend/src/features/dsComponents/DatasetComponents.tsx
@@ -27,7 +27,7 @@ const DatasetComponents: React.FC<{}> = () => {
   return (
     <div className='flex-grow flex overflow-hidden'>
       <DatasetCommits qriRef={qriRef} />
-      <div className='flex flex-col flex-grow overflow-x-hidden pt-4 pr-7'>
+      <div className='flex flex-col flex-grow overflow-x-hidden pt-4'>
         <CommitSummaryHeader dataset={dataset}>
           <DownloadDatasetButton qriRef={qriRef} />
         </CommitSummaryHeader>

--- a/frontend/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/frontend/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -31,7 +31,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
   }
 
   return (
-    <div className='flex flex-col w-full mt-1 py-4 overflow-hidden'>
+    <div className='flex flex-col w-full mt-1 pt-4 overflow-hidden'>
       <ComponentList
         dataset={dataset}
         onClick={setSelectedComponent}

--- a/frontend/src/features/dsComponents/body/BodyPreview.tsx
+++ b/frontend/src/features/dsComponents/body/BodyPreview.tsx
@@ -1,15 +1,12 @@
 // TODO(chriswhong): BodyPreview and Body should be combined since they share a lot of the same logic
 
-import React, { useEffect } from 'react'
+import React from 'react'
 import numeral from 'numeral'
 
 import Dataset,  { Structure, schemaToColumns, ColumnProperties } from '../../../qri/dataset'
 
 import BodyTable from './BodyTable'
 import BodyJson from './BodyJson'
-import { useDispatch } from 'react-redux'
-import { loadBody } from '../../dataset/state/datasetActions'
-import { newQriRef } from '../../../qri/ref'
 import Icon from '../../../chrome/Icon'
 
 export interface BodyProps {
@@ -34,19 +31,10 @@ const extractColumnHeaders = (structure: Structure, value: any[]): ColumnPropert
 const Body: React.FC<BodyProps> = ({
   dataset,
 }) => {
-  const dispatch = useDispatch()
   const {
     body,
     structure,
-    path,
-    name,
-    peername: username
   } = dataset
-
-  // list out dependencies on dataset body individually for proper memoization
-  useEffect(() => {
-    dispatch(loadBody(newQriRef({ path, name, username }), 1, 100))
-  }, [dispatch, path, name, username])
 
   if (!body) {
     return (

--- a/frontend/src/features/dsComponents/body/BodyTable.tsx
+++ b/frontend/src/features/dsComponents/body/BodyTable.tsx
@@ -39,7 +39,7 @@ interface BodyTableProps {
 //   return Math.abs(scrollTop + offsetHeight - scrollHeight) < buffer
 // }
 
-const cellClasses = 'px-2 py-2 overflow-hidden overflow-ellipsis whitespace-nowrap border-r border-gray-200 '
+const cellClasses = 'px-2 py-2 overflow-hidden overflow-ellipsis whitespace-nowrap border-r border-gray-200 max-w-xs'
 
 
 export default class BodyTable extends React.Component<BodyTableProps> {

--- a/frontend/src/features/dsComponents/readme/Readme.tsx
+++ b/frontend/src/features/dsComponents/readme/Readme.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
-import { refStringFromQriRef, QriRef } from '../../../qri/ref'
+import { QriRef } from '../../../qri/ref'
 import { API_BASE_URL } from '../../../store/api'
 
 export interface ReadmeProps {
@@ -11,26 +11,33 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
   const { qriRef } = props
   const [hasReadme, setHasReadme] = React.useState(true)
 
-  const qriRefStr = refStringFromQriRef(qriRef)
-
   const refCallback = useCallback((el: HTMLDivElement) =>{
     if (el !== null) {
       fetch(`${API_BASE_URL}/dataset_summary/readme?path=${qriRef.path}`)
-        .then(async (res) => {
-          return res.text()
+        .then((res) => {
+          if (res.ok) {
+            return res.text()
+          } else {
+            return Promise.reject('error 404')
+          }
         })
-        .then((render) => {
-          if (!render) { setHasReadme(false) }
-          el.innerHTML = render
+        .then((renderedReadme) => {
+          el.innerHTML = renderedReadme
         })
-
-      const render = "<h1>Heading</h1><p>Lorem Ipsum Dolor</p><p><strong>bold text</strong></p><h2>Heading 2</h2>"
-      el.innerHTML = render
+        .catch((e) => {
+          setHasReadme(false)
+        })
     }
-  }, [qriRefStr])
+  }, [qriRef.path])
 
   if (!hasReadme) {
-    return null
+    return (
+      <div className='h-full w-full flex items-center'>
+        <div className='text-center mx-auto text-sm'>
+          Error fetching readme
+        </div>
+      </div>
+    )
   }
   return (
     <div className='h-full w-full'>

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -3,9 +3,8 @@ import { useSelector, useDispatch } from 'react-redux'
 import useDimensions from 'react-use-dimensions'
 
 import { newQriRef } from '../../qri/ref';
-import { selectDsPreview, selectIsDsPreviewLoading } from './state/dsPreviewState'
+import { selectDsPreview } from './state/dsPreviewState'
 import { loadDsPreview } from './state/dsPreviewActions'
-import DatasetComponent from '../dsComponents/DatasetComponent'
 import Spinner from '../../chrome/Spinner'
 import ContentBox from '../../chrome/ContentBox'
 import Icon from '../../chrome/Icon'
@@ -19,6 +18,8 @@ import NavBar from '../navbar/NavBar'
 import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 import DeployingScreen from '../deploy/DeployingScreen'
 import commitishFromPath from '../../utils/commitishFromPath'
+import Readme from '../dsComponents/readme/Readme'
+import { qriRefFromDataset } from '../../qri/dataset'
 
 
 import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState';
@@ -32,7 +33,6 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   qriRef
 }) => {
   const dataset = useSelector(selectDsPreview)
-  const loading = useSelector(selectIsDsPreviewLoading)
   const editable = useSelector(selectSessionUserCanEditDataset)
   const dispatch = useDispatch()
 
@@ -50,32 +50,37 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
     dispatch(loadDsPreview(ref))
   }, [dispatch, qriRef.username, qriRef.name, qriRef.path ])
 
-
   return (
     <div className='flex flex-col h-full w-full bg-qrigray-100'>
       <NavBar />
       <div className='flex overflow-hidden w-full'>
         <DatasetNavSidebar qriRef={qriRef} />
-        {loading
+        {!dataset
         ? (<div className='w-full h-full p-4 flex justify-center items-center'>
             <Spinner color='#4FC7F3' />
           </div>)
         : (
           <div className='overflow-y-scroll overflow-x-hidden flex-grow relative flex'>
-            <div className='max-w-screen-lg mx-auto py-9 flex-grow'>
+            <div className='max-w-screen-lg mx-auto p-9 w-full flex-grow'>
               <DatasetHeader qriRef={qriRef} editable={editable} noBorder />
               <div className='-ml-2 -mr-3 mb-5'>
                 <div className='w-7/12 px-2 inline-block align-top' style={{ height: readmeContainerHeight}}>
                   <ContentBox className='flex flex-col h-full'>
                     <ContentBoxTitle title='Readme'/>
                     <div className='flex-grow overflow-hidden'>
-                      <DatasetComponent
-                        key='readme'
-                        componentName={'readme'}
-                        dataset={dataset}
-                      />
+                      {
+                        dataset.readme ? (
+                          <Readme qriRef={qriRefFromDataset(dataset)} />
+                        ) : (
+                          <div className='h-full w-full flex items-center'>
+                            <div className='text-center mx-auto text-sm'>
+                              No Readme
+                            </div>
+                          </div>
+                        )
+                      }
                     </div>
-                    {!expandReadme && (<div className='text-qriblue text-sm cursor-pointer' onClick={() => { setExpandReadme(true) }}>See More</div>)}
+                    {!expandReadme && (<div className='text-qriblue text-sm cursor-pointer mt-1' onClick={() => { setExpandReadme(true) }}>See More</div>)}
                   </ContentBox>
                 </div>
                 <div ref={versionInfoContainer} className='w-5/12 px-3 inline-block align-top'>
@@ -87,9 +92,9 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                           <Icon icon='commit' size='sm' className='-ml-2' />
                           <div className='font-medium'>{commitishFromPath(dataset.path)}</div>
                         </div>
-                        <div className='text-sm text-qrinavy mb-2'>{dataset.commit && dataset.commit.title}</div>
+                        <div className='text-sm text-qrinavy mb-2'>{dataset.commit?.title}</div>
                         <div className='flex items-center text-gray-400'>
-                          <RelativeTimestampWithIcon timestamp={new Date(dataset.commit && dataset.commit.timestamp)} className='mr-3' />
+                          <RelativeTimestampWithIcon timestamp={new Date(dataset.commit?.timestamp)} className='mr-3' />
                           <UsernameWithIcon username='chriswhong' className='mt-0.5' />
                         </div>
                       </div>
@@ -97,12 +102,12 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                     </div>
                     {/* Bottom of the box */}
 
-                    {dataset.meta && dataset.meta.description && (
-                      <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2'>{dataset.meta.description}</div>
-                    )}
 
-                    {dataset.meta && dataset.meta.keywords && dataset.meta.keywords.map((keyword) => {
-                      return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-2'>{keyword}</div>
+                    <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2'>{(dataset.meta?.description) || 'No Description'}</div>
+
+
+                    {dataset.meta?.keywords?.map((keyword) => {
+                      return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-1 mb-1'>{keyword}</div>
                     })}
                   </ContentBox>
                 </div>

--- a/frontend/src/features/snackBar/SnackBar.tsx
+++ b/frontend/src/features/snackBar/SnackBar.tsx
@@ -6,9 +6,11 @@ import ConnectionStatus from '../websocket/ConnectionStatus'
 const SnackBar: React.FC<{}> = () => {
   // TODO(b5): build a reducer the snack bar, use it to show messages here
   // TODO(b5): actions for dismissing snack bar messages
-  return (<div className="absolute bottom-0 right-0 py-4 pl-4">
-    <ConnectionStatus />
-  </div>)
+  return (
+    <div className="absolute bottom-0 left-0 py-2 px-3 text-xs">
+      <ConnectionStatus />
+    </div>
+  )
 }
 
 export default SnackBar

--- a/frontend/src/features/websocket/ConnectionStatus.tsx
+++ b/frontend/src/features/websocket/ConnectionStatus.tsx
@@ -12,8 +12,8 @@ const ConnectionStatus: React.FC<{}> = () => {
   }
 
   return (
-    <div className='flex'>
-      <div className='mt-1'>
+    <div className='flex items-center'>
+      <div className=''>
         <StatusDot showNoChanges status={componentStatusFromWSConnectionStatus(state.status)} />
       </div>
       <div className='ml-2'>
@@ -27,7 +27,7 @@ const ConnectionStatus: React.FC<{}> = () => {
               return "Connecting"
             case WSConnectionStatus.interrupted:
               return "Reconnecting..."
-            default: 
+            default:
               return null
           }
         })()}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -173,13 +173,15 @@ code {
   content: ' ';
   display: inline-block;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'%3E%3C/path%3E%3C/svg%3E");
-}.markdown-body {
+}
+
+.markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   line-height: 1.5;
   color: #24292e;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1.5;
   word-wrap: break-word;
 }
@@ -321,7 +323,7 @@ code {
 }
 
 .markdown-body h1 {
-  font-size: 24px;
+  font-size: 20px;
 }
 
 .markdown-body h1,
@@ -330,7 +332,7 @@ code {
 }
 
 .markdown-body h2 {
-  font-size: 20px;
+  font-size: 18px;
 }
 
 .markdown-body h3 {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -115,7 +115,8 @@ module.exports = {
     extend: {
       fontWeight: ['hover'],
       cursor: ['hover'],
-      borderWidth: ['last']
+      borderWidth: ['last'],
+      margin: ['last']
     },
   },
   plugins: [


### PR DESCRIPTION
- fixes some non-react-friendly svg attributes which were causing console warnings
- removes some unused imports that were causing console warnings
- adds a minwidth to the top-level viewport, keeping the layout intact but causing horizontal scrolling on smaller screens
- updates markdown styling for readme (makes all text smaller to fit better with the rest of the design)
- styles and relocates the "connecting..." message for websockets
- adds a "No Readme" placeholder for dataset previews with no readme, adds an "error fetching readme" placeholder for when there is supposed to be one but the network request 404s.
- adds a max-width to table columns
