### PR TITLE
feat: clean search results, add loading state to search and profile lists

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "puppeteer": "^5.5.0",
     "query-string": "7.0.0",
     "react": "^17.0.1",
+    "react-content-loader": "6.0.3",
     "react-data-table-component": "^7.0.0-alpha-1",
     "react-dom": "^17.0.1",
     "react-json-view": "^1.20.4",

--- a/frontend/src/chrome/DatasetList.tsx
+++ b/frontend/src/chrome/DatasetList.tsx
@@ -1,18 +1,36 @@
 import React from 'react'
 
 import SearchResultItem from '../features/search/SearchResultItem'
+import SearchResultItemSkeleton from '../features/search/SearchResultItemSkeleton'
+
 import { SearchResult } from '../qri/search'
 
 export interface DatasetListProps {
   datasets: SearchResult[]
+  loading?: boolean
 }
 
-const DatasetList: React.FC<DatasetListProps> = ({ datasets }) => (
-  <>
-    {
-      datasets.map((dataset) => <SearchResultItem key={`${dataset.peername}/${dataset.name}`} dataset={dataset} />)
-    }
-  </>
-)
+const DatasetList: React.FC<DatasetListProps> = ({ datasets, loading=false }) => {
+  // if loading, return 5 searchResultItems in loading state
+  if (loading) {
+    return (
+      <>
+        <SearchResultItem loading />
+        <SearchResultItem loading />
+        <SearchResultItem loading />
+        <SearchResultItem loading />
+        <SearchResultItem loading />
+      </>
+    )
+  }
+
+  return (
+    <>
+      {
+        datasets.map((dataset) => <SearchResultItem key={`${dataset.peername}/${dataset.name}`} dataset={dataset} />)
+      }
+    </>
+  )
+}
 
 export default DatasetList

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -2,9 +2,14 @@ import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import queryString from 'query-string'
+import ContentLoader from 'react-content-loader'
 
 import { loadSearchResults } from './state/searchActions'
-import { selectSearchResults, selectSearchPageInfo } from './state/searchState'
+import {
+  selectSearchResults,
+  selectSearchPageInfo,
+  selectSearchLoading
+} from './state/searchState'
 import NavBar from '../navbar/NavBar';
 import BigSearchBox from './BigSearchBox';
 import PageControl, { PageChangeObject } from '../../chrome/PageControl'
@@ -26,6 +31,7 @@ const Search: React.FC<{}> = () => {
   // get search results and accompanying pageInfo from the store
   const searchResults = useSelector(selectSearchResults)
   const pageInfo = useSelector(selectSearchPageInfo)
+  const loading = useSelector(selectSearchLoading)
 
   const searchParams = NewSearchParams(queryString.parse(search))
   const { q, page, sort } = searchParams
@@ -96,17 +102,35 @@ const Search: React.FC<{}> = () => {
       <NavBar showSearch={false} />
       <div className='flex-grow w-full py-9'>
         <div className='w-4/5 max-w-screen-lg mx-auto mb-10'>
-          <div className='flex items-center'>
-            <div className='flex-grow'>
-              <div className='text-qrinavy text-3xl font-black mb-2'>Dataset Search</div>
-              <div className='text-qrigray-400 text-sm mb-4'>{pageInfo.resultCount} datasets found matching '{q}'</div>
-            </div>
-            <DropdownMenu items={menuItems} className='ml-8'>
-              <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
-                Sort By
-                <Icon icon='caretDown' size='2xs' className='ml-3' />
-              </div>
-            </DropdownMenu>
+        <div className='text-qrinavy text-3xl font-black mb-2'>Dataset Search</div>
+          <div className='flex items-center mb-2 h-8'>
+            {searchResults.length > 0 ? (
+              <>
+                <div className='flex-grow'>
+                  <div className='text-qrigray-400 text-sm '>
+                    { loading ? (
+                      <ContentLoader
+                        width={300}
+                        height={20}
+                      >
+                        <rect y="0" width="300" height="18" rx="6"/>
+                      </ContentLoader>
+                    ) : (
+                      <>{pageInfo.resultCount} datasets found matching '{q}'</>
+                    )}
+                  </div>
+                </div>
+                <DropdownMenu items={menuItems} className='ml-8'>
+                  <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
+                    Sort By
+                    <Icon icon='caretDown' size='2xs' className='ml-3' />
+                  </div>
+                </DropdownMenu>
+              </>
+            ):(
+              <>&nbsp;</>
+            )}
+
           </div>
           <BigSearchBox onSubmit={handleSearchSubmit} value={q}/>
         </div>
@@ -117,6 +141,7 @@ const Search: React.FC<{}> = () => {
               <ContentBox className='mb-6'>
                 <DatasetList
                   datasets={searchResults}
+                  loading={loading}
                 />
               </ContentBox>
               <PageControl

--- a/frontend/src/features/search/SearchResultItem.tsx
+++ b/frontend/src/features/search/SearchResultItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import numeral from 'numeral'
 import { Link } from 'react-router-dom'
+import ContentLoader from 'react-content-loader'
 
 import DatasetInfoItem from '../dataset/DatasetInfoItem'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
@@ -8,50 +9,59 @@ import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import { SearchResult } from '../../qri/search'
 
 interface SearchResultItemProps {
-  dataset: SearchResult
+  dataset?: SearchResult
+  loading?: boolean
 }
 
-const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset }) => {
-    const {
-      peername,
-      name,
-      meta,
-      commit,
-      structure,
-      stats,
-      followStats
-    } = dataset
-    const datasetReference = `${peername}/${name}`
+const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset, loading=false }) => {
+    let itemContent
 
-    const title = meta?.title || datasetReference
+    if (loading) {
+      itemContent = (
+        <ContentLoader viewBox="0 0 780 126">
+          <rect width="448" height="22" rx="6"/>
+          <rect y="30" width="401" height="29" rx="6"/>
+          <rect y="73" width="674" height="17" rx="6"/>
+          <rect y="101" width="420" height="25" rx="6"/>
+        </ContentLoader>
+      )
+    } else if (dataset) {
+      const {
+        peername,
+        name,
+        meta,
+        commit,
+        structure,
+        stats,
+        followStats
+      } = dataset
 
-    const description = meta?.description
+      const humanRef = `${peername}/${name}`
+      const title = meta?.title || humanRef
+      const timestamp = new Date(commit.timestamp)
 
-    const timestamp = new Date(commit.timestamp)
+      itemContent = (
+        <>
+          <Link to={`/ds/${humanRef}`}><div className='text-sm text-gray-400 relative flex items-baseline group hover:text mb-2 font-mono hover:underline'>{humanRef}</div></Link>
+          <Link to={`/ds/${humanRef}`}><div className='text-xl text-qrinavy-500 font-medium hover:text hover:underline mb-3'>{title}</div></Link>
+          <div className='text-sm text-qrigray hover:text line-clamp-3 mb-3'>{meta?.description || 'No Description'}</div>
+          <div className='flex items-center flex-wrap'>
+            <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={timestamp} />} />
+            { meta?.structure?.length && <DatasetInfoItem icon='disk' label={numeral(meta.structure.length).format('0.0b')} />}
+            {/* <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' /> TODO(chriswhong): enable when we have automation info */}
+            {/* <DatasetInfoItem icon='commit' label={`17 versions`} /> TODO(chriswhong): enable when we have commit info */}
+            { stats?.downloadCount > 0 && <DatasetInfoItem icon='download' label={`${stats.downloadCount} download${(stats.downloadCount !== 1) ? 's' : ''}`} /> }
+            { followStats.followCount > 0 && <DatasetInfoItem icon='follower' label={`${followStats.followCount} follower${(followStats.followCount !== 1) ? 's' : ''}`} /> }
 
-    const userIcon = (
-      <div className='rounded-xl inline-block mr-1 bg-cover flex-shrink-0' style={{
-        height: '18px',
-        width: '18px',
-        backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
-      }} />
-    )
+            <DatasetInfoItem icon='lock' label='public' />
+          </div>
+        </>
+      )
+    }
 
     return (
-      <div key={datasetReference} className='pt-5 pb-6 border-b border-qrigray-200 last:border-b-0 first:pt-0 last:pb-0'>
-        <Link to={`/ds/${datasetReference}`}><div className='text-sm text-gray-400 relative flex items-baseline group hover:text mb-2 font-mono hover:underline'>{datasetReference}</div></Link>
-        <Link to={`/ds/${datasetReference}`}><div className='text-xl text-qrinavy-500 font-medium hover:text hover:underline mb-3'>{title}</div></Link>
-        <div className='text-sm text-qrigray hover:text line-clamp-3 mb-3'>{description || 'No Description'}</div>
-        <div className='flex items-center flex-wrap'>
-          <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={timestamp} />} />
-          <DatasetInfoItem icon={userIcon} label={peername} />
-          <DatasetInfoItem icon='disk' label={numeral(structure.length).format('0.0b')} />
-          {/* <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' /> TODO(chriswhong): enable when we have automation info */}
-          <DatasetInfoItem icon='commit' label={`17 versions`} />
-          <DatasetInfoItem icon='download' label={`${stats.downloadCount} download${(stats.downloadCount !== 1) ? 's' : ''}`} />
-          <DatasetInfoItem icon='follower' label={`${followStats.followCount} follower${(followStats.followCount !== 1) ? 's' : ''}`} />
-          <DatasetInfoItem icon='lock' label='public' />
-        </div>
+      <div className='pt-5 pb-6 border-b border-qrigray-200 last:border-b-0 first:pt-0 last:pb-0'>
+        {itemContent}
       </div>
     )
   }

--- a/frontend/src/features/search/state/searchState.ts
+++ b/frontend/src/features/search/state/searchState.ts
@@ -5,6 +5,8 @@ import { SearchResult, PageInfo } from '../../../qri/search'
 
 export const selectSearchResults = (state: RootState): SearchResult[] => state.search.results
 export const selectSearchPageInfo = (state: RootState): PageInfo => state.search.pageInfo
+export const selectSearchLoading = (state: RootState): boolean => state.search.loading
+
 
 export interface SearchState {
   results: SearchResult[]

--- a/frontend/src/features/userProfile/UserProfile.tsx
+++ b/frontend/src/features/userProfile/UserProfile.tsx
@@ -10,6 +10,7 @@ import {
 } from './state/userProfileActions'
 import {
   selectUserProfile,
+  selectUserProfileLoading,
   selectUserProfileDatasets,
   selectUserProfileFollowing,
 } from './state/userProfileState'
@@ -34,6 +35,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
   const history = useHistory()
 
   const profile = useSelector(selectUserProfile)
+  const loading = useSelector(selectUserProfileLoading)
 
   const paginatedDatasetResults = useSelector(selectUserProfileDatasets)
   const paginatedFollowingResults = useSelector(selectUserProfileFollowing)
@@ -101,7 +103,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
       <div className='flex-grow w-full py-9'>
         <div className='mx-auto flex' style={{ maxWidth: '1040px' }}>
           <div className='flex-auto'>
-              <UserProfileHeader profile={profile} />
+              <UserProfileHeader profile={profile} loading={loading} />
               <ContentTabs
                 tabs={tabs}
               />

--- a/frontend/src/features/userProfile/UserProfileDatasetList.tsx
+++ b/frontend/src/features/userProfile/UserProfileDatasetList.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ContentLoader from 'react-content-loader'
 
 import ContentBox from '../../chrome/ContentBox'
 import PageControl from '../../chrome/PageControl'
@@ -26,6 +27,7 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
   const {
     results,
     pageInfo,
+    loading
   } = paginatedResults
 
   const {
@@ -61,7 +63,19 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
       <ContentBox className='mb-6 rounded-tl-none pt-5 pb-5 pr-5 pl-5'>
         <div className='flex items-center justify-between border-b pb-5'>
           <div className='text-qrigray'>
-            Page {page} of {totalPages}
+            {
+              loading ? (
+                <ContentLoader
+                  width={100}
+                  height={20}
+                >
+                  <rect y="0" width="100" height="18" rx="6"/>
+                </ContentLoader>
+              ) : (
+                <>Page {page} of {totalPages}</>
+              )
+            }
+
           </div>
           <DropdownMenu items={menuItems} className='ml-8'>
             <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
@@ -70,7 +84,7 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
             </div>
           </DropdownMenu>
         </div>
-        <DatasetList datasets={results} />
+        <DatasetList datasets={results} loading={loading} />
       </ContentBox>
       <PageControl
         pageInfo={pageInfo}

--- a/frontend/src/features/userProfile/UserProfileHeader.tsx
+++ b/frontend/src/features/userProfile/UserProfileHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import format from 'date-fns/format'
 import fromUnixTime from 'date-fns/fromUnixTime'
+import ContentLoader from 'react-content-loader'
 
 import ContentBox from '../../chrome/ContentBox'
 import IconLink from '../../chrome/IconLink'
@@ -10,9 +11,10 @@ import { UserProfile } from '../../qri/userProfile'
 
 export interface UserProfileHeaderProps {
   profile: UserProfile
+  loading: boolean
 }
 
-const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile }) => {
+const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile, loading = false }) => {
   const {
     profile: avatarUrl,
     name,
@@ -31,17 +33,35 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile }) => {
         }}></div>
       </div>
       <div className='flex-grow ml-32'>
-        <div className='text-qrinavy text-xl font-medium mb-1'>{name || username}</div>
-        <div className='text-qrinavy text-sm'>{username}</div>
-        <div className='text-qrigray-400 text-sm'>{description || 'I\'m a Qri user'}</div>
+        { loading ? (
+          <ContentLoader
+            width={300}
+            height={80}
+          >
+            <rect y="0" width="300" height="18" rx="6"/>
+            <rect y="30" width="260" height="18" rx="6"/>
+            <rect y="60" width="300" height="18" rx="6"/>
+
+          </ContentLoader>
+        ) : (
+          <>
+            <div className='text-qrinavy text-xl font-medium mb-1'>{name || username}</div>
+            <div className='text-qrinavy text-sm'>{username}</div>
+            <div className='text-qrigray-400 text-sm'>{description || 'I\'m a Qri user'}</div>
+          </>
+        )}
       </div>
       <div className='flex flex-shrink-0 ml-4 flex-col justify-end items-end'>
-        <div className='flex justify-end mb-2'>
-          <IconLink icon='github' link='https://github.com/chriswhong' />
-          <IconLink icon='twitter' link='https://twitter.com/chriswhong' />
-          <IconLink icon='globe' link='https://chriswhong.com' />
-        </div>
-        <div className='text-xs text-qrigray-400'>Qri user since {format(fromUnixTime(created), 'yyyy')}</div>
+        { !loading && (
+          <>
+            <div className='flex justify-end mb-2'>
+              <IconLink icon='github' link='https://github.com/chriswhong' />
+              <IconLink icon='twitter' link='https://twitter.com/chriswhong' />
+              <IconLink icon='globe' link='https://chriswhong.com' />
+            </div>
+            <div className='text-xs text-qrigray-400'>Qri user since {format(fromUnixTime(created), 'yyyy')}</div>
+          </>
+        )}
       </div>
     </ContentBox>
   )

--- a/frontend/src/features/userProfile/state/userProfileState.ts
+++ b/frontend/src/features/userProfile/state/userProfileState.ts
@@ -5,6 +5,7 @@ import { PageInfo, SearchResult } from '../../../qri/search'
 import { UserProfile, NewUserProfile } from '../../../qri/userProfile'
 
 export const selectUserProfile = (state: RootState): UserProfile => state.userProfile.profile
+export const selectUserProfileLoading = (state: RootState): boolean => state.userProfile.loading
 export const selectUserProfileDatasets = (state: RootState): PaginatedResults => state.userProfile.datasets
 export const selectUserProfileFollowing = (state: RootState): PaginatedResults => state.userProfile.following
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2884,7 +2884,7 @@
   dependencies:
     "@types/react" "^16"
 
-"@types/react-paginate@7.1.3":
+"@types/react-paginate@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/react-paginate/-/react-paginate-7.1.0.tgz#e209fe9735f0a68633c82c419ba238133b3b31a1"
   integrity sha512-P6yboMnZtML4KyglK2p7Wlg+sIkhNUneES+jjFqPeQkjuM93X5QjhdKIW2Ayc7csVvx1pdC9v5R+hQ9KjcYBEQ==
@@ -11724,6 +11724,11 @@ react-color@^2.17.0:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-content-loader@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-6.0.3.tgz#32e28ca7120e0a2552fc26655d0d4448cc1fc0c5"
+  integrity sha512-CIRgTHze+ls+jGDIfCitw27YkW2XcaMpsYORTUdBxsMFiKuUYMnlvY76dZE4Lsaa9vFXVw+41ieBEK7SJt0nug==
 
 react-data-table-component@^7.0.0-alpha-1:
   version "7.0.0-alpha-1"


### PR DESCRIPTION
- Cleans up unused/future `DatasetInfoItem` elements on dataset list items, hides follower and download counts if they are zero.  Closes #180 

- Introduces `ContentLoader` which can be used to show loading state skeletons.
- Adds loading state with skeletons to search results
- Adds loading state with skeletons user profile header, and both user profile lists

![Jun-04-2021 16-11-23](https://user-images.githubusercontent.com/1833820/120864669-93a93300-c55a-11eb-9079-c6d3f7ca550a.gif)
