### PR TITLE
feat: add user profile page, improve search

### DIFF
--- a/frontend/src/chrome/ContentTabs.tsx
+++ b/frontend/src/chrome/ContentTabs.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import classNames from 'classnames'
+import { Link } from 'react-router-dom'
+
+export interface Tab {
+  name: string
+  link?: string
+  numberDecorator?: number
+  selected?: boolean
+  disabled?: boolean
+}
+
+interface ContentTabsProps {
+  tabs: Tab[]
+}
+
+export const ContentTabs: React.FC<ContentTabsProps> = ({ tabs }) => (
+  <div className='flex'>
+    {
+      tabs.map((tab: Tab) => {
+        const {
+          name,
+          link,
+          selected = false,
+          disabled = false,
+          numberDecorator
+        } = tab
+
+        let tabContent = (
+          <div className='flex justify-center'>
+            {name}
+            {
+              !!numberDecorator &&
+              (numberDecorator > 0) &&
+              (
+                <div className={classNames('text-white rounded px-2 ml-2', {
+                  'bg-qripink': selected,
+                  'bg-qrigray-400': !selected,
+                })}>
+                  {numberDecorator}
+                </div>
+              )
+            }
+          </div>
+        )
+
+        if (link) {
+          tabContent = (
+            <Link to={link}>
+              {tabContent}
+            </Link>
+          )
+        }
+
+        return (
+          <div
+            key={tab.name}
+            className={classNames('font-medium px-5 mr-2 last:mr-0 py-3 rounded-tr-lg rounded-tl-lg', {
+              'selected': selected,
+              'bg-white': selected,
+              'text-qripink': selected,
+              'bg-gray-200': !selected,
+              'text-gray-400': disabled,
+              'text-qrinavy': !disabled,
+              'hover:cursor-pointer': !disabled,
+            })}
+          >
+            {tabContent}
+          </div>
+        )
+      })
+    }
+  </div>
+)

--- a/frontend/src/chrome/DatasetList.tsx
+++ b/frontend/src/chrome/DatasetList.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import SearchResultItem from '../features/search/SearchResultItem'
+import { SearchResult } from '../qri/search'
+
+export interface DatasetListProps {
+  datasets: SearchResult[]
+}
+
+const DatasetList: React.FC<DatasetListProps> = ({ datasets }) => (
+  <>
+    {
+      datasets.map((dataset) => <SearchResultItem key={`${dataset.peername}/${dataset.name}`} dataset={dataset} />)
+    }
+  </>
+)
+
+export default DatasetList

--- a/frontend/src/chrome/DropdownMenu.tsx
+++ b/frontend/src/chrome/DropdownMenu.tsx
@@ -10,11 +10,13 @@ export interface DropDownMenuItem {
   // link overrides `onClick`, ie if you have both link and onClick set, only
   // the link will work
   link?: string
-  onClick?: (e?: React.MouseEvent) => void
+  active: boolean
   text: string
   disabled?: boolean
   // icon: options are found in the `Icon` component
   icon?: string
+  onClick?: (e?: React.MouseEvent) => void
+
 }
 
 interface DropdownMenuProps {
@@ -60,16 +62,16 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
           aria-labelledby="options-menu"
           style={{ minWidth: '9rem' }}
         >
-          <div className="py-1" onClick={ () => setOpen(false) }>
-            {items && items.map(({ link, onClick, text, icon='', disabled=false }, i) => {
-              let linkButtonClass = 'w-full block text-left px-4 py-2 text-sm whitespace-nowrap overflow-hidden'
+          <div className="py-1 flex flex-col" onClick={ () => setOpen(false) }>
+            {items && items.map(({ link, active, onClick, text, icon='', disabled=false }, i) => {
+              let linkButtonClass = 'text-left text-xs px-2 py-0.5 mx-2 my-1 whitespace-nowrap rounded-md'
               if (!disabled) {
-                linkButtonClass = `${linkButtonClass} hover:pointer text-gray-700 hover:bg-gray-100 hover:text-gray-900`
+                linkButtonClass = `${linkButtonClass} hover:pointer text-qrigray-400 hover:bg-gray-100`
               } else {
                 linkButtonClass = `${linkButtonClass} text-gray-400`
               }
 
-              const content = <span>{icon && <Icon icon={icon} className='mr-2' size='sm' />}{text}</span>
+              const content = <span className={classNames({ 'text-qripink font-semibold': active })}>{icon && <Icon icon={icon} className='mr-2' size='sm' />}{text}</span>
 
               if (link) {
                 if (link.startsWith('http')) {

--- a/frontend/src/chrome/ExternalLink.tsx
+++ b/frontend/src/chrome/ExternalLink.tsx
@@ -4,6 +4,7 @@ export interface ExternalLinkProps {
   id?: string
   to: string
   children: React.ReactNode
+  // providing className prop will override the component's color classes
   className?: string
   tooltip?: string
 }
@@ -22,7 +23,7 @@ export const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({
     href={to}
     target='_blank'
     rel="noopener noreferrer"
-    className={`text-qriblue hover:text-qriblue-600 hover:cursor-pointer ${className}`}
+    className={`${className || 'text-qriblue hover:text-qriblue-600'} hover:cursor-pointer`}
     data-tip={tooltip}
   >
     {children}

--- a/frontend/src/chrome/Icon.tsx
+++ b/frontend/src/chrome/Icon.tsx
@@ -6,7 +6,6 @@ import {
   faArrowRight,
   faBars,
   faBolt,
-  faCaretDown,
   faCheckCircle,
   faCircle,
   faCloudUploadAlt,
@@ -52,6 +51,7 @@ import Body from './icon/Body'
 import Brackets from './icon/Brackets'
 import CaretLeft from './icon/CaretLeft'
 import CaretRight from './icon/CaretRight'
+import CaretDown from './icon/CaretDown'
 import Checkbox from './icon/Checkbox'
 import Clock from './icon/Clock'
 import Code from './icon/Code'
@@ -102,7 +102,6 @@ const faIcons: Record<string, IconDefinition> = {
   'bars': faBars,
   'bolt': faBolt,
   'boolean': faToggleOn,
-  'caretDown': faCaretDown,
   'check': faCheck,
   'checkCircle': faCheckCircle,
   'circle': faCircle,
@@ -164,6 +163,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
     brackets: <Brackets className={className} size={size} />,
     caretLeft: <CaretLeft className={className} size={size} />,
     caretRight: <CaretRight className={className} size={size} />,
+    caretDown: <CaretDown className={className} size={size} />,
     checkbox: <Checkbox className={className} size={size} />,
     clock: <Clock className={className} size={size} />,
     code: <Code className={className} size={size} />,
@@ -197,7 +197,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
     return <FontAwesomeIcon rotation={rotation} size={sizes[size]} icon={faIcons[icon]} className={className} spin={spin} />
   }
 
-  return customIcons[icon]
+  return customIcons[icon] || '?'
 }
 
 export default Icon

--- a/frontend/src/chrome/IconLink.tsx
+++ b/frontend/src/chrome/IconLink.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ExternalLink from './ExternalLink'
+import Icon from './Icon'
+
+interface IconLinkProps {
+  icon: string
+  link: string
+}
+
+const IconLink: React.FC<IconLinkProps> = ({
+  icon,
+  link
+}) => (
+  <div className='ml-2'>
+    <ExternalLink to={link} className='text-qrinavy hover:text-qrinavy-600'>
+      <Icon icon={icon} size='sm'/>
+    </ExternalLink>
+  </div>
+)
+
+export default IconLink

--- a/frontend/src/chrome/NumericLabel.tsx
+++ b/frontend/src/chrome/NumericLabel.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface NumericLabelProps {
+  number: number | string
+  label: string
+}
+
+const NumericLabel: React.FC<NumericLabelProps> = ({
+  number,
+  label
+}) => (
+  <div className='flex items-center px-3 border-r border-qrigray-300 first:pl-0 last:border-0'>
+    <div className='text-qrinavy font-medium mr-2'>
+      {number}
+    </div>
+    <div className='text-qrigray-400 text-sm'>
+      {label}
+    </div>
+  </div>
+)
+
+export default NumericLabel

--- a/frontend/src/chrome/PageControl.tsx
+++ b/frontend/src/chrome/PageControl.tsx
@@ -5,9 +5,6 @@ import querystring from 'querystring'
 
 import Icon from '../chrome/Icon'
 
-import { QueryParams } from '../qri/queryParams'
-
-
 export interface PageInfo {
   resultCount: number
   page: number
@@ -20,7 +17,7 @@ export interface PageChangeObject {
 
 interface PageControlProps {
   pageInfo: PageInfo
-  queryParams: QueryParams
+  queryParams: Record<string, any>
   showRange?: boolean
   onPageChange: (o:PageChangeObject) => void
 }

--- a/frontend/src/chrome/icon/CaretDown.tsx
+++ b/frontend/src/chrome/icon/CaretDown.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import CustomIcon, { CustomIconProps } from '../CustomIcon'
+
+const CaretDown: React.FC<CustomIconProps> = (props) => (
+  <CustomIcon {...props}>
+    <path d="M22 7.09524L12 17L2 7.09524" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </CustomIcon>
+)
+
+export default CaretDown

--- a/frontend/src/features/dataset/DatasetInfoItem.tsx
+++ b/frontend/src/features/dataset/DatasetInfoItem.tsx
@@ -19,7 +19,7 @@ const DatasetInfoItem: React.FC<DatasetInfoItemProps> = ({
 
 
   return (
-    <div className='text-qrinavy-500 text-sm flex items-center inline-block mr-5'>
+    <div className='text-qrinavy-500 text-sm flex items-center inline-block mr-5 mb-2'>
       <div className='mr-1 flex items-center'>
         {(typeof icon === 'string') ? <Icon icon={icon} size='sm' className={iconClassName} /> : icon }
       </div>

--- a/frontend/src/features/dsComponents/readme/Readme.tsx
+++ b/frontend/src/features/dsComponents/readme/Readme.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback } from 'react'
 
 import { QriRef } from '../../../qri/ref'
 import { API_BASE_URL } from '../../../store/api'

--- a/frontend/src/features/navbar/SessionUserMenu.tsx
+++ b/frontend/src/features/navbar/SessionUserMenu.tsx
@@ -39,7 +39,7 @@ const SessionUserMenu: React.FC<{}> = () => {
   const menuItems = [
     {
       text: 'Profile',
-      link: '/profile'
+      link: `/${user.username}`
     },
     {
       text: 'Send Feedback',

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -7,10 +7,14 @@ import { loadSearchResults } from './state/searchActions'
 import { selectSearchResults, selectSearchPageInfo } from './state/searchState'
 import NavBar from '../navbar/NavBar';
 import BigSearchBox from './BigSearchBox';
-import SearchResultItem from './SearchResultItem'
 import PageControl, { PageChangeObject } from '../../chrome/PageControl'
 import Footer from '../footer/Footer'
 import { NewSearchParams } from '../../qri/search'
+import DatasetList from '../../chrome/DatasetList'
+import ContentBox from '../../chrome/ContentBox'
+import Icon from '../../chrome/Icon'
+import DropdownMenu from '../../chrome/DropdownMenu'
+import { CleanSearchParams } from '../../qri/search'
 
 const Search: React.FC<{}> = () => {
   const dispatch = useDispatch()
@@ -23,57 +27,104 @@ const Search: React.FC<{}> = () => {
   const searchResults = useSelector(selectSearchResults)
   const pageInfo = useSelector(selectSearchPageInfo)
 
-  const { q, page } = NewSearchParams(queryString.parse(search))
+  const searchParams = NewSearchParams(queryString.parse(search))
+  const { q, page, sort } = searchParams
 
   // if the query string ever changes, fetch new data
   useEffect(() => {
-    dispatch(loadSearchResults(q, page))
-  }, [q, page, dispatch])
+    dispatch(loadSearchResults(searchParams))
+  }, [q, page, sort, dispatch])
 
   // handle new search term input
   const handleSearchSubmit = (newQ:string) => {
-    const newParams = new URLSearchParams(`q=${newQ}`)
-    history.push({ search: newParams.toString() })
+    updateQueryParams({ q: newQ })
   }
 
   // handle page change from PageControl
   const handlePageChange = ({ selected: pageIndex }: PageChangeObject) => {
-    const newPage = pageIndex + 1
-    const newParams = new URLSearchParams(`q=${q}&page=${newPage}`)
-    history.push({ search: newParams.toString() })
-    if (scrollContainer.current) {
+    updateQueryParams({ page: pageIndex + 1 })
+  }
+
+  // merges new query params with existing params, updates history
+  const updateQueryParams = (newQueryParams: Record<string, any>) => {
+    const newParams = {
+      ...searchParams,
+      ...newQueryParams
+    }
+
+    // reset page if sort has changed
+    if (newParams.sort !== searchParams.sort) {
+      newParams.page = 1
+    }
+
+    // reset page if q has changed
+    if (newParams.q !== searchParams.q) {
+      newParams.page = 1
+    }
+
+    // scroll to top if page has changed
+    if (scrollContainer.current && (newParams.page !== searchParams.page)) {
       scrollContainer.current.scrollTop = 0
     }
+
+    // build a params object excluding undefined or default params, so they don't show up in the URL
+    const newParamsObject = new URLSearchParams()
+    const cleanParams: Record<string, any> = CleanSearchParams(newParams)
+    Object.keys(cleanParams).forEach((key) => {
+      newParamsObject.append(key, cleanParams[key])
+    })
+
+    // update the URL
+    history.push({ search: newParamsObject.toString() })
   }
+
+  const menuItems = [
+    {
+      text: 'Dataset Name',
+      active: sort === 'name',
+      onClick: () => { updateQueryParams({ sort: 'name' }) }
+    },
+    {
+      text: 'Recently Updated',
+      active: sort === 'recentlyupdated',
+      onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
+    }
+  ]
 
   return (
     <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
       <NavBar showSearch={false} />
       <div className='flex-grow w-full py-9'>
-        <div className='w-4/5 max-w-screen-lg mx-auto mb-2'>
-          <div className='text-qrinavy text-4xl font-bold mb-3'>Dataset Search</div>
+        <div className='w-4/5 max-w-screen-lg mx-auto mb-10'>
+          <div className='flex items-center'>
+            <div className='flex-grow'>
+              <div className='text-qrinavy text-3xl font-black mb-2'>Dataset Search</div>
+              <div className='text-qrigray-400 text-sm mb-4'>{pageInfo.resultCount} datasets found matching '{q}'</div>
+            </div>
+            <DropdownMenu items={menuItems} className='ml-8'>
+              <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
+                Sort By
+                <Icon icon='caretDown' size='2xs' className='ml-3' />
+              </div>
+            </DropdownMenu>
+          </div>
           <BigSearchBox onSubmit={handleSearchSubmit} value={q}/>
         </div>
         <div className='w-4/5 max-w-screen-lg mx-auto'>
           {
-            (searchResults.length > 0) ? (
-              <>
-                <div className='text-qrigray mb-2'>{pageInfo.resultCount} datasets found</div>
-                <div className='px-8 rounded-lg bg-white h-full mb-6'>
-                  {
-                    searchResults.map((dataset) => <SearchResultItem key={`${dataset.peername}/${dataset.name}`} dataset={dataset} />)
-                  }
-                </div>
-                <PageControl
-                  pageInfo={pageInfo}
-                  queryParams={{
-                    q,
-                    page
-                  }}
-                  onPageChange={handlePageChange}
+            (searchResults.length > 0) ?
+            <>
+              <ContentBox className='mb-6'>
+                <DatasetList
+                  datasets={searchResults}
                 />
-              </>
-            ) : (
+              </ContentBox>
+              <PageControl
+                pageInfo={pageInfo}
+                queryParams={CleanSearchParams(searchParams)}
+                onPageChange={handlePageChange}
+              />
+            </> : (
               <div className='text-center'>No results found for '{q}'</div>
             )
           }

--- a/frontend/src/features/search/SearchResultItem.tsx
+++ b/frontend/src/features/search/SearchResultItem.tsx
@@ -22,10 +22,10 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset }) => {
       followStats
     } = dataset
     const datasetReference = `${peername}/${name}`
-    let { title, description } = meta
-    if (title === undefined) {
-      title = datasetReference
-    }
+
+    const title = meta?.title || datasetReference
+
+    const description = meta?.description
 
     const timestamp = new Date(commit.timestamp)
 
@@ -38,11 +38,11 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset }) => {
     )
 
     return (
-      <div key={datasetReference} className='pt-5 pb-6 border-b border-qrigray-200 last:border-b-0'>
+      <div key={datasetReference} className='pt-5 pb-6 border-b border-qrigray-200 last:border-b-0 first:pt-0 last:pb-0'>
         <Link to={`/ds/${datasetReference}`}><div className='text-sm text-gray-400 relative flex items-baseline group hover:text mb-2 font-mono hover:underline'>{datasetReference}</div></Link>
         <Link to={`/ds/${datasetReference}`}><div className='text-xl text-qrinavy-500 font-medium hover:text hover:underline mb-3'>{title}</div></Link>
-        {description && (<div className='text-sm text-qrigray hover:text line-clamp-3 mb-3'>{description}</div>)}
-        <div className='flex items-center'>
+        <div className='text-sm text-qrigray hover:text line-clamp-3 mb-3'>{description || 'No Description'}</div>
+        <div className='flex items-center flex-wrap'>
           <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={timestamp} />} />
           <DatasetInfoItem icon={userIcon} label={peername} />
           <DatasetInfoItem icon='disk' label={numeral(structure.length).format('0.0b')} />

--- a/frontend/src/features/search/state/searchActions.ts
+++ b/frontend/src/features/search/state/searchActions.ts
@@ -1,12 +1,10 @@
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
 
-import { NewSearchResult } from '../../../qri/search'
+import { NewSearchResult, SearchParams } from '../../../qri/search'
 
-export const searchPageSizeDefault = 25
-
-export function loadSearchResults(q: string, page: number = 1, pageSize: number = searchPageSizeDefault): ApiActionThunk {
+export function loadSearchResults(searchParams: SearchParams): ApiActionThunk {
   return async (dispatch, getState) => {
-    return dispatch(fetchSearchResults(q, page, pageSize))
+    return dispatch(fetchSearchResults(searchParams))
   }
 }
 
@@ -14,17 +12,25 @@ const mapSearchResults = (results) => {
   return results.map((d) => NewSearchResult(d))
 }
 
-function fetchSearchResults (q: string, page: number, pageSize: number): ApiAction {
+const mapFrontendParams = (frontendParams: SearchParams) => {
+  // map frontend 'sort' param to backend 'orderBy'
+  return {
+    q: frontendParams.q,
+    orderBy: frontendParams.sort === 'recentlyupdated' ? 'created,desc' : 'name,asc'
+  }
+}
+
+function fetchSearchResults (searchParams: SearchParams): ApiAction {
   return {
     type: 'search',
     [CALL_API]: {
       endpoint: 'search',
       method: 'GET',
       pageInfo: {
-        page,
-        pageSize
+        page: searchParams.page,
+        pageSize: searchParams.pageSize
       },
-      query: { q },
+      query: mapFrontendParams(searchParams),
       map: mapSearchResults
     }
   }

--- a/frontend/src/features/userProfile/UserProfile.tsx
+++ b/frontend/src/features/userProfile/UserProfile.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams, useHistory, useLocation } from 'react-router-dom'
+import queryString from 'query-string'
+
+import {
+  loadUserProfile,
+  loadUserProfileDatasets,
+  loadUserProfileFollowing
+} from './state/userProfileActions'
+import {
+  selectUserProfile,
+  selectUserProfileDatasets,
+  selectUserProfileFollowing,
+} from './state/userProfileState'
+import ContentBox from '../../chrome/ContentBox'
+import NavBar from '../navbar/NavBar'
+import Footer from '../footer/Footer'
+import {
+  UserProfileDatasetListParams,
+  NewUserProfileDatasetListParams,
+  CleanUserProfileDatasetListParams
+} from '../../qri/userProfile'
+import { ContentTabs, Tab } from '../../chrome/ContentTabs'
+import UserProfileHeader from './UserProfileHeader'
+import UserProfileDatasetList from './UserProfileDatasetList'
+
+interface UserProfileProps {
+  path?: '/' | '/following'
+}
+
+const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
+  const dispatch = useDispatch()
+  const history = useHistory()
+
+  const profile = useSelector(selectUserProfile)
+
+  const paginatedDatasetResults = useSelector(selectUserProfileDatasets)
+  const paginatedFollowingResults = useSelector(selectUserProfileFollowing)
+
+  const scrollContainer = useRef<HTMLDivElement>(null)
+  const { username: usernameParam } = useParams();
+
+  const { search } = useLocation()
+  const userProfileParams: UserProfileDatasetListParams = NewUserProfileDatasetListParams(queryString.parse(search))
+  const { page, sort } = userProfileParams
+
+  // if the query string ever changes, fetch new data
+  useEffect(() => {
+    dispatch(loadUserProfile(usernameParam))
+    dispatch(loadUserProfileDatasets(usernameParam, userProfileParams))
+    dispatch(loadUserProfileFollowing(usernameParam, userProfileParams))
+  }, [usernameParam, page, sort, dispatch])
+
+  // merges new query params with existing params, updates history
+  const updateQueryParams = (newQueryParams: Record<string, any>) => {
+    const newParams = {
+      ...userProfileParams,
+      ...newQueryParams
+    }
+
+    // reset page if sort has changed
+    if (newParams.sort !== userProfileParams.sort) {
+      newParams.page = 1
+    }
+
+    // scroll to top if page has changed
+    if (scrollContainer.current && (newParams.page !== userProfileParams.page)) {
+      scrollContainer.current.scrollTop = 0
+    }
+
+    // build a params object excluding undefined or default params, so they don't show up in the URL
+    const newParamsObject = new URLSearchParams()
+    const cleanParams: Record<string, any> = CleanUserProfileDatasetListParams(newParams)
+    Object.keys(cleanParams).forEach((key) => {
+      newParamsObject.append(key, cleanParams[key])
+    })
+
+    // update the URL
+    history.push({ search: newParamsObject.toString() })
+  }
+
+  const tabs: Tab[] = [
+    {
+      name: 'Datasets',
+      link: `/${usernameParam}`,
+      numberDecorator: paginatedDatasetResults.pageInfo.resultCount,
+      selected: path === '/'
+    },
+    {
+      name: 'Following',
+      link: `/${usernameParam}/following`,
+      numberDecorator: paginatedFollowingResults.pageInfo.resultCount,
+      selected: path === '/following'
+    }
+  ]
+
+  return (
+    <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
+      <NavBar />
+      <div className='flex-grow w-full py-9'>
+        <div className='mx-auto flex' style={{ maxWidth: '1040px' }}>
+          <div className='flex-auto'>
+              <UserProfileHeader profile={profile} />
+              <ContentTabs
+                tabs={tabs}
+              />
+              <UserProfileDatasetList
+                paginatedResults={path === '/' ? paginatedDatasetResults : paginatedFollowingResults}
+                userProfileParams={userProfileParams}
+                onParamsUpdate={updateQueryParams}
+              />
+            </div>
+          <div className=' flex-none pl-8' style={{ width: '366px' }}>
+            <ContentBox>
+              Sidebar
+            </ContentBox>
+          </div>
+        </div>
+      </div>
+      <div className='bg-white flex-shrink-0'>
+        <Footer />
+      </div>
+    </div>
+  )
+}
+
+export default UserProfile;

--- a/frontend/src/features/userProfile/UserProfileDatasetList.tsx
+++ b/frontend/src/features/userProfile/UserProfileDatasetList.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import ContentBox from '../../chrome/ContentBox'
+import PageControl from '../../chrome/PageControl'
+import DropdownMenu from '../../chrome/DropdownMenu'
+import DatasetList from '../../chrome/DatasetList'
+import Icon from '../../chrome/Icon'
+import {
+  UserProfileDatasetListParams,
+  CleanUserProfileDatasetListParams
+} from '../../qri/userProfile'
+import { PaginatedResults } from './state/userProfileState'
+import { PageChangeObject } from '../../chrome/PageControl'
+
+export interface UserProfileDatasetListProps {
+  paginatedResults: PaginatedResults
+  userProfileParams: UserProfileDatasetListParams
+  onParamsUpdate: (newQueryParams: UserProfileDatasetListParams) => void
+}
+
+const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
+  paginatedResults,
+  userProfileParams,
+  onParamsUpdate
+}) => {
+  const {
+    results,
+    pageInfo,
+  } = paginatedResults
+
+  const {
+    page,
+  } = pageInfo
+
+  const {
+    sort
+  } = userProfileParams
+
+  const menuItems = [
+    {
+      text: 'Dataset Name',
+      active: sort === 'name',
+      onClick: () => { onParamsUpdate({ sort: 'name' }) }
+    },
+    {
+      text: 'Recently Updated',
+      active: sort === 'recentlyupdated',
+      onClick: () => { onParamsUpdate({ sort: 'recentlyupdated' }) }
+    }
+  ]
+
+  const totalPages = Math.ceil( pageInfo.resultCount / pageInfo.pageSize )
+
+  // handle page change from PageControl
+  const handlePageChange = ({ selected: pageIndex }: PageChangeObject) => {
+    onParamsUpdate({ page: pageIndex + 1 })
+  }
+
+  return (
+    <>
+      <ContentBox className='mb-6 rounded-tl-none pt-5 pb-5 pr-5 pl-5'>
+        <div className='flex items-center justify-between border-b pb-5'>
+          <div className='text-qrigray'>
+            Page {page} of {totalPages}
+          </div>
+          <DropdownMenu items={menuItems} className='ml-8'>
+            <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
+              Sort By
+              <Icon icon='caretDown' size='2xs' className='ml-3' />
+            </div>
+          </DropdownMenu>
+        </div>
+        <DatasetList datasets={results} />
+      </ContentBox>
+      <PageControl
+        pageInfo={pageInfo}
+        queryParams={CleanUserProfileDatasetListParams(userProfileParams)}
+        onPageChange={handlePageChange}
+      />
+    </>
+  )
+}
+
+export default UserProfileDatasetList

--- a/frontend/src/features/userProfile/UserProfileHeader.tsx
+++ b/frontend/src/features/userProfile/UserProfileHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import format from 'date-fns/format'
+import fromUnixTime from 'date-fns/fromUnixTime'
+
+import ContentBox from '../../chrome/ContentBox'
+import IconLink from '../../chrome/IconLink'
+
+import { UserProfile } from '../../qri/userProfile'
+
+
+export interface UserProfileHeaderProps {
+  profile: UserProfile
+}
+
+const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile }) => {
+  const {
+    profile: avatarUrl,
+    name,
+    username,
+    description,
+    created
+  } = profile
+
+  return (
+    <ContentBox className='flex mt-8 mb-6'>
+      <div className='relative'>
+        <div className='rounded-full inline-block bg-cover absolute -top-14' style={{
+          height: '100px',
+          width: '100px',
+          backgroundImage: `url(${avatarUrl})`
+        }}></div>
+      </div>
+      <div className='flex-grow ml-32'>
+        <div className='text-qrinavy text-xl font-medium mb-1'>{name || username}</div>
+        <div className='text-qrinavy text-sm'>{username}</div>
+        <div className='text-qrigray-400 text-sm'>{description || 'I\'m a Qri user'}</div>
+      </div>
+      <div className='flex flex-shrink-0 ml-4 flex-col justify-end items-end'>
+        <div className='flex justify-end mb-2'>
+          <IconLink icon='github' link='https://github.com/chriswhong' />
+          <IconLink icon='twitter' link='https://twitter.com/chriswhong' />
+          <IconLink icon='globe' link='https://chriswhong.com' />
+        </div>
+        <div className='text-xs text-qrigray-400'>Qri user since {format(fromUnixTime(created), 'yyyy')}</div>
+      </div>
+    </ContentBox>
+  )
+}
+
+export default UserProfileHeader

--- a/frontend/src/features/userProfile/state/userProfileActions.ts
+++ b/frontend/src/features/userProfile/state/userProfileActions.ts
@@ -1,0 +1,78 @@
+import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
+
+import { NewSearchResult } from '../../../qri/search'
+import { UserProfileDatasetListParams } from '../../../qri/userProfile'
+
+export const searchPageSizeDefault = 25
+
+export function loadUserProfile(username: string): ApiActionThunk {
+  return async (dispatch, getState) => {
+    return dispatch(fetchUserProfile(username))
+  }
+}
+
+export function loadUserProfileDatasets(username: string, userProfileParams: UserProfileDatasetListParams): ApiActionThunk {
+  return async (dispatch, getState) => {
+    return dispatch(fetchUserProfileDatasets(username, userProfileParams))
+  }
+}
+
+export function loadUserProfileFollowing(username: string, userProfileParams: UserProfileDatasetListParams): ApiActionThunk {
+  return async (dispatch, getState) => {
+    return dispatch(fetchUserProfileFollowing(username, userProfileParams))
+  }
+}
+
+function fetchUserProfile (username: string): ApiAction {
+  return {
+    type: 'userprofile',
+    [CALL_API]: {
+      endpoint: `identity/profile/${username}`,
+      method: 'GET',
+    }
+  }
+}
+
+const mapSearchResults = (results: any[]) => {
+  return results.map((d) => NewSearchResult(d))
+}
+
+const mapFrontendParams = (frontendParams: UserProfileDatasetListParams) => {
+  // map frontend 'sort' param to backend 'orderBy'
+  return {
+    orderBy: frontendParams.sort === 'recentlyupdated' ? 'created,desc' : 'name,asc'
+  }
+}
+
+function fetchUserProfileDatasets (username: string, userProfileParams: UserProfileDatasetListParams): ApiAction {
+
+  return {
+    type: 'userprofiledatasets',
+    [CALL_API]: {
+      endpoint: `dataset_summary/${username}`,
+      method: 'GET',
+      query: mapFrontendParams(userProfileParams),
+      pageInfo: {
+        page: userProfileParams.page,
+        pageSize: userProfileParams.pageSize
+      },
+      map: mapSearchResults
+    }
+  }
+}
+
+function fetchUserProfileFollowing (username: string, userProfileParams: UserProfileDatasetListParams): ApiAction {
+  return {
+    type: 'userprofilefollowing',
+    [CALL_API]: {
+      endpoint: `follow/${username}`,
+      method: 'GET',
+      query: mapFrontendParams(userProfileParams),
+      pageInfo: {
+        page: userProfileParams.page,
+        pageSize: userProfileParams.pageSize
+      },
+      map: mapSearchResults
+    }
+  }
+}

--- a/frontend/src/features/userProfile/state/userProfileState.ts
+++ b/frontend/src/features/userProfile/state/userProfileState.ts
@@ -1,0 +1,94 @@
+import { createReducer } from '@reduxjs/toolkit'
+
+import { RootState } from '../../../store/store'
+import { PageInfo, SearchResult } from '../../../qri/search'
+import { UserProfile, NewUserProfile } from '../../../qri/userProfile'
+
+export const selectUserProfile = (state: RootState): UserProfile => state.userProfile.profile
+export const selectUserProfileDatasets = (state: RootState): PaginatedResults => state.userProfile.datasets
+export const selectUserProfileFollowing = (state: RootState): PaginatedResults => state.userProfile.following
+
+export interface PaginatedResults {
+  results: SearchResult[]
+  pageInfo: PageInfo
+  loading: boolean
+}
+
+const NewPaginatedResults = () => {
+  return {
+    results: [],
+    pageInfo: {
+      nextUrl: '',
+      page: 0,
+      pageSize: 0,
+      pageCount: 0,
+      prevUrl: '',
+      resultCount: 0
+    },
+    loading: false
+  }
+}
+
+export interface UserProfileState {
+  profile: UserProfile
+  loading: boolean
+  datasets: {
+    results: SearchResult[]
+    pageInfo: PageInfo
+    loading: boolean
+  }
+  following: {
+    results: SearchResult[]
+    pageInfo: PageInfo
+    loading: boolean
+  }
+}
+
+const initialState: UserProfileState = {
+  profile: NewUserProfile(),
+  loading: false,
+  datasets: NewPaginatedResults(),
+  following: NewPaginatedResults()
+}
+
+export const userProfileReducer = createReducer(initialState, {
+  'API_USERPROFILE_REQUEST': (state: UserProfileState, action) => {
+    state.loading = true
+  },
+  'API_USERPROFILE_SUCCESS': (state: UserProfileState, action) => {
+    state.profile = action.payload.data
+    state.loading = false
+  },
+  'API_USERPROFILE_FAILURE': (state: UserProfileState) => {
+    state.loading = false
+  },
+
+  'API_USERPROFILEDATASETS_REQUEST': (state: UserProfileState, action) => {
+    state.datasets.loading = true
+  },
+  'API_USERPROFILEDATASETS_SUCCESS': (state: UserProfileState, action) => {
+    state.datasets.results = action.payload.data
+    state.datasets.pageInfo = action.payload.pagination
+    state.datasets.loading = false
+  },
+  'API_USERPROFILEDATASETS_FAILURE': (state: UserProfileState) => {
+    state.datasets.loading = false
+  },
+
+  'API_USERPROFILEFOLLOWING_REQUEST': (state: UserProfileState, action) => {
+    state.following.loading = true
+  },
+  'API_USERPROFILEFOLLOWING_SUCCESS': (state: UserProfileState, action) => {
+    state.following.results = action.payload.data
+    state.following.pageInfo = {
+      // TODO(chriswhong): this API doesn't return resultCount,
+      // this will ensure it exists in the frontend in development
+      ...action.payload.pagination,
+      resultCount: state.following?.results ? state.following.results.length : 0
+    }
+    state.following.loading = false
+  },
+  'API_USERPROFILEFOLLOWING_FAILURE': (state: UserProfileState) => {
+    state.following.loading = false
+  },
+})

--- a/frontend/src/qri/search.ts
+++ b/frontend/src/qri/search.ts
@@ -12,17 +12,32 @@ export interface PageInfo {
 export interface SearchParams {
   q: string
   sort: '' | 'name' | 'recentlyupdated'
-  page?: number
-  pagesize?: number
+  page: number
+  pageSize: number
 }
+
+const DEFAULT_SORT = 'recentlyupdated'
+const DEFAULT_PAGE = 1
+const DEFAULT_PAGESIZE = 25
 
 export function NewSearchParams(d: Record<string,any>): SearchParams {
   return {
     q: d.q || '',
-    sort: d.sort || 'recentlyupdated',
-    page: d.page,
-    pagesize: d.pagesize,
+    sort: d.sort || DEFAULT_SORT,
+    page: d.page || DEFAULT_PAGE,
+    pageSize: d.pageSize || DEFAULT_PAGESIZE
   }
+}
+
+export function CleanSearchParams(d: SearchParams): Record<string, any> {
+  const cleanParams:any = {
+    q: d.q
+  }
+  if (d.sort !== DEFAULT_SORT) { cleanParams.sort = d.sort }
+  if (d.page !== DEFAULT_PAGE) { cleanParams.page = d.page }
+  if (d.pageSize !== DEFAULT_PAGESIZE) { cleanParams.pageSize = d.pageSize }
+
+  return cleanParams
 }
 
 export interface SearchResult extends Dataset {

--- a/frontend/src/qri/userProfile.ts
+++ b/frontend/src/qri/userProfile.ts
@@ -1,0 +1,79 @@
+
+export interface UserProfile {
+  profile_id: string
+  PrivKey: string
+  username: string
+  created: number
+  updated: number
+  type: string
+  email: string
+  name: string
+  description: string
+  home_url: string
+  color: string
+  thumb: string
+  profile: string
+  poster: string
+  twitter: string
+  PeerIDs: string[]
+  NetworkAddrs: string[]
+  id: string
+  currentKey: string
+  EmailConfirmed: boolean
+  isAdmin: boolean
+}
+
+export const NewUserProfile = () => {
+  return {
+    profile_id: '',
+    PrivKey: '',
+    username: '',
+    created: 0,
+    updated: 0,
+    type: '',
+    email: '',
+    name: '',
+    description: '',
+    home_url: '',
+    color: '',
+    thumb: '',
+    profile: '',
+    poster: '',
+    twitter: '',
+    PeerIDs: [],
+    NetworkAddrs: [],
+    id: '',
+    currentKey: '',
+    EmailConfirmed: false,
+    isAdmin: false
+  }
+}
+
+export interface UserProfileDatasetListParams {
+  sort: 'name' | 'recentlyupdated'
+  page: number
+  pageSize: number
+}
+
+const DEFAULT_SORT = 'recentlyupdated'
+const DEFAULT_PAGE = 1
+const DEFAULT_PAGESIZE = 25
+
+// returns a fully populated UserProfileDatasetListParams by adding defaults for undefined values
+export function NewUserProfileDatasetListParams(d: any): UserProfileDatasetListParams {
+  return {
+    sort: d.sort || DEFAULT_SORT,
+    page: d.page || DEFAULT_PAGE,
+    pageSize: d.pageSize || DEFAULT_PAGESIZE
+  }
+}
+
+// returns only the non-default values, useful for excluding default values from query parameter strings
+export function CleanUserProfileDatasetListParams(d: UserProfileDatasetListParams): Record<string, any> {
+  const cleanParams:any = {}
+  if (d.sort !== DEFAULT_SORT) { cleanParams.sort = d.sort }
+  if (d.page !== DEFAULT_PAGE) { cleanParams.page = d.page }
+  if (d.pageSize !== DEFAULT_PAGESIZE) { cleanParams.pageSize = d.pageSize }
+
+  return cleanParams
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -17,6 +17,7 @@ import Collection from './features/collection/Collection';
 import Dashboard from './features/dashboard/Dashboard';
 import DatasetRoutes from './features/dataset/DatasetRoutes';
 import { AnonUser, selectSessionUser } from './features/session/state/sessionState'
+import UserProfile from './features/userProfile/UserProfile'
 
 const PrivateRoute: React.FC<any>  = ({ path, children }) => {
   const user = useSelector(selectSessionUser)
@@ -52,6 +53,10 @@ export default function Routes () {
 
         <Route path='/notifications'><NotificationList /></Route>
         <Route path='/notification_settings'><NotificationSettings /></Route>
+
+        <Route path='/:username' exact><UserProfile /></Route>
+        <Route path='/:username/following'><UserProfile path='/following' /></Route>
+
 
         <Route path='/'>
           {

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -20,6 +20,7 @@ import { sessionReducer, SessionState, AnonUser } from '../features/session/stat
 import { commitsReducer, CommitsState } from '../features/commits/state/commitState';
 import { datasetEditsReducer, DatasetEditsState } from '../features/dataset/state/editDatasetState';
 import { WebsocketState, websocketReducer } from '../features/websocket/state/websocketState';
+import { UserProfileState, userProfileReducer } from '../features/userProfile/state/userProfileState'
 
 export const history = createBrowserHistory()
 
@@ -36,6 +37,7 @@ export interface RootState {
   search: SearchState
   session: SessionState
   transfers: RemoteEvents
+  userProfile: UserProfileState
   workflow: WorkflowState
   edits: DatasetEditsState
   websocket: WebsocketState
@@ -57,6 +59,7 @@ const rootReducer = (h: History) => combineReducers({
   search: searchReducer,
   session: sessionReducer,
   transfers: transfersReducer,
+  userProfile: userProfileReducer,
   workflow: workflowReducer,
   edits: datasetEditsReducer,
   websocket: websocketReducer

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -116,7 +116,8 @@ module.exports = {
       fontWeight: ['hover'],
       cursor: ['hover'],
       borderWidth: ['last'],
-      margin: ['last']
+      margin: ['last'],
+      padding: ['first', 'last']
     },
   },
   plugins: [


### PR DESCRIPTION
Adds user profile routes with two dataset lists:
- user datasets `/:username`
- datasets the user is following `/:username/following`

Both lists share query params of type `UserProfileParams`.  Introduces a new pattern for query params:

1) on mount or update, read query params from URL
2) convert params from the URL into valid `UserProfileParams` by adding default values
3) fetch data using `UserProfileParams`
4) when user interacts with pagination, query, or sort, etc, modify the `UserProfileParams`
5) update the URL with a "cleaned" version of `UserProfileParams`, (excluding default values)
6) go to 1

Updates Search to use the same pattern for query params.

TODO:
- improve loading states
- add a sticky header on scroll
- handle no results (e.g. user doesn't follow any datasets)