### PR TITLE
Cw/UI punchlist

### DIFF
--- a/src/chrome/IconLink.tsx
+++ b/src/chrome/IconLink.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import classNames from 'classnames'
 import ExternalLink from './ExternalLink'
 import Icon, { IconSize } from './Icon'
 
@@ -6,6 +7,7 @@ interface IconLinkProps {
   icon: string
   link?: string
   size?: IconSize
+  className?: string
   onClick?: () => void
 }
 
@@ -13,14 +15,15 @@ const IconLink: React.FC<IconLinkProps> = ({
   icon,
   link,
   size='sm',
+  className,
   onClick
 }) => {
-  const classNames = 'text-qrinavy hover:text-qripink hover:cursor-pointer'
+  const linkClassNames = 'text-qrinavy hover:text-qripink hover:cursor-pointer'
 
   if (link) {
     return (
-      <div className='ml-2'>
-        <ExternalLink to={link} className={classNames}>
+      <div className={classNames('ml-2', className)}>
+        <ExternalLink to={link} className={linkClassNames}>
           <Icon icon={icon} size={size} />
         </ExternalLink>
       </div>
@@ -28,8 +31,8 @@ const IconLink: React.FC<IconLinkProps> = ({
   }
 
   return (
-    <div className='ml-2'>
-      <div className={classNames} onClick={onClick}>
+    <div className={classNames('ml-2', className)}>
+      <div className={linkClassNames} onClick={onClick}>
         <Icon icon={icon} size={size} />
       </div>
     </div>

--- a/src/features/app/App.css
+++ b/src/features/app/App.css
@@ -43,6 +43,7 @@
 .__react_component_tooltip {
 	transition: opacity 0.1s ease-in-out !important;
 	visibility: visible;
+  max-width: 250px;
 }
 
 // webkit scrollbars

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -1,4 +1,4 @@
- import React, { forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { useDispatch } from 'react-redux';
 import numeral from 'numeral'
 import ReactDataTable from 'react-data-table-component'
@@ -188,19 +188,20 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         )
       }
     },
-    {
-      name: 'Triggers',
-      style: {
-        flexShrink: 0
-      },
-      selector: 'triggers',
-      omit: simplified,
-      width: '160px',
-      cell: (row: VersionInfo) => (row.id
-          ? <div className='tracking-wider font-medium text-qrinavy'>Schedule, Run When, Webhook</div>
-          : '—'
-      )
-    },
+    // let's hide the Triggers column for now, to provide more room for the name column on narrow screens
+    // {
+    //   name: 'Triggers',
+    //   style: {
+    //     flexShrink: 0
+    //   },
+    //   selector: 'triggers',
+    //   omit: simplified,
+    //   width: '160px',
+    //   cell: (row: VersionInfo) => (row.id
+    //       ? <div className='tracking-wider font-medium text-qrinavy'>Schedule, Run When, Webhook</div>
+    //       : '—'
+    //   )
+    // },
     {
       name: 'Actions',
       style: {

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -14,30 +14,54 @@ import Icon from '../../chrome/Icon';
 export interface DatasetCommitProps {
   logItem: LogItem
   active?: boolean
+  isLink?: boolean
 }
 
 const DatasetCommit: React.FC<DatasetCommitProps> = ({
   logItem,
-  active = false
-}) => (
-  <Link
-    className={classNames('block rounded-md px-3 pt-2 pb-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-qrigray-400 border border-qrigray-300')}
-    to={pathToDatasetViewer(newQriRef(logItem))}
-    style={{ fontSize: 11 }}
-  >
-    <div className='flex justify-between'>
-      <div className='font-medium mb-1 pr-2'>{logItem.title}</div>
-      <div className='flex-grow-0 text-qrigreen'>
-        <Icon icon='automationFilled' size='sm'/>
+  active = false,
+  isLink = true
+}) => {
+  const content = (
+    <>
+      <div className='flex justify-between'>
+        <div className='font-medium mb-1 pr-2'>{logItem.title}</div>
+        <div className='flex-grow-0 text-qrigreen'>
+          <Icon icon='automationFilled' size='sm'/>
+        </div>
       </div>
+      <div className='flex items-center text-qrigray-400'>
+        {logItem.username && <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />}
+        <RelativeTimestampWithIcon timestamp={new Date(logItem.timestamp)} />
+      </div>
+      {/* TODO(chriswhong): restore when we can add component change indicators <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />*/}
+    </>
+  )
+
+  const containerClassNames = classNames('block rounded-md px-3 pt-2 pb-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-qrigray-400 border border-qrigray-300')
+
+  if (isLink) {
+    return (
+      <Link
+        className={containerClassNames}
+        to={pathToDatasetViewer(newQriRef(logItem))}
+        style={{ fontSize: 11 }}
+      >
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <div
+      className={containerClassNames}
+      style={{ fontSize: 11 }}
+    >
+      {content}
     </div>
-    <div className='flex items-center text-qrigray-400'>
-      {logItem.username && <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />}
-      <RelativeTimestampWithIcon timestamp={new Date(logItem.timestamp)} />
-    </div>
-    {/* TODO(chriswhong): restore when we can add component change indicators <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />*/}
-  </Link>
-)
+  )
+
+}
 
 
 export default DatasetCommit

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -9,7 +9,7 @@ import DownloadDatasetButton from '../download/DownloadDatasetButton'
 
 export interface DatasetMiniHeaderProps {
   dataset: Dataset
-  hide: boolean
+  show: boolean
 }
 
 // DatasetHeader and DatasetMiniHeader now accept children which will be displayed
@@ -19,16 +19,17 @@ export interface DatasetMiniHeaderProps {
 
 const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
   dataset,
-  hide,
+  show,
   children
 }) => {
   const qriRef = qriRefFromDataset(dataset)
   return (
-    <div className={classNames('sticky top-0 bg-white border border-qrigray-200 z-10', {
-      'invisible -top-16 h-0': !hide,
-      'visible top-0 transition-all': !hide
+    <div className={classNames('sticky bg-white border border-qrigray-200 z-10', {
+      'invisible -top-16 h-0': !show,
+      'visible top-0': show
     })} style={{
-      borderTopLeftRadius: '20px'
+      borderTopLeftRadius: '20px',
+      transition: 'top 150ms cubic-bezier(0.4, 0, 0.2, 1)'
     }}>
       <div className='px-7 pt-4 pb-3 flex z-10'>
         <div className='flex-grow'>

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -43,7 +43,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
 
   return (
     <div className={`side-nav pl-9 h-full bg-white relative pt-9 flex-shrink-0 ${expanded ? 'w-52' : 'w-24'}`}>
-      <div className='mb-9 flex align-center items-center'>
+      <div className='mb-9 flex align-center items-center h-6'>
         <div
           className='text-gray-400 text-sm font-medium mr-4 leading-6 transition-all duration-700'
           style={{

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -28,6 +28,12 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
 
   const toggleExpanded = () => {
     dispatch(toggleNavExpanded())
+    // the monaco code components in CodeEditor are listening for 'resize' so they can
+    // set their width.  A small delay is necessary here so that the CodeEditor resize
+    // works properly after collapsing the dataset menu
+    setTimeout(() => {
+      window.dispatchEvent(new Event('resize'))
+    }, 5)
   }
 
   // determine if the workflow is new by reading /new at the end of the pathname

--- a/src/features/dataset/DatasetSideNavItem.tsx
+++ b/src/features/dataset/DatasetSideNavItem.tsx
@@ -58,7 +58,7 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({
   if (disabled) {
     return (
       <>
-        <div className='mb-4 inline-block'>
+        <div className='mb-4 inline-block h-6'>
           <div className='font-medium text-qrigray-300 cursor-pointer'>
             {content}
           </div>
@@ -70,7 +70,7 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({
 
   return (
     <>
-      <div className='mb-4 inline-block'>
+      <div className='mb-4 inline-block h-6'>
         <Link to={to} className={classNames('font-medium text-qrinavy transition-100 transition-all hover:text-qripink', {
           'text-qripink': active
         })}>

--- a/src/features/deploy/DeployStatusIndicator.tsx
+++ b/src/features/deploy/DeployStatusIndicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import classNames from 'classnames'
+import ReactTooltip from 'react-tooltip'
 
 import Icon from '../../chrome/Icon'
 import { Workflow } from '../../qrimatic/workflow'
@@ -13,14 +14,21 @@ export interface DeployStatusIndicatorProps {
 
 const DeployStatusIndicator: React.FC<DeployStatusIndicatorProps> = ({ workflow }) => {
   const status = useSelector(newDeployStatusSelector(workflow.id))
-  const { statusIcon, color, statusText } = deployStatusInfoMap[status]
+  const { statusIcon, color, statusText, message } = deployStatusInfoMap[status]
 
   return (
     <div>
-      <div className='mb-2' >
+      <div className='mb-2 inline-block' data-tip data-for='deploy-status'>
         <Icon icon={statusIcon} className={classNames('mr-2.5', color)} size='md' />
         <span className={classNames('text-sm font-semibold text-gray-600', color)}>{statusText}</span>
       </div>
+      <ReactTooltip
+        id='deploy-status'
+        place='right'
+        effect='solid'
+      >
+        {message}
+      </ReactTooltip>
     </div>
   )
 }

--- a/src/features/dsComponents/ComponentHeader.tsx
+++ b/src/features/dsComponents/ComponentHeader.tsx
@@ -7,7 +7,7 @@ interface ComponentHeaderProps {
 
 const ComponentHeader: React.FC<ComponentHeaderProps> = ({ border = true, children }) => {
   return (
-    <div className={classNames('flex-grow text-sm py-3 px-4', {
+    <div className={classNames('flex-grow text-sm py-3', {
       'border-b': border
     })}>
       {children}

--- a/src/features/dsComponents/body/BodyTable.tsx
+++ b/src/features/dsComponents/body/BodyTable.tsx
@@ -145,7 +145,7 @@ export default class BodyTable extends React.Component<BodyTableProps> {
         style={{ maxWidth: 800 }}
         onScroll={() => { this.handleVerticalScrollThrottled() } }
       >
-        <table className='table text-xs border-separate border-l border-gray-200 ml-4 pr-4 mb-4 ' style={{ borderSpacing: 0 }}>
+        <table className='table text-xs border-separate border-l border-gray-200 mb-4 ' style={{ borderSpacing: 0 }}>
           <thead className='sticky top-0'>
             <tr>
               <th className=' h-6 bg-white p-0 border-t border-r border-b border-gray-200'>

--- a/src/features/dsComponents/structure/Structure.tsx
+++ b/src/features/dsComponents/structure/Structure.tsx
@@ -66,7 +66,7 @@ export const StructureComponent: React.FunctionComponent<StructureProps> = ({dat
   }
 
   return (
-    <div className='h-full w-full overflow-x-hidden px-4 pb-4'>
+    <div className='h-full w-full overflow-x-hidden pb-4'>
       <LabeledStats data={data} size='lg' />
       <Schema
         data={schema}

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -67,7 +67,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
           </div>)
         : (
           <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
-            <DatasetMiniHeader dataset={dataset} hide={!inView} />
+            <DatasetMiniHeader dataset={dataset} show={!inView} />
             <div className='max-w-screen-lg mx-auto p-7 w-full h-full'>
               <div ref={stickyHeaderTriggerRef}>
                 <DatasetHeader dataset={dataset} editable={editable} noBorder />

--- a/src/features/footer/Footer.tsx
+++ b/src/features/footer/Footer.tsx
@@ -31,11 +31,27 @@ const Footer: React.FC<{}> = () => (
     <div className='flex flex-grow justify-end'>
       {
         [
-          { icon: 'github' },
-          { icon: 'youtube' },
-          { icon: 'twitter' },
-          { icon: 'discord' }
-        ].map(({ icon }, i) => <IconLink key={i} icon={icon} size='md' className='ml-5' />)
+          { icon: 'github',
+            link: 'https://github.com/qri-io',
+          },
+          { icon: 'youtube',
+            link: 'https://www.youtube.com/channel/UC7E3_hURgFO2mVCLDwPSyOQ',
+          },
+          { icon: 'twitter',
+            link: 'https://twitter.com/qri_io',
+          },
+          { icon: 'discord',
+            link: 'https://discordapp.com/invite/thkJHKj',
+          }
+        ].map(({ icon, link }, i) => (
+          <IconLink
+            key={i}
+            icon={icon}
+            size='md'
+            link={link}
+            className='ml-5'
+          />
+        ))
       }
     </div>
   </div>

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -110,12 +110,12 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ runMode, run, workflow 
                 />}
             </section>
             <h3 className='text-sm text-qrinavy font-semibold cursor-pointer mb-0.5'>
-              Output
+              Result
             </h3>
 
-            <div className='text-xs mb-2.5 text-gray-400'>Your script will create a new version of this dataset.</div>
+            <div className='text-xs mb-2.5 text-gray-400'>Preview the results of your script here</div>
 
-            <ScrollAnchor id='new-version-preview' />
+            <ScrollAnchor id='result' />
             <WorkflowDatasetPreview dataset={run?.dsPreview}/>
           </ContentBox>
           <OnComplete />

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -40,6 +40,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
           <div className='mb-2'>
             <ScrollTrigger target='triggers'>
               <div className='font-semibold text-qrinavy mb-1'>Triggers</div>
+              <div className='text-qrigray-400'>—</div>
               <div className='mb-4'></div>
             </ScrollTrigger>
           </div>
@@ -95,7 +96,10 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
             )}
           </ScrollTrigger>
 
-          <ScrollTrigger target='on-completion'><div className='font-semibold text-qrinavy mb-2'>On Completion</div></ScrollTrigger>
+          <ScrollTrigger target='on-completion'>
+            <div className='font-semibold text-qrinavy mb-1'>On Completion</div>
+            <div className='text-qrigray-400'>—</div>
+          </ScrollTrigger>
 
           <hr className='mb-4'/>
 

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -74,8 +74,8 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
             </ScrollTrigger>}
           </div>
           <hr/>
-          <ScrollTrigger target='new-version-preview'>
-            <div className='text-sm text-qrigray-400 pt-2 pb-1'>Output</div>
+          <ScrollTrigger target='result'>
+            <div className='text-sm text-qrigray-400 pt-2 pb-1'>Result</div>
             { /*
               TODO(chriswhong): we need the backend to return a timestamp for the dry run and a commit message in order to render this commit box
               this can be a proper LogItem or we can modify the props for DatasetCommit, or make a new component, this is a placeholder
@@ -91,7 +91,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
               />
             ) : (
               <div className='text-xs block rounded-md px-3 pt-3 pb-4 mb-6 w-full overflow-x-hidden text-qrigray-400 border border-qrigray-300'>
-                Click <span className='border rounded-sm px-1'>Dry Run</span> to preview the output of this script
+                Click <span className='border rounded-sm px-1'>Dry Run</span> to preview the result of this script
               </div>
             )}
           </ScrollTrigger>

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -86,6 +86,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
                   title: 'new version from workflow'
                 }}
                 active
+                isLink={false}
               />
             ) : (
               <div className='text-xs block rounded-md px-3 pt-3 pb-4 mb-6 w-full overflow-x-hidden text-qrigray-400 border border-qrigray-300'>

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -88,8 +88,8 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
                 active
               />
             ) : (
-              <div className='text-xs block rounded-md px-3 pt-2 pb-3 mb-6 w-full overflow-x-hidden text-qrigray-400 border border-qrigray-300'>
-                Such Empty
+              <div className='text-xs block rounded-md px-3 pt-3 pb-4 mb-6 w-full overflow-x-hidden text-qrigray-400 border border-qrigray-300'>
+                Click <span className='border rounded-sm px-1'>Dry Run</span> to preview the output of this script
               </div>
             )}
           </ScrollTrigger>

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -82,7 +82,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           </div>)
         : (
             <Scroller className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
-              <DatasetMiniHeader dataset={dataset} hide={!inView}>
+              <DatasetMiniHeader dataset={dataset} show={!inView}>
                 {runBar}
               </DatasetMiniHeader>
               <div className='p-7 w-full'>


### PR DESCRIPTION
Fixes ALL THE THINGS in #212:

- [x] When user is on a New Workflow, other dataset nav items should be grayed out (Preview, history, run log)
- [x] Too much padding on left and right of output body preview
- [x] Mini Header should instantly disappear when user scrolls back to the top, not animate up
- [x] Need some better placeholder for empty output dataset.  Right now it just says “such empty”
- [x] Expanding Dataset Nav leaves code editor cells at their previous width (need to call the method that resizes them to their container)
- [x] Icons do a slight vertical jump when expanding/closing dataset nav
- [x] Clicking output dataset in outline shows navigation warning (because it thinks it’s a link in addition to being a scrolltrigger)
- [x] Let’s show a tooltip over DeploymentStatus in workflow outline
- [x] Empty triggers and on completion in outline should show something, perhaps ‘--’
- [x] Collection view should prioritize name column when narrowed
- [x] Let’s say “Result” instead of “Output”
- [x] Footer Icon Links don’t work