### PR TITLE
feat: Download Links & Commit Titles

### DIFF
--- a/frontend/src/chrome/RelativeTimestampWithIcon.tsx
+++ b/frontend/src/chrome/RelativeTimestampWithIcon.tsx
@@ -13,8 +13,8 @@ const RelativeTimestampWithIcon: React.FC<RelativeTimestampWithIconProps> = ({
   timestamp,
   className
  }) => (
-   <div className={classNames('flex items-center leading-tight text-xs tracking-wider', className)}>
-     <Icon icon='clock' size='2xs' className='mr-1' /><RelativeTimestamp timestamp={timestamp} />
+   <div className={classNames('flex items-center leading-tight tracking-wider', className)}>
+     <Icon icon='clock' size='2xs' className='mr-0.5' /><RelativeTimestamp timestamp={timestamp} />
    </div>
 )
 

--- a/frontend/src/chrome/UsernameWithIcon.tsx
+++ b/frontend/src/chrome/UsernameWithIcon.tsx
@@ -4,17 +4,19 @@ import classNames from 'classnames'
 interface UsernameWithIconProps {
   username: string
   className?: string
+  iconWidth?: number
 }
 
 // TODO(chriswhong): make the prop a user object, or pass in icon URL as a separate prop
 const UsernameWithIcon: React.FunctionComponent<UsernameWithIconProps> = ({
   username,
-  className
+  className,
+  iconWidth = 18
 }) => (
-   <div className={classNames('flex items-center text-xs tracking-wider leading-snug', className)}>
+   <div className={classNames('flex items-center tracking-wider leading-snug', className)}>
      <div className='rounded-xl inline-block mr-1 bg-cover flex-shrink-0' style={{
-       height: '18px',
-       width: '18px',
+       height: iconWidth,
+       width: iconWidth,
        backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
      }}></div>
      <p className='truncate'>{username}</p>

--- a/frontend/src/features/commits/CommitSummaryHeader.tsx
+++ b/frontend/src/features/commits/CommitSummaryHeader.tsx
@@ -26,7 +26,7 @@ const CommitSummaryHeader: React.FC<CommitSummaryHeaderProps> = ({
             <div className='mx-3 text-gray-400'>|</div>
             <div className=''>{commit.title}</div>
           </div>
-          <div className='flex items-center text-gray-400'>
+          <div className='flex items-centern text-xs text-gray-400'>
             <RelativeTimestampWithIcon timestamp={new Date(commit.timestamp)} className='mr-4' />
             <UsernameWithIcon username='chriswhong' className='mt-0.5' />
           </div>

--- a/frontend/src/features/commits/DatasetCommitItem.tsx
+++ b/frontend/src/features/commits/DatasetCommitItem.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { LogItem } from '../../qri/log';
 import { newQriRef } from '../../qri/ref';
 import { pathToDatasetViewer } from '../dataset/state/datasetPaths';
-import ComponentChangeIndicatorGroup from './ComponentChangeIndicatorGroup';
+// import ComponentChangeIndicatorGroup from './ComponentChangeIndicatorGroup';
 import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon';
 import UsernameWithIcon from '../../chrome/UsernameWithIcon';
 
@@ -24,27 +24,33 @@ const DatasetCommitItem: React.FC<DatasetCommitItemProps> = ({
   first = false,
   last = false
 }) => (
-    <li className='flex items-stretch text-qrinavy tracking-wider'>
-      <div className='relative w-4 mr-5 flex-shrink-0'>
-        <div className={classNames('absolute top-5 w-4 h-4 rounded-3xl bg-gray-300', active && 'bg-qripink')}>&nbsp;</div>
-        <div className='relative line-container w-0.5 mx-auto h-full'>
-          {!first && <div className='absolute top-0 w-full h-3 bg-gray-300 rounded'>&nbsp;</div>}
-          {!last && <div className='absolute top-11 bottom-0 w-full bg-gray-300 rounded'>&nbsp;</div>}
+  <li className='flex items-stretch text-qrinavy tracking-wider'>
+    <div className='relative w-4 mr-5 flex-shrink-0'>
+      <div className={classNames('absolute top-5 w-4 h-4 rounded-3xl bg-gray-300', active && 'bg-qripink')}>&nbsp;</div>
+      <div className='relative line-container w-0.5 mx-auto h-full'>
+        {!first && <div className='absolute top-0 w-full h-3 bg-gray-300 rounded'>&nbsp;</div>}
+        {!last && <div className='absolute top-11 bottom-0 w-full bg-gray-300 rounded'>&nbsp;</div>}
+      </div>
+    </div>
+    <Link
+      className={classNames('block rounded-md px-3 pt-2 pb-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-gray-400 border border-gray-300')}
+      to={pathToDatasetViewer(newQriRef(logItem))}
+      style={{ fontSize: 11 }}
+    >
+      <div className='flex justify-between'>
+        <div className='font-medium mb-1'>{logItem.title}</div>
+        <div className='flex-grow-0 text-qrigreen'>
+          <Icon icon='automationFilled' size='sm'/>
         </div>
       </div>
-      <Link className={classNames('block rounded-md p-4 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-gray-400 border border-gray-300')} to={pathToDatasetViewer(newQriRef(logItem))}>
-        <div className='flex mb-1 justify-between'>
-          <UsernameWithIcon username={logItem.username} />
-          <div className='flex-grow-0 text-qrigreen'>
-            <Icon icon='automationFilled' size='sm'/>
-          </div>
-        </div>
-        <RelativeTimestampWithIcon className='mb-2' timestamp={new Date(logItem.timestamp)} />
-        {/* TODO(chriswhong): in case we want to restore commit title */}
-        {/* <p className='truncate overflow-ellipsis'>{logItem.title || ' '}</p> */}
-        <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />
-      </Link>
-    </li>
-  )
+      <div className='flex items-center text-qrigray-400'>
+        <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />
+        <RelativeTimestampWithIcon timestamp={new Date(logItem.timestamp)} />
+      </div>
+      {/* TODO(chriswhong): restore when we can add component change indicators <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />*/}
+    </Link>
+  </li>
+)
+
 
 export default DatasetCommitItem

--- a/frontend/src/features/commits/DatasetCommits.tsx
+++ b/frontend/src/features/commits/DatasetCommits.tsx
@@ -37,7 +37,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
   }, [dispatch, qriRef.username, qriRef.name])
 
   return (
-    <div className='pt-4 overflow-y-hidden flex flex-col text-xs flex-shrink-0' style={{ width: '325px'}}>
+    <div className='pt-4 overflow-y-hidden flex flex-col text-xs flex-shrink-0' style={{ width: 300 }}>
       <header className='flex-grow-0 mb-4'>
         <h3 className='text-2xl text-qrinavy-500 font-black'>History</h3>
         <div className='text-xs text-gray-400 tracking-wider'>{commits.length} {commits.length === 1 ? 'version' : 'versions'}</div>

--- a/frontend/src/features/commits/state/commitActions.ts
+++ b/frontend/src/features/commits/state/commitActions.ts
@@ -17,7 +17,7 @@ function fetchDatasetCommits(qriRef: QriRef): ApiAction {
     type: 'dataset_commits',
     qriRef,
     [CALL_API]: {
-      endpoint: `history/`,
+      endpoint: `ds/activity`,
       method: 'POST',
       body: {
         ref: `${qriRef.username}/${qriRef.name}`

--- a/frontend/src/features/dataset/state/datasetActions.ts
+++ b/frontend/src/features/dataset/state/datasetActions.ts
@@ -1,7 +1,8 @@
-import Dataset, { NewDataset } from "../../../qri/dataset";
-import { QriRef } from "../../../qri/ref";
-import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
-import { RENAME_NEW_DATASET } from "./datasetState";
+import Dataset, { NewDataset } from "../../../qri/dataset"
+import { QriRef } from "../../../qri/ref"
+import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api"
+import { RENAME_NEW_DATASET } from "./datasetState"
+import { API_BASE_URL } from '../../../store/api'
 
 export const bodyPageSizeDefault = 50
 
@@ -18,6 +19,17 @@ export function loadDataset(ref: QriRef): ApiActionThunk {
     // TODO (b5) - check state before making a network request
     return dispatch(fetchDataset(ref))
   }
+}
+
+// downloadLinkFromQriRef creates a download link
+export function downloadLinkFromQriRef(ref: QriRef, body: boolean = false): string {
+  console.log('theRef', ref)
+  let pathSegment = ref.path ? `/at${ref.path}` : ''
+
+  if (body) {
+    return `${API_BASE_URL}/ds/get/${ref.username}/${ref.name}${pathSegment}/body.csv`
+  }
+  return `${API_BASE_URL}/download/${ref.username}/${ref.name}${pathSegment}`
 }
 
 function fetchDataset (ref: QriRef): ApiAction {

--- a/frontend/src/features/download/DownloadDatasetButton.tsx
+++ b/frontend/src/features/download/DownloadDatasetButton.tsx
@@ -4,10 +4,11 @@ import { useSelector, useDispatch } from 'react-redux'
 import Button, { ButtonType } from '../../chrome/Button'
 import Icon from '../../chrome/Icon'
 import IconLink from '../../chrome/IconLink'
-import { QriRef, downloadLinkFromQriRef } from '../../qri/ref'
+import { QriRef } from '../../qri/ref'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import { selectSessionUser } from '../session/state/sessionState'
+import { downloadLinkFromQriRef } from '../dataset/state/datasetActions'
 
 export interface DownloadDatasetButtonProps {
   qriRef: QriRef

--- a/frontend/src/features/download/DownloadDatasetButton.tsx
+++ b/frontend/src/features/download/DownloadDatasetButton.tsx
@@ -1,25 +1,70 @@
 import React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 
 import Button, { ButtonType } from '../../chrome/Button'
 import Icon from '../../chrome/Icon'
-import { QriRef } from '../../qri/ref'
+import IconLink from '../../chrome/IconLink'
+import { QriRef, downloadLinkFromQriRef } from '../../qri/ref'
+import { showModal } from '../app/state/appActions'
+import { ModalType } from '../app/state/appState'
+import { selectSessionUser } from '../session/state/sessionState'
 
 export interface DownloadDatasetButtonProps {
   qriRef: QriRef
+  // if small=true, the component will render a Button with an icon instead of text
   small?: boolean
   type?: ButtonType
+  // if asIconLink=true, the component will render an IconLink instead of a Button
+  // useful for showing a download link in BodyHeader
+  asIconLink?: boolean
+  // if body=true, the downloadLink will get the dataset body
+  body?: boolean
 }
 
 const DownloadDatasetButton: React.FC<DownloadDatasetButtonProps> = ({
   qriRef,
-  small=false,
-  type='primary-outline'
+  asIconLink=false,
+  body=false,
+  small=false
 }) => {
-  return (
-    <Button onClick={() => { alert(`unfinished: download ${qriRef.username}/${qriRef.name}`)}} type={type} size='sm'>
-    {small ? <Icon icon='download' /> : 'Download'}
-    </Button>
-  )
+  const dispatch = useDispatch()
+
+  const user = useSelector(selectSessionUser)
+
+  const handleDownloadClick = () => {
+    dispatch(showModal(ModalType.logIn))
+  }
+
+  const downloadLink = downloadLinkFromQriRef(qriRef, body)
+
+  // returns <IconLink>
+  if (asIconLink) {
+    if (user.username === 'new') {
+      return <IconLink icon='download' onClick={handleDownloadClick} />
+    } else {
+      return <IconLink icon='download' link={downloadLink} />
+    }
+  } else { // returns <Button>
+    let buttonContent = (
+      <Button type='primary-outline' size='sm'>
+        {small ? <Icon icon='download' /> : 'Download'}
+      </Button>
+    )
+
+    if (user.username === 'new') {
+      return (
+        <div onClick={handleDownloadClick}>
+          {buttonContent}
+        </div>
+      )
+    }
+
+    return (
+      <a href={downloadLink}>
+        {buttonContent}
+      </a>
+    )
+  }
 }
 
 export default DownloadDatasetButton

--- a/frontend/src/features/dsComponents/DatasetComponent.tsx
+++ b/frontend/src/features/dsComponents/DatasetComponent.tsx
@@ -33,7 +33,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   switch (componentName) {
     case 'body':
       component = <Body data={dataset} />
-      componentHeader = <BodyHeader data={dataset} onToggleExpanded={handleToggleExpanded} showExpand={!expanded}/>
+      componentHeader = <BodyHeader dataset={dataset} onToggleExpanded={handleToggleExpanded} showExpand={!expanded}/>
       break
     case 'meta':
       component = <Meta data={dataset.meta}/>

--- a/frontend/src/features/dsComponents/body/BodyHeader.tsx
+++ b/frontend/src/features/dsComponents/body/BodyHeader.tsx
@@ -1,22 +1,26 @@
 import React from 'react'
 import numeral from 'numeral'
 
-import Dataset, { Structure, schemaToColumns, ColumnProperties, extractColumnHeaders } from '../../../qri/dataset'
+import Dataset, {
+  qriRefFromDataset,
+  extractColumnHeaders
+} from '../../../qri/dataset'
 import Icon from '../../../chrome/Icon'
 import IconLink from '../../../chrome/IconLink'
+import DownloadDatasetButton from '../../download/DownloadDatasetButton'
 
 interface BodyHeaderProps {
-  data: Dataset
+  dataset: Dataset
   onToggleExpanded?: () => void
   showExpand?: boolean
 }
 
-const Body: React.FC<BodyHeaderProps> = ({
-  data,
+const BodyHeader: React.FC<BodyHeaderProps> = ({
+  dataset,
   onToggleExpanded,
   showExpand = true
 }) => {
-  const { structure, body } = data
+  const { structure, body } = dataset
   const headers = extractColumnHeaders(structure, body)
 
   return (
@@ -29,9 +33,10 @@ const Body: React.FC<BodyHeaderProps> = ({
           <Icon icon='columns' size='2xs' className='mr-1'/> {numeral(headers.length).format('0,0')} columns
         </div>
       </div>
+      <DownloadDatasetButton qriRef={qriRefFromDataset(dataset)} asIconLink body />
       {showExpand && <IconLink icon='fullScreen' onClick={onToggleExpanded} />}
     </div>
   )
 }
 
-export default Body
+export default BodyHeader

--- a/frontend/src/features/dsComponents/body/BodyPreview.tsx
+++ b/frontend/src/features/dsComponents/body/BodyPreview.tsx
@@ -58,7 +58,7 @@ const Body: React.FC<BodyProps> = ({
   return (
     <div className='w-full h-full flex flex-col'>
       <ComponentHeader>
-        <BodyHeader data={dataset} showExpand={false} />
+        <BodyHeader dataset={dataset} showExpand={false} />
       </ComponentHeader>
       <div className='overflow-scroll border border-gray-200'>
       {

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -139,9 +139,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                       <DownloadDatasetButton qriRef={qriRef} small light />
                     </div>
                     {/* Bottom of the box */}
-
                     <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2 break-words'>{(dataset.meta?.description) || 'No Description'}</div>
-
                     {dataset.meta?.keywords?.map((keyword) => {
                       return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-1 mb-1'>{keyword}</div>
                     })}

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -25,7 +25,7 @@ import Readme from '../dsComponents/readme/Readme'
 import { qriRefFromDataset } from '../../qri/dataset'
 
 
-import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState';
+import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState'
 import { QriRef } from '../../qri/ref'
 
 interface DatasetPreviewPageProps {
@@ -35,9 +35,9 @@ interface DatasetPreviewPageProps {
 const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   qriRef
 }) => {
+  const dispatch = useDispatch()
   const dataset = useSelector(selectDsPreview)
   const editable = useSelector(selectSessionUserCanEditDataset)
-  const dispatch = useDispatch()
 
   const { ref: stickyHeaderTriggerRef, inView } = useInView({
     threshold: 0.6,
@@ -123,7 +123,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                 </div>
                 <div ref={versionInfoContainer} className='w-5/12 px-3 inline-block align-top'>
                   <ContentBox>
-                    <div className='flex items-center border-b pb-4'>
+                    <div className='flex items-center border-b pb-4 mb-4'>
                       <div className='flex-grow'>
                         <ContentBoxTitle title='Version Info' />
                         <div className='text-qrinavy text-sm flex items-center mb-0'>
@@ -139,6 +139,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                       <DownloadDatasetButton qriRef={qriRef} small light />
                     </div>
                     {/* Bottom of the box */}
+                    <ContentBoxTitle title='Description' />
                     <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2 break-words'>{(dataset.meta?.description) || 'No Description'}</div>
                     {dataset.meta?.keywords?.map((keyword) => {
                       return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-1 mb-1'>{keyword}</div>

--- a/frontend/src/qri/ref.ts
+++ b/frontend/src/qri/ref.ts
@@ -2,8 +2,6 @@
 
 import { ComponentName } from "./dataset"
 
-import { API_BASE_URL } from '../store/api'
-
 // QriRef models a reference to a user, dataset, or part of a dataset within Qri
 // We use "QriRef" instead of "Ref" to disambiguate with the react "ref"
 // property.
@@ -150,17 +148,6 @@ export function qriRefIsSameDataset (a: QriRef, b: QriRef): boolean {
 // dropping any path or identifier data
 export function humanRef(ref: QriRef): QriRef {
   return newQriRef({ username : ref.username, name: ref.name })
-}
-
-// downloadLinkFromQriRef creates a download link
-export function downloadLinkFromQriRef(ref: QriRef, body: boolean = false): string {
-  console.log('theRef', ref)
-  let pathSegment = ref.path ? `/at${ref.path}` : ''
-
-  if (body) {
-    return `${API_BASE_URL}/ds/get/${ref.username}/${ref.name}${pathSegment}/body.csv`
-  }
-  return `${API_BASE_URL}/download/${ref.username}/${ref.name}${pathSegment}`
 }
 
 // // selectedComponentFromQriRef takes a qriRef and gets the selected component

--- a/frontend/src/qri/ref.ts
+++ b/frontend/src/qri/ref.ts
@@ -2,6 +2,8 @@
 
 import { ComponentName } from "./dataset"
 
+import { API_BASE_URL } from '../store/api'
+
 // QriRef models a reference to a user, dataset, or part of a dataset within Qri
 // We use "QriRef" instead of "Ref" to disambiguate with the react "ref"
 // property.
@@ -47,7 +49,7 @@ export interface QriRef {
   // commit hash, eg: /ipfs/QmY9WcXXUnHJbYRA28LRctiL4qu4y...
   path?: string
   // optional: a specific component the user is trying to index into component
-  component?: ComponentName 
+  component?: ComponentName
   // address into dataset structure
   selector?: string[]
 }
@@ -148,6 +150,17 @@ export function qriRefIsSameDataset (a: QriRef, b: QriRef): boolean {
 // dropping any path or identifier data
 export function humanRef(ref: QriRef): QriRef {
   return newQriRef({ username : ref.username, name: ref.name })
+}
+
+// downloadLinkFromQriRef creates a download link
+export function downloadLinkFromQriRef(ref: QriRef, body: boolean = false): string {
+  console.log('theRef', ref)
+  let pathSegment = ref.path ? `/at${ref.path}` : ''
+
+  if (body) {
+    return `${API_BASE_URL}/ds/get/${ref.username}/${ref.name}${pathSegment}/body.csv`
+  }
+  return `${API_BASE_URL}/download/${ref.username}/${ref.name}${pathSegment}`
 }
 
 // // selectedComponentFromQriRef takes a qriRef and gets the selected component


### PR DESCRIPTION
- Changes the api endpoint for commit history (uses `ds/activity` instead of `history`)
- Refactors `DownloadDatasetButton` to serve all of our download needs (it can return `Button` or `IconLink`, and has an option for downloading the body or the full dataset.
- If there is no logged in user, `DownloadDatasetButton` will open the Log In Modal on click instead of starting a download.
- Download Buttons attached to full commits or the dataset preview will download a zipped CSV of the entire dataset at that commit.
- `DownloadDatasetButton` as `IconLink` is used only in `BodyHeader` and will download only the body.
![image](https://user-images.githubusercontent.com/1833820/121263560-c6696900-c883-11eb-9ac2-5eadb625fdc4.png)


- Adds commit titles to commit history items, updates layout
<img width="319" alt="Home___Qri_Cloud" src="https://user-images.githubusercontent.com/1833820/121626610-c1531800-ca43-11eb-984a-3ffa02191c6a.png">


Closes #175 