### PR TITLE
various cleanup items

### DIFF
--- a/frontend/src/chrome/Button.tsx
+++ b/frontend/src/chrome/Button.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps {
   type?: ButtonType
   size?: 'sm' | 'md' | 'lg'
   className?: string
+  submit?: boolean
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -21,10 +22,11 @@ const Button: React.FC<ButtonProps> = ({
   size='md',
   className,
   onClick,
+  submit = false,
   children
 }) => (
   <button
-    type="button"
+    type={submit ? 'submit' : 'button'}
     className={classNames(
       'inline-flex items-center justify-center rounded-md shadow-sm bg-transparent font-medium focus:outline-none focus:ring focus:ring-offset ring-offset-transparent mt-0 transition-all duration-100',
       className,

--- a/frontend/src/chrome/TextLink.tsx
+++ b/frontend/src/chrome/TextLink.tsx
@@ -18,7 +18,7 @@ const defaultColorClassname = 'text-qriblue hover:text-qriblue-800'
 const TextLink: React.FC<TextLinkProps> = ({
   to='',
   onClick,
-  className,
+  className='',
   colorClassName = defaultColorClassname,
   children
 }) => {

--- a/frontend/src/chrome/TextLink.tsx
+++ b/frontend/src/chrome/TextLink.tsx
@@ -23,7 +23,7 @@ const TextLink: React.FC<TextLinkProps> = ({
   children
 }) => {
 
-  const combinedClassNames = classNames('hover:cursor-pointer transition-all duration-100', colorClassName, className)
+  const combinedClassNames = classNames('hover:cursor-pointer hover:underline transition-all duration-100', colorClassName, className)
 
   if (to) {
     if (to.indexOf('http') === 0) {

--- a/frontend/src/features/collection/Collection.tsx
+++ b/frontend/src/features/collection/Collection.tsx
@@ -9,10 +9,11 @@ import PageWithFooter from '../app/PageWithFooter'
 import CollectionTable from './CollectionTable'
 import Button from '../../chrome/Button'
 import Spinner from '../../chrome/Spinner'
+import TextLink from '../../chrome/TextLink'
 import SearchBox from '../search/SearchBox'
 import { filterVersionInfos } from '../../qri/versionInfo'
 
-const Collection: React.FC<any> = () => {
+const Collection: React.FC<{}> = () => {
   const dispatch = useDispatch()
   const fullCollection = useSelector(selectCollection)
   const loading = useSelector(selectIsCollectionLoading)
@@ -58,6 +59,17 @@ const Collection: React.FC<any> = () => {
       <div className='h-full w-full flex justify-center items-center text-qrigray-400'>
         No datasets found for&nbsp;
         <span className='font-semibold'>{searchString}</span>
+      </div>
+    )
+  }
+
+  // if no results in the full collection (new user), show a nudge
+  if (!loading && fullCollection.length === 0) {
+    resultsContent = (
+      <div className='h-full w-full flex justify-center items-center text-qrigray-400'>
+        <div className='text-center'>
+          You don't have any datasets!<br/> You can push datasets using <TextLink to='https://qri.io/docs/getting-started/qri-cli-quickstart'>qri CLI</TextLink>.
+        </div>
       </div>
     )
   }

--- a/frontend/src/features/dataset/DatasetHeader.tsx
+++ b/frontend/src/features/dataset/DatasetHeader.tsx
@@ -28,8 +28,10 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
     alert(message)
   }
 
+  const qriRef = qriRefFromDataset(dataset)
+
   const handleRename = (_:string, value:string) => {
-    dispatch(renameDataset(qriRefFromDataset(dataset), { username: dataset.username, name: value }))
+    dispatch(renameDataset(qriRef, { username: dataset.username, name: value }))
     // TODO(b5): we should be chaining this route replacement after successful
     // dispatch with a "then" off the renameDataset action
     const newPath = history.location.pathname.replace(dataset.name, value)

--- a/frontend/src/features/dataset/DatasetHeader.tsx
+++ b/frontend/src/features/dataset/DatasetHeader.tsx
@@ -9,6 +9,7 @@ import { renameDataset } from './state/datasetActions'
 import { Dataset, qriRefFromDataset } from '../../qri/dataset'
 import DatasetInfoItem from './DatasetInfoItem'
 import Button from '../../chrome/Button'
+import TextLink from '../../chrome/TextLink'
 
 export interface DatasetHeaderProps {
   dataset: Dataset
@@ -52,7 +53,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
       <div className='flex'>
         <div className='flex-grow'>
           <div className='text-md text-gray-400 relative flex items-baseline group hover:text pb-1 font-mono'>
-            <span>{qriRef.username || 'new'}/</span>
+            <TextLink to={`/${qriRef.username}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{qriRef.username || 'new'}</TextLink>/
             <EditableLabel readOnly={!editable} name='name' onChange={handleRename} value={qriRef.name} />
             {editable && <DropdownMenu items={menuItems}>
               <Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />

--- a/frontend/src/features/dsComponents/ComponentHeader.tsx
+++ b/frontend/src/features/dsComponents/ComponentHeader.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
+import classNames from 'classnames'
 
-const ComponentHeader: React.FC<{}> = ({ children }) => {
+interface ComponentHeaderProps {
+  border?: boolean
+}
+
+const ComponentHeader: React.FC<ComponentHeaderProps> = ({ border = true, children }) => {
   return (
-    <div className='flex-grow text-sm py-3 border-b'>
+    <div className={classNames('flex-grow text-sm py-3', {
+      'border-b': border
+    })}>
       {children}
     </div>
   )

--- a/frontend/src/features/dsComponents/DatasetComponent.tsx
+++ b/frontend/src/features/dsComponents/DatasetComponent.tsx
@@ -69,7 +69,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
     <div
       className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex flex-col transform transition-all px-4', {})}
     >
-      <ComponentHeader>
+      <ComponentHeader border={componentName !== 'body'}>
         {componentHeader}
       </ComponentHeader>
       <div className='overflow-auto flex-grow'>

--- a/frontend/src/features/dsComponents/body/BodyPreview.tsx
+++ b/frontend/src/features/dsComponents/body/BodyPreview.tsx
@@ -57,10 +57,10 @@ const Body: React.FC<BodyProps> = ({
 
   return (
     <div className='w-full h-full flex flex-col'>
-      <ComponentHeader>
+      <ComponentHeader border={false}>
         <BodyHeader dataset={dataset} showExpand={false} />
       </ComponentHeader>
-      <div className='overflow-scroll border border-gray-200'>
+      <div className='overflow-scroll'>
       {
         (structure.format === 'csv' && Array.isArray(body))
           ? <BodyTable

--- a/frontend/src/features/dsComponents/body/BodyTable.tsx
+++ b/frontend/src/features/dsComponents/body/BodyTable.tsx
@@ -39,7 +39,7 @@ interface BodyTableProps {
 //   return Math.abs(scrollTop + offsetHeight - scrollHeight) < buffer
 // }
 
-const cellClasses = 'px-2 py-2 overflow-hidden overflow-ellipsis whitespace-nowrap border-r border-gray-200 max-w-xs'
+const cellClasses = 'px-2 py-2 overflow-hidden overflow-ellipsis whitespace-nowrap max-w-xs'
 
 
 export default class BodyTable extends React.Component<BodyTableProps> {
@@ -115,8 +115,8 @@ export default class BodyTable extends React.Component<BodyTableProps> {
 
     const tableRows = body.map((row, i) => {
       return (
-        <tr key={i} className='border-b border-gray-200'>
-          <td key={0}className='bg-white text-center'>
+        <tr key={i} className=''>
+          <td key={0}className='bg-white text-center border-r border-b border-gray-200'>
             <div className={classNames(cellClasses, 'text-qrinavy-500')}>
               {
                 // TODO (ramfox): when we add back pageInfo/fetching
@@ -128,7 +128,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
           </td>
           {row.map((d: any, j: number) => {
             return (
-              <td key={j + 1}>
+              <td key={j + 1} className='border-r border-b border-gray-200'>
                 <div className={classNames(cellClasses, 'text-qrigray-400')}>{typeof d === 'boolean' ? JSON.stringify(d) : d}</div>
               </td>
             )
@@ -145,16 +145,16 @@ export default class BodyTable extends React.Component<BodyTableProps> {
         style={{ maxWidth: 800 }}
         onScroll={() => { this.handleVerticalScrollThrottled() } }
       >
-        <table className='table text-xs'>
-          <thead className='border-b border-gray-200'>
+        <table className='table text-xs border-separate border-l border-gray-200' style={{ borderSpacing: 0 }}>
+          <thead className='sticky top-0'>
             <tr>
-              <th className='sticky top-0 h-6 bg-white cursor-pointer p-0'>
-                <div className={classNames(cellClasses, 'border-r border-b leading-4')}>&nbsp;</div>
+              <th className=' h-6 bg-white p-0 border-t border-r border-b border-gray-200'>
+                <div className={classNames(cellClasses, 'leading-4')}>&nbsp;</div>
               </th>
               {headers && headers.map((d: any, j: number) => {
                 return (
-                  <th key={j} className='sticky top-0 h-6 bg-white font-medium text-left p-0'>
-                    <div className={classNames(cellClasses, 'text-qrinavy text-sm border-r border-b leading-4')} >
+                  <th key={j} className=' h-6 bg-white font-medium text-left p-0 p-0 border-t border-r border-b border-gray-200'>
+                    <div className={classNames(cellClasses, 'text-qrinavy text-sm leading-4')} >
                       <TypeLabel type={d.type} showLabel={false}/>&nbsp;{d.title}
                     </div>
                   </th>

--- a/frontend/src/features/dsComponents/readme/Readme.tsx
+++ b/frontend/src/features/dsComponents/readme/Readme.tsx
@@ -33,7 +33,7 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
   if (!hasReadme) {
     return (
       <div className='h-full w-full flex items-center'>
-        <div className='text-center mx-auto text-sm'>
+        <div className='text-center mx-auto text-sm text-qrigray-400'>
           Error fetching readme
         </div>
       </div>

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -123,7 +123,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                 </div>
                 <div ref={versionInfoContainer} className='w-5/12 px-3 inline-block align-top'>
                   <ContentBox>
-                    <div className='flex items-center border-b pb-4'>
+                    <div className='flex items-center border-b pb-4 mb-3'>
                       <div className='flex-grow truncate'>
                         <ContentBoxTitle title='Version Info' />
                         <div className='text-qrinavy text-sm flex items-center mb-0'>

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -14,6 +14,7 @@ import ContentBoxTitle from '../../chrome/ContentBoxTitle'
 import DownloadDatasetButton from '../download/DownloadDatasetButton'
 import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
+import TextLink from '../../chrome/TextLink'
 import Button from '../../chrome/Button'
 import BodyPreview from '../dsComponents/body/BodyPreview'
 import DatasetHeader from '../dataset/DatasetHeader'
@@ -79,7 +80,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
               <div className='px-8 pt-4 pb-3 flex'>
                 <div className='flex-grow'>
                   <div className='text-xs text-gray-400 font-mono'>
-                    {dataset.peername}/{dataset.name}
+                    <TextLink to={`/${dataset.peername}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{dataset.peername || 'new'}</TextLink>/{dataset.name}
                   </div>
                   <div className='text-normal text-qrinavy font-semibold'>
                     {dataset.meta?.title || dataset.name}

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -127,11 +127,11 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                       <div className='flex-grow truncate'>
                         <ContentBoxTitle title='Version Info' />
                         <div className='text-qrinavy text-sm flex items-center mb-0'>
-                          <Icon icon='commit' size='sm' className='-ml-2' />
+                          <Icon icon='commit' size='sm' className='-ml-1.5' />
                           <div className='font-medium'>{commitishFromPath(dataset.path)}</div>
                         </div>
                         <div className='text-sm text-qrinavy mb-2 truncate' title={dataset.commit?.title}>{dataset.commit?.title}</div>
-                        <div className='flex items-center text-gray-400'>
+                        <div className='flex items-center text-gray-400 text-xs'>
                           <RelativeTimestampWithIcon timestamp={new Date(dataset.commit?.timestamp)} className='mr-3' />
                           <UsernameWithIcon username='chriswhong' className='mt-0.5' />
                         </div>

--- a/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/frontend/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -143,7 +143,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                     </div>
                     {/* Bottom of the box */}
                     <ContentBoxTitle title='Description' />
-                    <div className='pt-4 text-gray-400 text-xs tracking-wider mb-2 break-words'>{(dataset.meta?.description) || 'No Description'}</div>
+                    <div className='text-gray-400 text-xs tracking-wider mb-2 break-words'>{(dataset.meta?.description) || 'No Description'}</div>
                     {dataset.meta?.keywords?.map((keyword) => {
                       return <div key={keyword} className='leading-tight text-gray-400 text-xs tracking-wider inline-block border border-qrigray-400 rounded-md px-2 py-1 mr-1 mb-1'>{keyword}</div>
                     })}

--- a/frontend/src/features/navbar/NavBar.tsx
+++ b/frontend/src/features/navbar/NavBar.tsx
@@ -7,6 +7,8 @@ import SearchBox from '../search/SearchBox'
 import QriLogo from '../../chrome/QriLogo'
 import ButtonGroup from '../../chrome/ButtonGroup'
 import { selectNavExpanded } from '../app/state/appState'
+import { AnonUser, selectSessionUser } from '../session/state/sessionState'
+
 
 export interface NavBarProps {
   minimal?: boolean
@@ -18,6 +20,7 @@ const NavBar: React.FC<NavBarProps> = ({
   showSearch = true
 }) => {
   const expanded = useSelector(selectNavExpanded)
+  const user = useSelector(selectSessionUser)
   const location = useLocation()
   const history = useHistory()
 
@@ -46,7 +49,7 @@ const NavBar: React.FC<NavBarProps> = ({
       </Link>
       {!minimal && showSearch && <SearchBox onSubmit={handleSearchSubmit} placeholder='Search for Datasets' />}
       <div className='flex m-auto items-center'>
-        {!minimal && (
+        {!minimal && (user !== AnonUser) && (
           <ButtonGroup
             items={buttonItems}
             selectedIndex={buttonItems.findIndex((d) => location.pathname === d.link)}

--- a/frontend/src/features/session/modal/LogInModal.tsx
+++ b/frontend/src/features/session/modal/LogInModal.tsx
@@ -28,7 +28,8 @@ const LogInModal: React.FC = () => {
     dispatch(showModal(ModalType.signUp))
   }
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     logIn(username, password)(dispatch)
       .then((action: AnyAction) => {
         if (getActionType(action) === ACTION_FAILURE) {
@@ -46,29 +47,30 @@ const LogInModal: React.FC = () => {
       </div>
       <div className='text-3xl font-black mb-8 text-qrinavy'>Welcome to Qri</div>
       <div className='w-72 mx-auto'>
-        <div className='mb-8'>
-          <TextInput
-            name='username'
-            value={username}
-            onChange={(value) => { setUsername(value)  }}
-            placeholder='Username'
-          />
-          <TextInput
-            name='password'
-            type='password'
-            value={password}
-            onChange={(value) => { setPassword(value)  }}
-            placeholder='Password'
-          />
-          <Link to='/forgot-password'><div className='text-left text-qrinavy text-xs font-medium'>Forgot your Password?</div></Link>
-        </div>
+        <form>
+          <div className='mb-8'>
+            <TextInput
+              name='username'
+              value={username}
+              onChange={(value) => { setUsername(value)  }}
+              placeholder='Username'
+            />
+            <TextInput
+              name='password'
+              type='password'
+              value={password}
+              onChange={(value) => { setPassword(value)  }}
+              placeholder='Password'
+            />
+            <Link to='/forgot-password'><div className='text-left text-qrinavy text-xs font-medium'>Forgot your Password?</div></Link>
+          </div>
 
-        {loginError && <div className='text-xs text-red-500 text-left mb-2'>{loginError}</div>}
+          {loginError && <div className='text-xs text-red-500 text-left mb-2'>{loginError}</div>}
 
-        <Button size='sm' className='w-full mb-6' onClick={handleButtonClick}>
-          {loading ? <Spinner color='#fff' size={6} /> : 'Log In'}
-        </Button>
-
+          <Button size='sm' className='w-full mb-6' onClick={handleButtonClick} submit>
+            {loading ? <Spinner color='#fff' size={6} /> : 'Log In'}
+          </Button>
+        </form>
         <div className='mb-3 text-qrigray-400 tracking-wider text-xs'>
           By continuing, you agree to Qri's <TextLink to='https://qri.io/legal/tos'>Terms of Service</TextLink> & <TextLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</TextLink>.
         </div>

--- a/frontend/src/features/session/modal/SignUpModal.tsx
+++ b/frontend/src/features/session/modal/SignUpModal.tsx
@@ -35,7 +35,8 @@ const SignUpModal: React.FC = () => {
     dispatch(showModal(ModalType.logIn))
   }
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     // validate email
     const emailError = validateEmail(email)
     setEmailError(emailError)
@@ -66,35 +67,36 @@ const SignUpModal: React.FC = () => {
       </div>
       <div className='text-3xl font-black mb-8 text-qrinavy'>Sign Up for Qri</div>
       <div className='w-72 mx-auto'>
-        <div className='mb-8'>
-          <TextInput
-            name='email'
-            placeholder='Email'
-            value={email}
-            onChange={(value) => { setEmail(value)  }}
-            error={emailError}
-          />
-          <TextInput
-            name='username'
-            placeholder='Username'
-            value={username}
-            onChange={(value) => { setUsername(value)  }}
-            error={usernameError}
-          />
-          <TextInput
-            name='password'
-            type='password'
-            placeholder='Password'
-            value={password}
-            onChange={(value) => { setPassword(value)  }}
-            error={passwordError}
-          />
-        </div>
-        {signupError && <div className='text-xs text-red-500 text-left mb-2'>{signupError}</div>}
-        <Button size='sm' className='w-full mb-6' onClick={handleButtonClick}>
-          {loading ? <Spinner color='#fff' size='6' /> : 'Continue'}
-        </Button>
-
+        <form>
+          <div className='mb-8'>
+            <TextInput
+              name='email'
+              placeholder='Email'
+              value={email}
+              onChange={(value) => { setEmail(value)  }}
+              error={emailError}
+            />
+            <TextInput
+              name='username'
+              placeholder='Username'
+              value={username}
+              onChange={(value) => { setUsername(value)  }}
+              error={usernameError}
+            />
+            <TextInput
+              name='password'
+              type='password'
+              placeholder='Password'
+              value={password}
+              onChange={(value) => { setPassword(value)  }}
+              error={passwordError}
+            />
+          </div>
+          {signupError && <div className='text-xs text-red-500 text-left mb-2'>{signupError}</div>}
+          <Button size='sm' className='w-full mb-6' onClick={handleButtonClick} submit>
+            {loading ? <Spinner color='#fff' size='6' /> : 'Continue'}
+          </Button>
+        </form>
         <div className='mb-3 text-qrigray-400 tracking-wider text-xs'>
           By continuing, you agree to Qri's <TextLink to='https://qri.io/legal/tos'>Terms of Service</TextLink> & <TextLink to='https://qri.io/legal/privacy-policy'>Privacy Policy</TextLink>.
         </div>

--- a/frontend/src/features/userProfile/UserProfile.tsx
+++ b/frontend/src/features/userProfile/UserProfile.tsx
@@ -122,7 +122,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
               }}></div>
               <div>
                 <div className='text-qrinavy text-sm font-semibold'>{profile.name}</div>
-                <div className='text-qrigray-400 text-xs'>{profile.username}</div>
+                <div className='text-qrigray-400 text-xs font-mono'>{profile.username}</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION

- fixes a bug where qriRef was undefined in `DatasetHeader`
- use mono font in profile sticky header
- add a simple prompt when user has no datasets, link to Qri CLI quickstart
- user can hit enter to submit login/signup forms
- hide my datasets/dashboard nav items when user is not logged in
- make readme error text gray
- add some margin above Description in preview
- make usernames clickable in dataset header, links to user's profile
- adjust padding for description in preview page
- clean up table borders!