### PR TITLE
refactor(api): aligning cloud/core routes

### DIFF
--- a/src/chrome/PageControl.tsx
+++ b/src/chrome/PageControl.tsx
@@ -24,7 +24,7 @@ interface PageControlProps {
 
 // pass in pageInfo prop to show pagination info and controls
 const PageControl: React.FC<PageControlProps> = ({
-  pageInfo,
+  pageInfo = {},
   queryParams,
   showRange = true,
   onPageChange

--- a/src/features/activityFeed/state/activityFeedActions.ts
+++ b/src/features/activityFeed/state/activityFeedActions.ts
@@ -17,8 +17,11 @@ function fetchDatasetLogs(qriRef: QriRef): ApiAction {
     type: 'dataset_logs',
     qriRef,
     [CALL_API]: {
-      endpoint: `history/${qriRef.username}/${qriRef.name}`,
-      method: 'GET',
+      endpoint: `ds/activity`,
+      method: 'POST',
+      body: {
+        ref: `${qriRef.username}/${qriRef.name}`
+      },
       map: mapLogs
     }
   }

--- a/src/features/dataset/state/datasetActions.ts
+++ b/src/features/dataset/state/datasetActions.ts
@@ -36,7 +36,7 @@ function fetchDataset (ref: QriRef): ApiAction {
     type: 'dataset',
     ref,
     [CALL_API]: {
-      endpoint: 'dataset_summary',
+      endpoint: 'ds/get',
       method: 'GET',
       segments: ref,
       map: mapDataset
@@ -55,7 +55,7 @@ function fetchBody (ref: QriRef, page: number, pageSize: number): ApiAction {
     type: 'body',
     ref,
     [CALL_API]: {
-      endpoint: 'get',
+      endpoint: 'ds/get',
       method: 'GET',
       pageInfo: {
         page,

--- a/src/features/dataset/state/datasetActions.ts
+++ b/src/features/dataset/state/datasetActions.ts
@@ -28,7 +28,7 @@ export function downloadLinkFromQriRef(ref: QriRef, body: boolean = false): stri
   if (body) {
     return `${API_BASE_URL}/ds/get/${ref.username}/${ref.name}${pathSegment}/body.csv`
   }
-  return `${API_BASE_URL}/download/${ref.username}/${ref.name}${pathSegment}`
+  return `${API_BASE_URL}/ds/get/${ref.username}/${ref.name}${pathSegment}?format=zip`
 }
 
 function fetchDataset (ref: QriRef): ApiAction {

--- a/src/features/dsComponents/readme/Readme.tsx
+++ b/src/features/dsComponents/readme/Readme.tsx
@@ -1,44 +1,29 @@
 import React, { useCallback } from 'react'
 
-import { QriRef } from '../../../qri/ref'
-import { API_BASE_URL } from '../../../store/api'
+import Dataset from '../../../qri/dataset'
 
 export interface ReadmeProps {
-  qriRef: QriRef
+  dataset: Dataset
 }
 
-export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => {
-  const { qriRef } = props
-  const [hasReadme, setHasReadme] = React.useState(true)
-
+export const ReadmeComponent: React.FC<ReadmeProps> = ({ dataset }) => {
+  const readme = dataset.readme?.script
   const refCallback = useCallback((el: HTMLDivElement) =>{
-    if (el !== null) {
-      fetch(`${API_BASE_URL}/dataset_summary/readme?path=${qriRef.path}`)
-        .then((res) => {
-          if (res.ok) {
-            return res.text()
-          } else {
-            return Promise.reject('error 404')
-          }
-        })
-        .then((renderedReadme) => {
-          el.innerHTML = renderedReadme
-        })
-        .catch((e) => {
-          setHasReadme(false)
-        })
+    if (readme) {
+      el.innerHTML = readme
     }
-  }, [qriRef.path])
+  }, [readme])
 
-  if (!hasReadme) {
+  if (!readme) {
     return (
       <div className='h-full w-full flex items-center'>
         <div className='text-center mx-auto text-sm text-qrigray-400'>
-          Error fetching readme
+          no readme
         </div>
       </div>
     )
   }
+
   return (
     <div className='h-full w-full'>
       <div
@@ -51,5 +36,4 @@ export const ReadmeComponent: React.FunctionComponent<ReadmeProps> = (props) => 
   )
 }
 
-// TODO (b5) - this doesn't need to be a container at all
 export default ReadmeComponent

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -21,7 +21,6 @@ import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 import DeployingScreen from '../deploy/DeployingScreen'
 import commitishFromPath from '../../utils/commitishFromPath'
 import Readme from '../dsComponents/readme/Readme'
-import { qriRefFromDataset } from '../../qri/dataset'
 import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState'
 import { QriRef } from '../../qri/ref'
 import MetaChips from '../../chrome/MetaChips'
@@ -79,7 +78,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                     <div className='flex-grow overflow-hidden'>
                       {
                         dataset.readme ? (
-                          <Readme qriRef={qriRefFromDataset(dataset)} />
+                          <Readme dataset={dataset} />
                         ) : (
                           <div className='h-full w-full flex items-center'>
                             <div className='text-center mx-auto text-sm'>

--- a/src/features/dsPreview/state/dsPreviewActions.ts
+++ b/src/features/dsPreview/state/dsPreviewActions.ts
@@ -3,9 +3,14 @@ import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api";
 
 export function loadDsPreview(ref: QriRef): ApiActionThunk {
   return async (dispatch, getState) => {
-    return dispatch(fetchDsPreview(ref))
+    await Promise.all([dispatch(fetchDsPreview(ref))])
+    dispatch(fetchDsPreviewBody(ref))
+    dispatch(fetchDsPreviewReadme(ref))
+    return dispatch(fetchPreviewDone(ref))
   }
 }
+
+export const bodyPageSizeDefault = 50
 
 function fetchDsPreview (ref: QriRef): ApiAction {
   return {
@@ -16,5 +21,50 @@ function fetchDsPreview (ref: QriRef): ApiAction {
       method: 'GET',
       segments: ref
     }
+  }
+}
+
+function fetchDsPreviewBody (ref: QriRef, page: number = 1, pageSize: number = bodyPageSizeDefault): ApiAction {
+  return {
+    type: 'datasetpreviewbody',
+    ref,
+    [CALL_API]: {
+      endpoint: 'ds/get',
+      method: 'GET',
+      pageInfo: {
+        page,
+        pageSize
+      },
+      segments: {
+        username: ref.username,
+        name: ref.name,
+        path: ref.path,
+        selector: ['body']
+      },
+    }
+  }
+}
+
+function fetchDsPreviewReadme (ref: QriRef): ApiAction {
+  return {
+    type: 'datasetpreviewreadme',
+    ref,
+    [CALL_API]: {
+      endpoint: 'ds/get',
+      method: 'GET',
+      segments: {
+        username: ref.username,
+        name: ref.name,
+        path: ref.path,
+        selector: ['readme']
+      },
+    }
+  }
+}
+
+function fetchPreviewDone (ref: QriRef): ApiAction {
+  return {
+    type: 'datasetpreviewfetchdone',
+    ref
   }
 }

--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -21,8 +21,28 @@ export const dsPreviewReducer = createReducer(initialState, {
     state.preview = undefined
     state.loading = true
   },
+  'API_DATASETPREVIEWFETCHDONE_REQUEST': (state) => {
+    state.loading = true
+  },
+  'API_DATASETPREVIEWBODY_REQUEST': (state) => {
+    state.loading = true
+  },
+  'API_DATASETPREVIEWREADME_REQUEST': (state) => {
+    state.loading = true
+  },
   'API_DATASETPREVIEW_SUCCESS': (state, action) => {
     state.preview = action.payload.data
+  },
+  'API_DATASETPREVIEWBODY_SUCCESS': (state, action) => {
+    state.preview.body = action.payload.data
+  },
+  'API_DATASETPREVIEWREADME_SUCCESS': (state, action) => {
+    state.preview.readme = action.payload.data
+  },
+  'API_DATASETPREVIEWFETCHDONE_SUCCESS': (state) => {
+    state.loading = false
+  },
+  'API_DATASETPREVIEWFETCHDONE_FAILURE': (state) => {
     state.loading = false
   },
   'API_DATASETPREVIEW_FAILURE': (state) => {

--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -17,35 +17,35 @@ const initialState: DsPreviewState = {
 }
 
 export const dsPreviewReducer = createReducer(initialState, {
-  'API_DATASETPREVIEW_REQUEST': (state) => {
+  'DS_PREVIEW_REQUEST': (state) => {
     state.preview = undefined
     state.loading = true
   },
-  'API_DATASETPREVIEWFETCHDONE_REQUEST': (state) => {
-    state.loading = true
+  'DS_PREVIEW_SUCCESS': (state) => {
+    state.loading = false
   },
-  'API_DATASETPREVIEWBODY_REQUEST': (state) => {
-    state.loading = true
+  'DS_PREVIEW_FAILURE': (state) => {
+    state.loading = false
   },
-  'API_DATASETPREVIEWREADME_REQUEST': (state) => {
-    state.loading = true
+
+
+  'API_PREVIEW_FAILURE': (state) => {
+    state.loading = false
   },
-  'API_DATASETPREVIEW_SUCCESS': (state, action) => {
+  'API_PREVIEW_SUCCESS': (state, action) => {
     state.preview = action.payload.data
   },
-  'API_DATASETPREVIEWBODY_SUCCESS': (state, action) => {
+
+  'API_PREVIEWBODY_REQUEST': (state) => {
+    state.loading = true
+  },
+  'API_PREVIEWBODY_SUCCESS': (state, action) => {
     state.preview.body = action.payload.data
   },
-  'API_DATASETPREVIEWREADME_SUCCESS': (state, action) => {
-    state.preview.readme = action.payload.data
+
+  'API_PREVIEWREADME_SUCCESS': (state, action) => {
+    state.preview.readme = { script: atob(action.payload.data) }
   },
-  'API_DATASETPREVIEWFETCHDONE_SUCCESS': (state) => {
-    state.loading = false
+  'API_PREVIEWREADME_FAILURE': (state, action) => {
   },
-  'API_DATASETPREVIEWFETCHDONE_FAILURE': (state) => {
-    state.loading = false
-  },
-  'API_DATASETPREVIEW_FAILURE': (state) => {
-    state.loading = false
-  }
 })

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -40,7 +40,7 @@ const Search: React.FC<{}> = () => {
   // if the query string ever changes, fetch new data
   useEffect(() => {
     dispatch(loadSearchResults(searchParams))
-  }, [q, page, sort, dispatch, searchParams])
+  }, [q, page, sort, dispatch])
 
   // handle new search term input
   const handleSearchSubmit = (newQ:string) => {

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -40,7 +40,7 @@ const Search: React.FC<{}> = () => {
   // if the query string ever changes, fetch new data
   useEffect(() => {
     dispatch(loadSearchResults(searchParams))
-  }, [q, page, sort, dispatch])
+  }, [q, page, sort, dispatch, searchParams])
 
   // handle new search term input
   const handleSearchSubmit = (newQ:string) => {

--- a/src/features/search/state/searchActions.ts
+++ b/src/features/search/state/searchActions.ts
@@ -24,13 +24,15 @@ function fetchSearchResults (searchParams: SearchParams): ApiAction {
   return {
     type: 'search',
     [CALL_API]: {
-      endpoint: 'search',
-      method: 'GET',
+      endpoint: 'remote/search',
+      method: 'POST',
+      body: {
+        query: mapFrontendParams(searchParams),
+      },
       pageInfo: {
         page: searchParams.page,
         pageSize: searchParams.pageSize
       },
-      query: mapFrontendParams(searchParams),
       map: mapSearchResults
     }
   }

--- a/src/features/search/state/searchActions.ts
+++ b/src/features/search/state/searchActions.ts
@@ -21,18 +21,22 @@ const mapFrontendParams = (frontendParams: SearchParams) => {
 }
 
 function fetchSearchResults (searchParams: SearchParams): ApiAction {
+  // TODO(arqu): We send the q param as in the POST body, but also as a url query to be able to work
+  // across both cloud and core until the alignment between the two is complete. Should be POST only
+  // with just the body
   return {
     type: 'search',
     [CALL_API]: {
-      endpoint: 'remote/search',
+      endpoint: 'registry/search',
       method: 'POST',
       body: {
-        query: mapFrontendParams(searchParams),
+        q: searchParams.q,
       },
       pageInfo: {
         page: searchParams.page,
         pageSize: searchParams.pageSize
       },
+      query: mapFrontendParams(searchParams),
       map: mapSearchResults
     }
   }

--- a/src/features/search/state/searchState.ts
+++ b/src/features/search/state/searchState.ts
@@ -34,7 +34,7 @@ export const searchReducer = createReducer(initialState, {
   'API_SEARCH_SUCCESS': (state: SearchState, action) => {
     state.results = action.payload.data
     state.loading = false
-    state.pageInfo = action.payload.pagination
+    state.pageInfo = action.payload.pagination || {}
   },
   'API_SEARCH_FAILURE': (state: SearchState) => {
     state.loading = false

--- a/src/qri/search.ts
+++ b/src/qri/search.ts
@@ -52,37 +52,38 @@ export interface SearchResult extends Dataset {
 }
 
 export function NewSearchResult(d: Record<string,any>): SearchResult {
-  const ds = NewDataset(d)
+  const dv = d.value
+  const ds = NewDataset(dv)
   let stats
-  let followStats
-  let issueStats
+  let followStats = {}
+  let issueStats = {}
 
-  if (d.stats) {
+  if (dv.stats) {
     stats = {
-      downloadCount: d.stats.download_count,
-      pullCount: d.stats.pull_count,
-      viewCount: d.stats.view_count
+      downloadCount: dv.stats.download_count,
+      pullCount: dv.stats.pull_count,
+      viewCount: dv.stats.view_count
     }
   }
 
-  if (d.follow_stats) {
+  if (dv.follow_stats) {
     followStats = {
-      followCount: d.follow_stats.follow_count,
-      followStatus: d.follow_stats.follow_status
+      followCount: dv.follow_stats.follow_count,
+      followStatus: dv.follow_stats.follow_status
     }
   }
 
-  if (d.issue_stats) {
+  if (dv.issue_stats) {
     issueStats = {
-      openIssues: d.issue_stats.open_issues,
-      closedIssues: d.issue_stats.closed_issues
+      openIssues: dv.issue_stats.open_issues,
+      closedIssues: dv.issue_stats.closed_issues
     }
   }
 
   return {
     ...ds,
     stats,
-    followStats: d.followStats || followStats,
-    issueStats: d.issueStats || issueStats
+    followStats: dv.followStats || followStats,
+    issueStats: dv.issueStats || issueStats
   }
 }

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -150,14 +150,12 @@ function apiUrl (endpoint: string, segments?: QriRef, query?: ApiQuery, pageInfo
     if (segments.peerID) {
       url = addToUrl(url, segments.peerID)
     }
-    // TODO(b5): restore! this is causing issues with updated backend API routes
-    // somehwere.
-    // if (segments.path) {
-    //   url = addToUrl(url, segments.path)
-    // }
-    // if (segments.selector) {
-    //   url = addToUrl(url, segments.selector.join('/'))
-    // }
+    if (segments.path) {
+      url = addToUrl(url, segments.path)
+    }
+    if (segments.selector) {
+      url = addToUrl(url, segments.selector.join('/'))
+    }
   }
 
   if (query) {

--- a/src/utils/commitishFromPath.ts
+++ b/src/utils/commitishFromPath.ts
@@ -1,3 +1,6 @@
 export default function commitishFromPath (path: string): string {
-  return path.split('/')[2].substr(0,8)
+	if (path) {
+		return path.split('/')[2].substr(0,8)		
+	}
+  	return "unknown"
 }


### PR DESCRIPTION
I've cobbled together some wannabe fixes (my react foo is barely enough to make it work, best practices are out of the window). But this does set the stage for a few things to work better between core/cloud. Read up on the notes in the related issue for a better overview https://github.com/qri-io/qri/issues/1800 (especially the last section). 

~~Depends on: https://github.com/qri-io/cloud/pull/519 & https://github.com/qri-io/qri/pull/1816~~