### PR TITLE
Cw/bugfixes

### DIFF
--- a/src/features/dataset/modal/RemoveDatasetModal.tsx
+++ b/src/features/dataset/modal/RemoveDatasetModal.tsx
@@ -19,7 +19,7 @@ const RemoveDatasetModal: React.FC<RemoveDatasetModalProps> = ({ username, name 
     removeDataset({username, name})(dispatch)
       .then((action: AnyAction) => {
         if (action.type.includes('SUCCESS')) {
-          loadCollection(dispatch, 1, 50)
+          dispatch(loadCollection())
           return
         }
         // TODO (ramfox): when we add in toasts, this should be replaced with a

--- a/src/features/dataset/state/datasetActions.ts
+++ b/src/features/dataset/state/datasetActions.ts
@@ -1,5 +1,5 @@
 import Dataset, { NewDataset } from "../../../qri/dataset"
-import { QriRef } from "../../../qri/ref"
+import { QriRef, refStringFromQriRef } from "../../../qri/ref"
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api"
 import { RENAME_NEW_DATASET } from "./datasetState"
 import { API_BASE_URL } from '../../../store/api'
@@ -80,7 +80,7 @@ export function removeDataset (ref: QriRef): ApiActionThunk {
         endpoint: 'ds/remove',
         method: 'POST',
         body: {
-          ref: `${ref.username}/${ref.name}`
+          ref: refStringFromQriRef(ref)
         }
       }
     }

--- a/src/features/dataset/state/datasetActions.ts
+++ b/src/features/dataset/state/datasetActions.ts
@@ -77,12 +77,10 @@ export function removeDataset (ref: QriRef): ApiActionThunk {
     const action = {
       type: 'remove',
       [CALL_API]: {
-        endpoint: 'remove',
-        method: 'DELETE',
-        segments: {
-          peername: ref.username,
-          name: ref.name,
-          path: ref.path
+        endpoint: 'ds/remove',
+        method: 'POST',
+        body: {
+          ref: `${ref.username}/${ref.name}`
         }
       }
     }

--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -36,7 +36,14 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   switch (componentName) {
     case 'body':
       component = <Body data={dataset} preview={preview} />
-      componentHeader = <BodyHeader dataset={dataset} onToggleExpanded={handleToggleExpanded} showExpand={!expanded}/>
+      componentHeader = (
+        <BodyHeader
+          dataset={dataset}
+          onToggleExpanded={handleToggleExpanded}
+          showDownload={!preview}
+          showExpand={!expanded}
+        />
+      )
       break
     case 'meta':
       component = <Meta data={dataset.meta}/>
@@ -70,7 +77,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
 
   return (
     <div
-      className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex flex-col transform transition-all', {})}
+      className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex flex-col', {})}
     >
       <ComponentHeader border={!['body', 'structure'].includes(componentName)}>
         {componentHeader}

--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -16,11 +16,14 @@ import IconLink from '../../chrome/IconLink'
 export interface DatasetComponentProps {
   dataset: Dataset
   componentName: ComponentName
+  // preview will cause the body component to render only what is in dataset and not fetch more data
+  preview?: boolean
 }
 
 const DatasetComponent: React.FC<DatasetComponentProps> = ({
   dataset,
   componentName,
+  preview = false
 }) => {
   const [ expanded, setExpanded ] = useState(false)
 
@@ -32,7 +35,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   let componentHeader: JSX.Element | null = null
   switch (componentName) {
     case 'body':
-      component = <Body data={dataset} />
+      component = <Body data={dataset} preview={preview} />
       componentHeader = <BodyHeader dataset={dataset} onToggleExpanded={handleToggleExpanded} showExpand={!expanded}/>
       break
     case 'meta':

--- a/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -49,7 +49,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
         border
       />
       <div
-        className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex-grow flex flex-col transform transition-all px-4', {
+        className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex-grow flex flex-col px-4', {
           'border-r-2 border-b-2 border-l-2 border-qrigray-200 rounded-b-lg': border
         })}
       >

--- a/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -13,6 +13,8 @@ export interface TabbedComponentViewerProps {
   loading?: boolean
   // border is used to display TabbedComponentViewer over a white background e.g. on the workflow editor
   border?: boolean
+  // preview will cause the body component to render only what is in dataset and not fetch more data
+  preview?: boolean
 }
 
 export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
@@ -21,6 +23,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
   selectedComponent,
   setSelectedComponent,
   border = false,
+  preview = false,
   children
 }) => {
   if (loading) {
@@ -55,6 +58,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
             <DatasetComponent
               dataset={dataset}
               componentName={selectedComponent}
+              preview={preview}
             />
           )
         }

--- a/src/features/dsComponents/body/BodyHeader.tsx
+++ b/src/features/dsComponents/body/BodyHeader.tsx
@@ -11,14 +11,16 @@ import DownloadDatasetButton from '../../download/DownloadDatasetButton'
 
 interface BodyHeaderProps {
   dataset: Dataset
-  onToggleExpanded?: () => void
   showExpand?: boolean
+  showDownload?: boolean
+  onToggleExpanded?: () => void
 }
 
 const BodyHeader: React.FC<BodyHeaderProps> = ({
   dataset,
   onToggleExpanded,
-  showExpand = true
+  showExpand = true,
+  showDownload = true
 }) => {
   const { structure, body } = dataset
   const headers = extractColumnHeaders(structure, body)
@@ -33,7 +35,7 @@ const BodyHeader: React.FC<BodyHeaderProps> = ({
           <Icon icon='columns' size='2xs' className='mr-1'/> {numeral(headers.length).format('0,0')} columns
         </div>
       </div>
-      <DownloadDatasetButton qriRef={qriRefFromDataset(dataset)} asIconLink body />
+      {showDownload && <DownloadDatasetButton qriRef={qriRefFromDataset(dataset)} asIconLink body />}
       {showExpand && <IconLink icon='fullScreen' onClick={onToggleExpanded} />}
     </div>
   )

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -42,11 +42,17 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
     }
   }, [dispatch, location.state])
 
+  // determine if the workflow is new by reading /new at the end of the pathname
+  const segments = location.pathname.split('/')
+  const isNewWorkflow = segments[segments.length - 1] === 'new'
+
   useEffect(() => {
     // TODO (b5) - highly-unlikely but possible race condition here. loading workflow
     // should be chained in a promise
     dispatch(setWorkflowRef(qriRef))
-    dispatch(loadWorkflowByDatasetRef(qriRef))
+    if (!isNewWorkflow) {
+      dispatch(loadWorkflowByDatasetRef(qriRef))
+    }
   }, [dispatch, qriRef])
 
   const handleBlockedNavigation = (nextLocation: Location ) => {

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -33,11 +33,11 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const [ redirectTo, setRedirectTo ] = useState('')
 
   useEffect(() => {
-    if (location.state && location.state.template) {
+    if (location.state?.template) {
       dispatch(setWorkflow(selectTemplate(location.state.template)))
     }
 
-    if (location.state && location.state.showSplashModal) {
+    if (location.state?.showSplashModal) {
       dispatch(showModal(ModalType.workflowSplash))
     }
   }, [dispatch, location.state])

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -81,7 +81,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
           message={handleBlockedNavigation}
         />
         <WorkflowOutline workflow={workflow} run={latestRun} runMode={runMode} />
-        <WorkflowEditor workflow={workflow} run={latestRun} runMode={runMode} />
+        <WorkflowEditor qriRef={qriRef} workflow={workflow} run={latestRun} runMode={runMode} />
         { !shouldPrompt && redirectTo && <Redirect to={redirectTo} /> }
       </div>
     </>

--- a/src/features/workflow/WorkflowDatasetPreview.tsx
+++ b/src/features/workflow/WorkflowDatasetPreview.tsx
@@ -22,6 +22,7 @@ const WorkflowDatasetPreview: React.FC<WorkflowDatasetPreviewProps> = ({
           selectedComponent={selectedComponent}
           setSelectedComponent={(component: ComponentName) => { setSelectedComponent(component) }}
           border
+          preview
         />
       ) : (
         <TabbedComponentViewer

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -6,6 +6,7 @@ import WorkflowCell from './WorkflowCell'
 import WorkflowTriggersEditor from '../trigger/WorkflowTriggersEditor'
 import OnComplete from './OnComplete'
 import { NewRunStep, Run, RunStep } from '../../qri/run'
+import { Dataset } from '../../qri/dataset'
 import { changeWorkflowTransformStep, applyWorkflowTransform } from './state/workflowActions'
 import { RunMode } from './state/workflowState'
 import { Workflow } from '../../qrimatic/workflow'
@@ -13,15 +14,23 @@ import ScrollAnchor from '../scroller/ScrollAnchor'
 import ContentBox from '../../chrome/ContentBox'
 import DeployButton from '../deploy/DeployButton'
 import WorkflowDatasetPreview from './WorkflowDatasetPreview'
+import { QriRef } from '../../qri/ref'
+
 
 
 export interface WorkflowEditorProps {
+  qriRef: QriRef
   runMode: RunMode
   workflow: Workflow
   run?: Run
 }
 
-const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ runMode, run, workflow }) => {
+const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
+  qriRef,
+  runMode,
+  run,
+  workflow
+}) => {
   const dispatch = useDispatch()
 
   const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
@@ -51,6 +60,23 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ runMode, run, workflow 
     if (keyName === 'cmd+enter') {
       runScript()
     }
+  }
+
+  // appends username, name, and meta.title to a dry run's preview, useful for
+  // display of downstream components that expect these as part of a Dataset (e.g. fullscreen body)
+  const appendRefAndMeta = (dsPreview: Dataset) => {
+    if (dsPreview) {
+      return {
+        peername: qriRef.username,
+        name: qriRef.name,
+        meta: {
+          title: 'Dry Run Data Preview'
+        },
+        ...dsPreview
+      }
+    }
+
+    return dsPreview
   }
 
   return (
@@ -116,7 +142,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ runMode, run, workflow 
             <div className='text-xs mb-2.5 text-gray-400'>Preview the results of your script here</div>
 
             <ScrollAnchor id='result' />
-            <WorkflowDatasetPreview dataset={run?.dsPreview}/>
+            <WorkflowDatasetPreview dataset={appendRefAndMeta(run?.dsPreview)}/>
           </ContentBox>
           <OnComplete />
           <div className='mt-6'>

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -69,9 +69,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       return {
         peername: qriRef.username,
         name: qriRef.name,
-        meta: {
-          title: 'Dry Run Data Preview'
-        },
+        meta: dsPreview.meta || { title: 'Workflow Result' },
         ...dsPreview
       }
     }

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -64,7 +64,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   }
 
   useEffect(() => {
-    if (isNew) { return }
+    if (isNew || isNewWorkflow) { return }
     const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
     dispatch(loadDataset(ref))
   }, [dispatch, qriRef.username, qriRef.name, qriRef.path, isNew])
@@ -91,7 +91,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
                     {runBar}
                   </DatasetHeader>
                 </div>
-                <Workflow qriRef={qriRef}/>
+                <Workflow qriRef={qriRef} />
               </div>
             </Scroller>
           )}

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -97,6 +97,12 @@ export const workflowReducer = createReducer(initialState, {
       }
     }
   },
+  'API_WORKFLOW_REQUEST': (state, action) => {
+    // reset workflow and lastRunID to initialState values
+    state.runMode = initialState.runMode
+    state.workflow = initialState.workflow
+    state.lastRunID = undefined
+  },
   'API_WORKFLOW_SUCCESS': (state, action) => {
     const w = action.payload.data as Workflow
     // TODO (b5) - right now we only use the single-workflow fetch endpoint in one


### PR DESCRIPTION
- User can remove a dataset from Collection View Row Menu (Closes #223)
- Don't fetch data on new workflows (Closes #211)
- Prevent Body fetch on Workflow Dry Run Preview (also related to #211)
- Fix full screen body layout when triggered from Dry Run Preview (Closes #178)
- Reset workflow state on `API_WORKFLOW_REQUEST` (Closes #67)