### PR TITLE
Fix react-paginate types version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-redux": "^7.1.7",
-    "@types/react-paginate": "7.1.3",
+    "@types/react-paginate": "7.1.0",
     "@types/rimraf": "^3.0.0",
     "autoprefixer": "^9",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Uses version `7.1.0` of `@types/react-paginate` which will prevent an error when running `yarn install`