### PR TITLE
History improvements

### DIFF
--- a/frontend/src/features/commits/DatasetCommits.tsx
+++ b/frontend/src/features/commits/DatasetCommits.tsx
@@ -22,8 +22,15 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
   const commits = useSelector(newDatasetCommitsSelector(qriRef))
   const loading = useSelector(selectDatasetCommitsLoading)
   const editable = useSelector(selectSessionUserCanEditDataset)
-  const { fs, hash } = useParams()
+  let { fs, hash } = useParams()
+
+  // if there are no fs/hash in the URL, set it to the fs/hash of the latest commit
+  if ((!fs && !hash) && commits.length) {
+    [,fs, hash] = commits[0].path.split('/')
+  }
+
   const path = `/${fs}/${hash}`
+
 
   useEffect(() => {
     dispatch(loadDatasetCommits(newQriRef({ username: qriRef.username, name: qriRef.name })))
@@ -33,7 +40,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
     <div className='pt-4 overflow-y-hidden flex flex-col text-xs flex-shrink-0' style={{ width: '325px'}}>
       <header className='flex-grow-0 mb-4'>
         <h3 className='text-2xl text-qrinavy-500 font-black'>History</h3>
-        <div className='text-xs text-gray-400 tracking-wider'>{commits.length === 1 ? 'version' : 'versions'}</div>
+        <div className='text-xs text-gray-400 tracking-wider'>{commits.length} {commits.length === 1 ? 'version' : 'versions'}</div>
       </header>
       <ul className='block flex-grow overflow-y-auto pb-40 pr-8'>
         <HistorySearchBox />

--- a/frontend/src/features/commits/state/commitActions.ts
+++ b/frontend/src/features/commits/state/commitActions.ts
@@ -17,8 +17,11 @@ function fetchDatasetCommits(qriRef: QriRef): ApiAction {
     type: 'dataset_commits',
     qriRef,
     [CALL_API]: {
-      endpoint: `history/${qriRef.username}/${qriRef.name}`,
-      method: 'GET',
+      endpoint: `history/`,
+      method: 'POST',
+      body: {
+        ref: `${qriRef.username}/${qriRef.name}`
+      },
       map: mapCommits
     }
   }

--- a/frontend/src/features/dsComponents/ComponentHeader.tsx
+++ b/frontend/src/features/dsComponents/ComponentHeader.tsx
@@ -1,45 +1,9 @@
 import React from 'react'
 
-import { ComponentName, ComponentStatus } from '../../qri/dataset'
-import StatusDot from '../../chrome/StatusDot'
-import displayProps from './displayProps'
-import Icon from '../../chrome/Icon'
-
-export interface ComponentHeaderProps {
-  componentName: ComponentName
-  status?: ComponentStatus
-}
-
-const ComponentHeader: React.FC<ComponentHeaderProps> = ({
-  componentName,
-  status
-}) => {
-
-  // const qriRef = qriRefFromRoute(props)
-  // const { component = '' } = qriRef
-  // const { path: routePath } = useRouteMatch()
-  // const statusInfo = useSelector((state: Store) => {
-  //   if (isEditPath(routePath)) {
-  //     return selectStatusInfoFromMutations(state, component as SelectedComponent)
-  //   } else {
-  //     return selectDatasetStatusInfo(state, component as SelectedComponent)
-  //   }
-  // })
-
-  const { displayName, icon, tooltip } = displayProps[componentName]
+const ComponentHeader: React.FC<{}> = ({ children }) => {
   return (
-    <div className='flex-grow text-sm'>
-      <div className='flex text-sm items-center px-3 py-4'>
-        <div className='w-4 mr-2 text-center' data-tip={tooltip}>
-          <Icon icon={icon} size='sm'/>
-        </div>
-        <div className='font-bold'>
-          {displayName}
-        </div>
-      </div>
-      <div className='flex-none'>
-        {status && <StatusDot status={status} />}
-      </div>
+    <div className='flex-grow text-sm px-8 py-3 border-b'>
+      {children}
     </div>
   )
 }

--- a/frontend/src/features/dsComponents/DatasetComponent.tsx
+++ b/frontend/src/features/dsComponents/DatasetComponent.tsx
@@ -13,15 +13,12 @@ import Readme from './readme/Readme'
 export interface DatasetComponentProps {
   dataset: Dataset
   componentName: ComponentName
-  noHeader?: boolean
 }
 
 const DatasetComponent: React.FC<DatasetComponentProps> = ({
   dataset,
   componentName,
-  noHeader = false
 }) => {
-
   let component: JSX.Element
   switch (componentName) {
     case 'body':
@@ -48,14 +45,14 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
 
   return (
     <div
-      className={classNames(
-        'rounded-md bg-white w-full overflow-auto', {
-        'rounded-tl-none' : noHeader,
-        'my-6': !noHeader
-      })}
+      className='rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex flex-col'
     >
-      {!noHeader && <ComponentHeader componentName={componentName} />}
-      {component}
+      <ComponentHeader>
+        &nbsp;
+      </ComponentHeader>
+      <div className='overflow-auto flex-grow'>
+        {component}
+      </div>
     </div>
   )
 }

--- a/frontend/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/frontend/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -40,7 +40,6 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
       <DatasetComponent
         dataset={dataset}
         componentName={selectedComponent}
-        noHeader
       />
     </div>
   )

--- a/frontend/src/features/dsComponents/readme/Readme.tsx
+++ b/frontend/src/features/dsComponents/readme/Readme.tsx
@@ -43,7 +43,7 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
     <div className='h-full w-full'>
       <div
         // use "editor-preview" class to piggie-back off the simplemde styling
-        className="markdown-body"
+        className="markdown-body px-8 py-6"
         ref={refCallback}
       >loading...
       </div>


### PR DESCRIPTION
- highlights the latest commit when landing on the history view Closes #173 
- changes the history API call from `GET` to `POST`, restoring the history list
- adds an empty header to component tabs, to be used later
- adds padding to improve the display of the readme tab in history view