### PR TITLE
feat: add sticky mini-headers to preview and profile views

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "react-content-loader": "6.0.3",
     "react-data-table-component": "^7.0.0-alpha-1",
     "react-dom": "^17.0.1",
+    "react-intersection-observer": "8.32.0",
     "react-json-view": "^1.20.4",
     "react-monaco-editor": "^0.41.2",
     "react-paginate": "7.1.3",

--- a/frontend/src/features/dataset/DatasetHeader.tsx
+++ b/frontend/src/features/dataset/DatasetHeader.tsx
@@ -6,19 +6,18 @@ import Icon from '../../chrome/Icon'
 import DropdownMenu from '../../chrome/DropdownMenu'
 import EditableLabel from '../../chrome/EditableLabel'
 import { renameDataset } from './state/datasetActions'
-import { QriRef } from '../../qri/ref'
+import { Dataset, qriRefFromDataset } from '../../qri/dataset'
 import DatasetInfoItem from './DatasetInfoItem'
 import Button from '../../chrome/Button'
 
-
 export interface DatasetHeaderProps {
-  qriRef: QriRef
+  dataset: Dataset
   border?: boolean
   editable?: boolean
 }
 
 const DatasetHeader: React.FC<DatasetHeaderProps> = ({
-  qriRef,
+  dataset,
   border = false,
   editable = false
 }) => {
@@ -30,10 +29,10 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   }
 
   const handleRename = (_:string, value:string) => {
-    dispatch(renameDataset(qriRef, { username: qriRef.username, name: value }))
+    dispatch(renameDataset(qriRefFromDataset(dataset), { username: dataset.username, name: value }))
     // TODO(b5): we should be chaining this route replacement after successful
     // dispatch with a "then" off the renameDataset action
-    const newPath = history.location.pathname.replace(qriRef.name, value)
+    const newPath = history.location.pathname.replace(dataset.name, value)
     console.log('routing from ', history.location.pathname, ' to ', newPath)
     history.replace(newPath)
   }
@@ -51,15 +50,15 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
       <div className='flex'>
         <div className='flex-grow'>
           <div className='text-md text-gray-400 relative flex items-baseline group hover:text pb-1'>
-            <span>{qriRef.username || 'new'} / </span>
-            <EditableLabel readOnly={!editable} name='name' onChange={handleRename} value={qriRef.name} />
+            <span>{dataset.peername || 'new'} / </span>
+            <EditableLabel readOnly={!editable} name='name' onChange={handleRename} value={dataset.name} />
             {editable && <DropdownMenu items={menuItems}>
               <Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />
             </DropdownMenu>}
           </div>
 
           <div className='text-2xl text-qrinavy-500 font-black group hover:text mb-3'>
-            {qriRef.name}
+            {dataset.meta?.title || dataset.name}
           </div>
 
           <div className='flex mb-5'>

--- a/frontend/src/features/dataset/DatasetPage.tsx
+++ b/frontend/src/features/dataset/DatasetPage.tsx
@@ -7,7 +7,7 @@ import { newQriRef } from '../../qri/ref';
 import { loadDataset } from './state/datasetActions'
 import DatasetNavSidebar from './DatasetNavSidebar';
 import { selectSessionUser } from '../session/state/sessionState';
-import { selectSessionUserCanEditDataset } from './state/datasetState';
+import { selectSessionUserCanEditDataset, selectDataset } from './state/datasetState';
 import DatasetHeader from './DatasetHeader';
 import DeployingScreen from '../deploy/DeployingScreen'
 
@@ -16,6 +16,7 @@ const DatasetPage: React.FC<{}> = ({
   children
 }) => {
   const qriRef = newQriRef(useParams())
+  const dataset = useSelector(selectDataset)
   const user = useSelector(selectSessionUser)
   const editable = useSelector(selectSessionUserCanEditDataset)
   const dispatch = useDispatch()
@@ -42,7 +43,7 @@ const DatasetPage: React.FC<{}> = ({
       <div className='flex overflow-hidden w-full'>
         <DatasetNavSidebar qriRef={qriRef} />
         <div className='flex flex-col flex-grow overflow-hidden px-7 pb-7 pt-9'>
-          <DatasetHeader qriRef={qriRef} editable={editable} />
+          <DatasetHeader dataset={dataset} editable={editable} />
           {children}
         </div>
         <DeployingScreen qriRef={qriRef} />

--- a/frontend/src/features/download/DownloadDatasetButton.tsx
+++ b/frontend/src/features/download/DownloadDatasetButton.tsx
@@ -1,20 +1,22 @@
 import React from 'react'
 
-import Button from '../../chrome/Button'
+import Button, { ButtonType } from '../../chrome/Button'
 import Icon from '../../chrome/Icon'
 import { QriRef } from '../../qri/ref'
 
 export interface DownloadDatasetButtonProps {
   qriRef: QriRef
   small?: boolean
+  type?: ButtonType
 }
 
 const DownloadDatasetButton: React.FC<DownloadDatasetButtonProps> = ({
   qriRef,
-  small=false
+  small=false,
+  type='primary-outline'
 }) => {
   return (
-    <Button onClick={() => { alert(`unfinished: download ${qriRef.username}/${qriRef.name}`)}} type='primary-outline' size='sm'>
+    <Button onClick={() => { alert(`unfinished: download ${qriRef.username}/${qriRef.name}`)}} type={type} size='sm'>
     {small ? <Icon icon='download' /> : 'Download'}
     </Button>
   )

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import useDimensions from 'react-use-dimensions'
+import { useInView } from 'react-intersection-observer'
+import classNames from 'classnames'
 
 import { newQriRef } from '../../qri/ref';
 import { selectDsPreview } from './state/dsPreviewState'
@@ -12,6 +14,7 @@ import ContentBoxTitle from '../../chrome/ContentBoxTitle'
 import DownloadDatasetButton from '../download/DownloadDatasetButton'
 import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
+import Button from '../../chrome/Button'
 import BodyPreview from '../dsComponents/body/BodyPreview'
 import DatasetHeader from '../dataset/DatasetHeader'
 import NavBar from '../navbar/NavBar'
@@ -35,6 +38,11 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   const dataset = useSelector(selectDsPreview)
   const editable = useSelector(selectSessionUserCanEditDataset)
   const dispatch = useDispatch()
+
+  const { ref: stickyHeaderTriggerRef, inView } = useInView({
+    threshold: 0.6,
+    initialInView: true
+  });
 
   const [versionInfoContainer, { height: versionInfoContainerHeight }] = useDimensions();
   const [expandReadme, setExpandReadme] = useState(false)
@@ -60,9 +68,39 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
             <Spinner color='#4FC7F3' />
           </div>)
         : (
-          <div className='overflow-y-scroll overflow-x-hidden flex-grow relative flex'>
-            <div className='max-w-screen-lg mx-auto p-9 w-full flex-grow'>
-              <DatasetHeader qriRef={qriRef} editable={editable} noBorder />
+          <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
+            {/* begin sticky header */}
+            <div className={classNames('sticky top-0 bg-white border border-qrigray-200', {
+              'invisible -top-16 h-0': inView,
+              'visible top-0 transition-all': !inView
+            })} style={{
+              borderTopLeftRadius: '20px'
+            }}>
+              <div className='px-8 pt-4 pb-3 flex'>
+                <div className='flex-grow'>
+                  <div className='text-xs text-gray-400 font-mono'>
+                    {dataset.peername}/{dataset.name}
+                  </div>
+                  <div className='text-normal text-qrinavy font-semibold'>
+                    {dataset.meta?.title || dataset.name}
+                  </div>
+                </div>
+                <div className='flex items-center content-center'>
+                  <Button className='mr-3' type='light' filled={false}>
+                    Follow
+                  </Button>
+                  <Button className='mr-3' type='secondary'>
+                    <Icon icon='globe' size='lg' className='mr-2' /> Share
+                  </Button>
+                  <DownloadDatasetButton qriRef={qriRef} type='primary' small />
+                </div>
+              </div>
+            </div>
+            {/* end sticky header */}
+            <div className='max-w-screen-lg mx-auto p-9 w-full h-full'>
+              <div ref={stickyHeaderTriggerRef}>
+                <DatasetHeader dataset={dataset} editable={editable} noBorder />
+              </div>
               <div className='-ml-2 -mr-3 mb-5'>
                 <div className='w-7/12 px-2 inline-block align-top' style={{ height: readmeContainerHeight}}>
                   <ContentBox className='flex flex-col h-full'>
@@ -98,14 +136,10 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                           <UsernameWithIcon username='chriswhong' className='mt-0.5' />
                         </div>
                       </div>
-                      <DownloadDatasetButton qriRef={qriRef} small/>
+                      <DownloadDatasetButton qriRef={qriRef} small light />
                     </div>
                     {/* Bottom of the box */}
-
-
                     <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2'>{(dataset.meta?.description) || 'No Description'}</div>
-
-
                     {dataset.meta?.keywords?.map((keyword) => {
                       return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-1 mb-1'>{keyword}</div>
                     })}

--- a/frontend/src/features/userProfile/UserProfile.tsx
+++ b/frontend/src/features/userProfile/UserProfile.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import classNames from 'classnames'
+import { useInView } from 'react-intersection-observer'
 import { useParams, useHistory, useLocation } from 'react-router-dom'
 import queryString from 'query-string'
 
@@ -36,6 +38,11 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
 
   const profile = useSelector(selectUserProfile)
   const loading = useSelector(selectUserProfileLoading)
+
+  const { ref: stickyHeaderTriggerRef, inView } = useInView({
+    threshold: 0.6,
+    initialInView: true
+  });
 
   const paginatedDatasetResults = useSelector(selectUserProfileDatasets)
   const paginatedFollowingResults = useSelector(selectUserProfileFollowing)
@@ -98,12 +105,34 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
   ]
 
   return (
-    <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
+    <div className='flex flex-col h-full w-full' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
       <NavBar />
-      <div className='flex-grow w-full py-9'>
-        <div className='mx-auto flex' style={{ maxWidth: '1040px' }}>
+      <div className='flex-grow w-full overflow-y-scroll'>
+        {/* begin sticky header */}
+        <div className={classNames('sticky bg-white  border border-qrigray-200 z-10', {
+          'invisible -top-16 h-0': inView,
+          'visible top-0 transition-all': !inView
+        })}>
+          <div className='px-8 pt-4 pb-3 flex'>
+            <div className='flex items-center'>
+              <div className='rounded-2xl inline-block bg-cover flex-shrink-0 mr-3' style={{
+                height: '30px',
+                width: '30px',
+                backgroundImage: `url(${profile.profile})`
+              }}></div>
+              <div>
+                <div className='text-qrinavy text-sm font-semibold'>{profile.name}</div>
+                <div className='text-qrigray-400 text-xs'>{profile.username}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* end sticky header */}
+        <div className='mx-auto flex py-9' style={{ maxWidth: '1040px' }}>
           <div className='flex-auto'>
-              <UserProfileHeader profile={profile} loading={loading} />
+              <div ref={stickyHeaderTriggerRef}>
+                <UserProfileHeader profile={profile} loading={loading} />
+              </div>
               <ContentTabs
                 tabs={tabs}
               />

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11876,6 +11876,11 @@ react-inspector@^5.0.1:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intersection-observer@^8.32.0:
+  version "8.32.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.0.tgz#47249332e12e8bb99ed35a10bb7dd10446445a7b"
+  integrity sha512-RlC6FvS3MFShxTn4FHAy904bVjX5Nn4/eTjUkurW0fHK+M/fyQdXuyCy9+L7yjA+YMGogzzSJNc7M4UtfSKvtw==
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -14317,7 +14322,7 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-debounce@^6.0.1:
+use-debounce@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-6.0.1.tgz#ed1eb2b30189408fb9792ea2887f4c6c3cb401a3"
   integrity sha512-kpvIxpa0vOLz/2I2sfNJ72mUeaT2CMNCu5BT1f2HkV9qZK27UVSOFf1sSSu+wjJE4TcR2VTXS2SM569+m3TN7Q==


### PR DESCRIPTION
Adds sticky mini-headers to preview and profile views, which animate in once the user scrolls the main header out of view.
![Jun-08-2021 15-07-59](https://user-images.githubusercontent.com/1833820/121249676-d7f64500-c872-11eb-946d-0e89947fd004.gif)
