### PR TITLE
Cw cleanup

### DIFF
--- a/frontend/src/chrome/ExternalLink.tsx
+++ b/frontend/src/chrome/ExternalLink.tsx
@@ -4,7 +4,6 @@ export interface ExternalLinkProps {
   id?: string
   to: string
   children: React.ReactNode
-  // providing className prop will override the component's color classes
   className?: string
   tooltip?: string
 }
@@ -23,7 +22,7 @@ export const ExternalLink: React.FunctionComponent<ExternalLinkProps> = ({
     href={to}
     target='_blank'
     rel="noopener noreferrer"
-    className={`${className || 'text-qriblue hover:text-qriblue-600'} hover:cursor-pointer`}
+    className={className}
     data-tip={tooltip}
   >
     {children}

--- a/frontend/src/chrome/IconLink.tsx
+++ b/frontend/src/chrome/IconLink.tsx
@@ -5,8 +5,8 @@ import Icon, { IconSize } from './Icon'
 interface IconLinkProps {
   icon: string
   link?: string
-  onClick?: () => void
   size?: IconSize
+  onClick?: () => void
 }
 
 const IconLink: React.FC<IconLinkProps> = ({

--- a/frontend/src/chrome/TextLink.tsx
+++ b/frontend/src/chrome/TextLink.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import classNames from 'classnames'
+
+import ExternalLink from './ExternalLink'
+
+interface TextLinkProps {
+  to?: string
+  // appends arbitrary classnames to the rendered element
+  className?: string
+  // overrides the default color and hover color
+  colorClassName?: string
+  onClick?: () => void
+}
+
+const defaultColorClassname = 'text-qriblue hover:text-qriblue-800'
+
+const TextLink: React.FC<TextLinkProps> = ({
+  to='',
+  onClick,
+  className,
+  colorClassName = defaultColorClassname,
+  children
+}) => {
+
+  const combinedClassNames = classNames('hover:cursor-pointer transition-all duration-100', colorClassName, className)
+
+  if (to) {
+    if (to.indexOf('http') === 0) {
+      return <ExternalLink to={to} className={combinedClassNames}>{children}</ExternalLink>
+    } else {
+      return <Link to={to} className={combinedClassNames}>{children}</Link>
+    }
+  }
+
+  return (
+    <span className={combinedClassNames} onClick={onClick}>
+      {children}
+    </span>
+  )
+}
+
+export default TextLink

--- a/frontend/src/features/footer/Footer.tsx
+++ b/frontend/src/features/footer/Footer.tsx
@@ -1,19 +1,33 @@
 import React from 'react'
 
 import Icon from '../../chrome/Icon'
+import TextLink from '../../chrome/TextLink'
+import IconLink from '../../chrome/IconLink'
 
 const Footer: React.FC<{}> = () => (
   <div className='flex w-9/12 mx-auto text-qrinavy text-sm py-5 tracking-wide'>
-    <div className='flex flex-grow'>
-      <div className='mr-10'>
+    <div className='flex flex-grow font-medium'>
+      <TextLink
+        className='mr-10'
+        colorClassName='text-qrinavy hover:text-qripink'
+        to='https://qri.io/docs'
+      >
         Tutorials
-      </div>
-      <div className='mr-10'>
+      </TextLink>
+      <TextLink
+        className='mr-10'
+        colorClassName='text-qrinavy hover:text-qripink'
+        to='https://qri.io/docs'
+      >
         Docs
-      </div>
-      <div className='mr-10'>
+      </TextLink>
+      <TextLink
+        className='mr-10'
+        colorClassName='text-qrinavy hover:text-qripink'
+        to='https://qri.io/faq'
+      >
         FAQs
-      </div>
+      </TextLink>
     </div>
     <div className='flex flex-grow justify-end'>
       {
@@ -22,7 +36,7 @@ const Footer: React.FC<{}> = () => (
           { icon: 'youtube' },
           { icon: 'twitter' },
           { icon: 'discord' }
-        ].map(({ icon }, i) => <Icon key={i} icon={icon} className='ml-5' />)
+        ].map(({ icon }, i) => <IconLink key={i} icon={icon} size='md' className='ml-5' />)
       }
     </div>
   </div>

--- a/frontend/src/features/navbar/NavBar.tsx
+++ b/frontend/src/features/navbar/NavBar.tsx
@@ -33,7 +33,7 @@ const NavBar: React.FC<NavBarProps> = ({
   }
 
   return (
-    <div className='bg-white text-qrinavy-700 text-bold flex items-center pr-8' style={{
+    <div className='bg-white text-qrinavy-700 text-bold flex items-center pr-8 font-medium' style={{
       height: '110px',
       paddingTop: '30px',
       paddingBottom: '30px',

--- a/frontend/src/features/navbar/SessionUserMenu.tsx
+++ b/frontend/src/features/navbar/SessionUserMenu.tsx
@@ -7,9 +7,7 @@ import { logOut } from '../session/state/sessionActions'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import Button from '../../chrome/Button'
-import ExternalLink from '../../chrome/ExternalLink'
-
-const navbarLinkClassNames = 'text-qriblue font-medium hover:text-qriblue-800 hover:cursor-pointer transition-all duration-100'
+import TextLink from '../../chrome/TextLink'
 
 const SessionUserMenu: React.FC<{}> = () => {
   const user = useSelector(selectSessionUser)
@@ -26,9 +24,7 @@ const SessionUserMenu: React.FC<{}> = () => {
 
     return (
       <>
-        <div className={navbarLinkClassNames}
-          onClick={handleLogInClick}
-        >Log In</div>
+        <TextLink onClick={handleLogInClick}>Log In</TextLink>
         <Button onClick={handleSignUpClick} size='sm' className='ml-8'>
           Sign Up
         </Button>
@@ -52,11 +48,10 @@ const SessionUserMenu: React.FC<{}> = () => {
   ]
 
   return (
-    <div className="relative flex items-center">
-      <ExternalLink
+    <div className="relative flex items-center font-medium">
+      <TextLink
         to='https://qri.io/docs'
-        className={navbarLinkClassNames}
-      >Help</ExternalLink>
+      >Help</TextLink>
       <DropdownMenu items={menuItems} className='ml-8'>
         <div className='rounded-2xl inline-block bg-cover flex-shrink-0' style={{
           height: '30px',

--- a/frontend/src/features/search/Search.tsx
+++ b/frontend/src/features/search/Search.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useHistory, useLocation, Link } from 'react-router-dom'
 import queryString from 'query-string'
 import ContentLoader from 'react-content-loader'
 
@@ -17,6 +17,7 @@ import Footer from '../footer/Footer'
 import { NewSearchParams } from '../../qri/search'
 import DatasetList from '../../chrome/DatasetList'
 import ContentBox from '../../chrome/ContentBox'
+import TextLink from '../../chrome/TextLink'
 import Icon from '../../chrome/Icon'
 import DropdownMenu from '../../chrome/DropdownMenu'
 import { CleanSearchParams } from '../../qri/search'
@@ -97,13 +98,46 @@ const Search: React.FC<{}> = () => {
     }
   ]
 
+  // shown if user lands on /search with no query params
+  let resultsContent = (
+    <div className='text-center font-semibold text-sm'>
+      <span className='text-qrigray-400 mr-4'>Try:</span>
+      <TextLink to='/search?q=transportation' className='mr-6'>transportation</TextLink>
+      <TextLink to='/search?q=census' className='mr-6'>census</TextLink>
+      <TextLink to='/search?q=covid-19'>covid-19</TextLink>
+    </div>
+  )
+
+  if (q) {
+    if (searchResults.length > 0) {
+      resultsContent = (
+        <>
+          <ContentBox className='mb-6'>
+            <DatasetList
+              datasets={searchResults}
+              loading={loading}
+            />
+          </ContentBox>
+          <PageControl
+            pageInfo={pageInfo}
+            queryParams={CleanSearchParams(searchParams)}
+            onPageChange={handlePageChange}
+          />
+        </>
+      )
+    } else {
+      resultsContent = <div className='text-center'>No results found for '{q}'</div>
+    }
+  }
+
   return (
     <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
       <NavBar showSearch={false} />
       <div className='flex-grow w-full py-9'>
-        <div className='w-4/5 max-w-screen-lg mx-auto mb-10'>
-        <div className='text-qrinavy text-3xl font-black mb-2'>Dataset Search</div>
-          <div className='flex items-center mb-2 h-8'>
+        <div className='w-4/5 max-w-screen-lg mx-auto'>
+        <div className='text-qrinavy text-3xl font-black mb-4'>Dataset Search</div>
+          <BigSearchBox onSubmit={handleSearchSubmit} value={q} className='mb-4'/>
+          <div className='flex items-center mb-4 h-8'>
             {searchResults.length > 0 ? (
               <>
                 <div className='flex-grow'>
@@ -130,29 +164,10 @@ const Search: React.FC<{}> = () => {
             ):(
               <>&nbsp;</>
             )}
-
           </div>
-          <BigSearchBox onSubmit={handleSearchSubmit} value={q}/>
         </div>
         <div className='w-4/5 max-w-screen-lg mx-auto'>
-          {
-            (searchResults.length > 0) ?
-            <>
-              <ContentBox className='mb-6'>
-                <DatasetList
-                  datasets={searchResults}
-                  loading={loading}
-                />
-              </ContentBox>
-              <PageControl
-                pageInfo={pageInfo}
-                queryParams={CleanSearchParams(searchParams)}
-                onPageChange={handlePageChange}
-              />
-            </> : (
-              <div className='text-center'>No results found for '{q}'</div>
-            )
-          }
+          { resultsContent }
         </div>
       </div>
       <div className='bg-white flex-shrink-0'>

--- a/frontend/src/features/session/modal/LogInModal.tsx
+++ b/frontend/src/features/session/modal/LogInModal.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { AnyAction } from '@reduxjs/toolkit'
 
 import { ACTION_FAILURE, getActionType } from '../../../store/api'
-import ExternalLink from '../../../chrome/ExternalLink'
+import TextLink from '../../../chrome/TextLink'
 import Button from '../../../chrome/Button'
 import TextInput from '../../../chrome/forms/TextInput'
 import { showModal, clearModal } from '../../app/state/appActions'
@@ -70,13 +70,13 @@ const LogInModal: React.FC = () => {
         </Button>
 
         <div className='mb-3 text-qrigray-400 tracking-wider text-xs'>
-          By continuing, you agree to Qri's <ExternalLink to='https://qri.io/legal/tos'>Terms of Service</ExternalLink> & <ExternalLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</ExternalLink>.
+          By continuing, you agree to Qri's <TextLink to='https://qri.io/legal/tos'>Terms of Service</TextLink> & <TextLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</TextLink>.
         </div>
 
         <hr className='w-20 mx-auto mb-3'/>
 
-        <div className='text-qrinavy text-xs font-medium hover:cursor-pointer' onClick={handleSignUpClick}>
-          Not on Qri yet? Sign Up
+        <div className='text-qrinavy text-xs font-medium'>
+          Not on Qri yet? <TextLink onClick={handleSignUpClick}>Sign Up</TextLink>
         </div>
       </div>
     </div>

--- a/frontend/src/features/session/modal/SignUpModal.tsx
+++ b/frontend/src/features/session/modal/SignUpModal.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AnyAction } from '@reduxjs/toolkit';
 
 import { ACTION_FAILURE, getActionType } from '../../../store/api';
-import ExternalLink from '../../../chrome/ExternalLink'
+import TextLink from '../../../chrome/TextLink'
 import Button from '../../../chrome/Button'
 import TextInput from '../../../chrome/forms/TextInput'
 import { showModal, clearModal } from '../../app/state/appActions'
@@ -96,13 +96,13 @@ const SignUpModal: React.FC = () => {
         </Button>
 
         <div className='mb-3 text-qrigray-400 tracking-wider text-xs'>
-          By continuing, you agree to Qri's <ExternalLink to='https://qri.io/legal/tos'>Terms of Service</ExternalLink> & <ExternalLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</ExternalLink>.
+          By continuing, you agree to Qri's <TextLink to='https://qri.io/legal/tos'>Terms of Service</TextLink> & <TextLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</TextLink>.
         </div>
 
         <hr className='w-20 mx-auto mb-3'/>
 
-        <div className='text-qrinavy text-xs font-medium hover:cursor-pointer' onClick={handleLogInClick}>
-          Already on Qri?  Log In
+        <div className='text-qrinavy text-xs font-medium'>
+          Already on Qri? <TextLink onClick={handleLogInClick}>Log In</TextLink>
         </div>
       </div>
     </div>

--- a/frontend/src/features/userProfile/UserProfileHeader.tsx
+++ b/frontend/src/features/userProfile/UserProfileHeader.tsx
@@ -55,9 +55,9 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile, loading 
         { !loading && (
           <>
             <div className='flex justify-end mb-2'>
-              <IconLink icon='github' link='https://github.com/chriswhong' />
-              <IconLink icon='twitter' link='https://twitter.com/chriswhong' />
-              <IconLink icon='globe' link='https://chriswhong.com' />
+              <IconLink icon='github' className='ml-2' link='https://github.com/chriswhong' />
+              <IconLink icon='twitter' className='ml-2' link='https://twitter.com/chriswhong' />
+              <IconLink icon='globe' className='ml-2' link='https://chriswhong.com' />
             </div>
             <div className='text-xs text-qrigray-400'>Qri user since {format(fromUnixTime(created), 'yyyy')}</div>
           </>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -23,7 +23,7 @@ const PrivateRoute: React.FC<any>  = ({ path, children }) => {
   const user = useSelector(selectSessionUser)
   return (
     <Route path={path}>
-      { user !== AnonUser ? <>{children}</> : <Redirect to={{ pathname: '/splash' }} /> }
+      { user !== AnonUser ? <>{children}</> : <Redirect to={{ pathname: '/' }} /> }
     </Route>
   )
 }


### PR DESCRIPTION
- fixes a bug: when anonymous users load a secure route, they were redirected to `/splash` which does not exist, so was treated as seeking the profile for user `splash`

- Adds default content to `/search` with links to three search terms to try out
- Improves links throughout the site, making use of `TextLink` and `IconLink` in various places to standardize the color, hover styles, etc.  `ExternalLink` no longer applies classes of its own and is used for marking up the `a` tag with target=_blank etc.