### PR TITLE
modal and button improvements

### DIFF
--- a/src/chrome/Button.tsx
+++ b/src/chrome/Button.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
 
-export type ButtonType = 'primary'
-  | 'primary-outline'
-  | 'secondary'
-  | 'light'
-  | 'warning'
-  | 'danger'
-  | 'dark'
+export type ButtonType = 'primary' // light blue button with white text
+  | 'primary-outline' // light blue outline button, thick border
+  | 'secondary' // pink button with white text
+  | 'warning' // yellow button with dark text
+  | 'danger' // red button with white text
+  | 'light' // gray outline and text, thin border, e.g. cancel button for modal
+  | 'dark' // dark outline and text, thin border, e.g. follow button
 
 export interface ButtonProps {
   onClick?: () => void
@@ -30,24 +30,24 @@ const Button: React.FC<ButtonProps> = ({
   <button
     type={submit ? 'submit' : 'button'}
     className={classNames(
-      'inline-flex items-center justify-center rounded-md shadow-sm bg-transparent font-medium focus:outline-none focus:ring focus:ring-offset ring-offset-transparent mt-0 transition-all duration-100',
+      'inline-flex items-center justify-center rounded-md shadow-sm bg-transparent font-medium focus:outline-none focus:ring-none mt-0 transition-all duration-100',
       className,
       {
         'cursor-default bg-opacity-40 hover:bg-opacity-40': disabled
       },
       {
-        'text-sm px-2 h-9 ': (size === 'sm'),
+        'text-sm px-2.5 h-9 ': (size === 'sm'),
         'text-sm px-4 h-10': (size === 'md'),
         'text-md px-8 py-3': (size === 'lg'),
       },
       {
-        'text-white bg-qriblue hover:bg-qriblue-600 focus:ring-qriblue': (type === 'primary'),
+        'text-white bg-qriblue hover:bg-qriblue-600': (type === 'primary'),
         'text-qriblue hover:text-qriblue-600 text-sm font-medium border-2 border-qriblue hover:border-qriblue-600 box-border': (type === 'primary-outline'),
-        'text-white bg-qripink hover:bg-qripink-600 focus:ring-qripink': (type === 'secondary'),
-        'text-gray-700 hover:text-qripink border border-gray-700 hover:border-qripink focus:ring-indigo-500': (type === 'light'),
-        'text-white bg-qrinavy-400 hover:bg-qrinavy-500 focus:ring-qrinavy-400': (type === 'dark'),
-        'text-gray-700 bg-yellow-300 hover:bg-yellow-400 focus:ring-yellow-400': (type === 'warning'),
-        'text-white bg-red-600 hover:bg-red-700 focus:ring-red-500': (type === 'danger'),
+        'text-white bg-qripink hover:bg-qripink-600': (type === 'secondary'),
+        'text-qrigray-900 bg-warningyellow hover:bg-warningyellow-600': (type === 'warning'),
+        'text-white bg-qrired-700 hover:bg-qrired-900': (type === 'danger'),
+        'text-qrigray-400 hover:text-qrigray-600 border border-qrigray-400 hover:border-qrigray-600': (type === 'light'),
+        'text-qrigray-900 hover:text-qripink border border-qrigray-900 hover:border-qripink': (type === 'dark'),
       }
     )}
     onClick={onClick}

--- a/src/features/app/modal/Modal.tsx
+++ b/src/features/app/modal/Modal.tsx
@@ -48,33 +48,33 @@ const Modal: React.FC<any> = () => {
   return (
     <div className='fixed z-20 inset-0 overflow-y-auto'>
       <div className='flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0'>
-      <div ref={maskRef} className="fixed inset-0 transition-opacity" aria-hidden="true">
-        <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-      </div>
+        <div ref={maskRef} className="fixed inset-0 transition-opacity" aria-hidden="true">
+          <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
 
-        <div className='inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full" role="dialog" aria-modal="true" aria-labelledby="modal-headline'>
-            {(() => {
-              switch (modal.type) {
-                case ModalType.schedulePicker:
-                  return <ScheduleModal {...modal.props} />
-                case ModalType.unsavedChanges:
-                    return <UnsavedChangesModal {...modal.props} />
-                case ModalType.deployWorkflow:
-                    return <DeployWorkflowModal {...modal.props} />
-                case ModalType.removeDataset:
-                    return <RemoveDatasetModal {...modal.props as RemoveDatasetModalProps} />
-                case ModalType.logIn:
-                    return <LogInModal {...modal.props} />
-                case ModalType.signUp:
-                    return <SignUpModal {...modal.props} />
-                case ModalType.workflowSplash:
-                    return <WorkflowSplashModal {...modal.props} />
-                case ModalType.deploy:
-                    return <DeployModal {...modal.props} />
-                default:
-                  return null
-              }
-            })()}
+        <div className='inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle max-w-xl' role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+          {(() => {
+            switch (modal.type) {
+              case ModalType.schedulePicker:
+                return <ScheduleModal {...modal.props} />
+              case ModalType.unsavedChanges:
+                  return <UnsavedChangesModal {...modal.props} />
+              case ModalType.deployWorkflow:
+                  return <DeployWorkflowModal {...modal.props} />
+              case ModalType.removeDataset:
+                  return <RemoveDatasetModal {...modal.props as RemoveDatasetModalProps} />
+              case ModalType.logIn:
+                  return <LogInModal {...modal.props} />
+              case ModalType.signUp:
+                  return <SignUpModal {...modal.props} />
+              case ModalType.workflowSplash:
+                  return <WorkflowSplashModal {...modal.props} />
+              case ModalType.deploy:
+                  return <DeployModal {...modal.props} />
+              default:
+                return null
+            }
+          })()}
         </div>
       </div>
     </div>

--- a/src/features/app/modal/ModalLayout.tsx
+++ b/src/features/app/modal/ModalLayout.tsx
@@ -1,9 +1,32 @@
 import React from 'react'
 import { useDispatch } from 'react-redux'
+import classNames from 'classnames'
 
-import Icon from '../../../chrome/Icon'
 import Button, { ButtonType } from '../../../chrome/Button'
+import IconButton from '../../../chrome/IconButton'
 import { clearModal } from '../state/appActions'
+
+interface modalTypeConfig {
+  actionButtonType: ButtonType
+}
+
+function typeSettings(type: ModalLayoutType): modalTypeConfig {
+  switch (type) {
+    case 'warning':
+      return {
+        actionButtonType: 'warning',
+      }
+   case 'danger':
+     return {
+        actionButtonType: 'danger',
+     }
+   default:
+     return {
+        actionButtonType: 'primary',
+     }
+  }
+
+}
 
 export type ModalLayoutType = 'info' | 'warning' | 'danger'
 
@@ -19,7 +42,6 @@ export interface ModalLayoutProps {
 const ModalLayout: React.FC<ModalLayoutProps> = ({
   title,
   type='info',
-  icon,
   actionButtonText,
   action,
   cancelButtonText='Cancel',
@@ -36,74 +58,45 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
     dispatch(clearModal())
   }
 
-  let { displayIcon, actionButtonType, iconBgColorClass, iconColorClass } = typeSettings(type)
+  let { actionButtonType } = typeSettings(type)
 
   return (
     <>
-      <div className='bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4'>
-        <div className='sm:flex sm:items-start'>
-          <div className={`mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full sm:mx-0 sm:h-10 sm:w-10 ${iconBgColorClass}`}>
-            <Icon icon={icon || displayIcon} className={iconColorClass} />
-          </div>
-          <div className="mt-3 sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 className="text-lg leading-6 font-medium text-gray-900">{title}</h3>
-            <div className="mt-2 text-sm text-gray-500">
-              {children}
+      <div className='bg-white p-8'>
+        <div>
+          <div className='flex'>
+            <div className='flex-grow'>
+              <h3 className={classNames('text-2xl leading-6 font-black text-qrinavy mb-5', {
+                'text-qrired-700': type === 'danger'
+              })}>{title}</h3>
             </div>
+            <IconButton icon='close' onClick={handleCancelButtonClick} />
+          </div>
+          <div className="mb-5 text-base text-qrinavy">
+            {children}
           </div>
         </div>
+        <div>
+          <Button
+            type={actionButtonType}
+            onClick={handleActionButtonClick}
+            size='sm'
+          >
+            {actionButtonText}
+          </Button>
+          <Button
+            type='light'
+            onClick={handleCancelButtonClick}
+            className='ml-4'
+            size='sm'
+          >
+           {cancelButtonText}
+          </Button>
+        </div>
       </div>
-      <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <Button
-          type={actionButtonType}
-          onClick={handleActionButtonClick}
-        >
-          {actionButtonText}
-        </Button>
-        <Button
-          type='light'
-          onClick={handleCancelButtonClick}
-          className='mr-2'
-        >
-         {cancelButtonText}
-        </Button>
-      </div>
+
     </>
   )
-}
-
-interface modalTypeConfig {
-  displayIcon: string
-  actionButtonType: ButtonType
-  iconBgColorClass: string
-  iconColorClass: string
-}
-
-function typeSettings(type: ModalLayoutType): modalTypeConfig {
-  switch (type) {
-    case 'warning':
-      return {
-        actionButtonType: 'warning',
-        displayIcon: 'exclamationTriangle',
-        iconBgColorClass: 'bg-yellow-100',
-        iconColorClass: 'text-yellow-400'
-      }
-   case 'danger':
-     return {
-        actionButtonType: 'danger',
-        displayIcon: 'exclamationTriangle',
-        iconBgColorClass: 'bg-red-100',
-        iconColorClass: 'text-red-600'
-     }
-   default:
-     return {
-        displayIcon: 'info',
-        actionButtonType: 'primary',
-        iconBgColorClass: 'bg-qriblue-100',
-        iconColorClass: 'text-qriblue-600'
-     }
-  }
-
 }
 
 export default ModalLayout

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -83,7 +83,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
         <div className='flex items-center content-center'>
           {children || (
             <>
-              <Button className='mr-3' type='light' filled={false}>
+              <Button className='mr-3' type='dark'>
                 Follow
               </Button>
               <Button type='secondary'>

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -43,7 +43,7 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
         <div className='flex items-center content-center'>
           {children || (
             <>
-              <Button className='mr-3' type='light' filled={false}>
+              <Button className='mr-3' type='dark'>
                 Follow
               </Button>
               <Button className='mr-3' type='secondary'>

--- a/src/features/dataset/modal/RemoveDatasetModal.tsx
+++ b/src/features/dataset/modal/RemoveDatasetModal.tsx
@@ -32,10 +32,10 @@ const RemoveDatasetModal: React.FC<RemoveDatasetModalProps> = ({ username, name 
     <ModalLayout
       title='Remove Dataset'
       type='danger'
-      actionButtonText='I understand, remove it'
+      actionButtonText='I Understand, Remove it'
       action={onRemove}
     >
-      <p className='mb-4'>Are you sure you want to remove the dataset <span className='font-semibold'>{username}/{name}</span>?</p>
+      <p className='mb-2'>Are you sure you want to remove the dataset <span className='font-semibold'>{username}/{name}</span>?</p>
       <p>This action cannot be undone.</p>
     </ModalLayout>
   )

--- a/src/features/dsComponents/ComponentItem.tsx
+++ b/src/features/dsComponents/ComponentItem.tsx
@@ -37,7 +37,7 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
   return (
     <div
       id={`${displayName.toLowerCase()}-status`}
-      className={classNames('flex flex-grow mw-40 mr-2 last:mr-0 py-2 rounded-tr-lg rounded-tl-lg group justify-center relative -bottom-0.5', {
+      className={classNames('flex flex-grow mw-40 mr-2 last:mr-0 py-2 rounded-tr-lg rounded-tl-lg group justify-center relative', {
         'selected': selected,
         'bg-white': selected,
         'text-qripink': selected,
@@ -46,7 +46,7 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
         'text-qrinavy': !disabled,
         'hover:cursor-pointer': !disabled,
         'w-1/4': displayName === 'Data',
-        'border-grigray-200 border-t-2 border-r-2 border-l-2': border
+        'border-grigray-200 border-t-2 border-r-2 border-l-2 -bottom-0.5': border
       })}
       onClick={() => {
         if (onClick && displayName) {

--- a/src/features/dsComponents/ComponentList.tsx
+++ b/src/features/dsComponents/ComponentList.tsx
@@ -104,6 +104,7 @@ const ComponentList: React.FC<ComponentListProps> = ({
               key={name}
               displayName={displayName}
               icon={icon}
+              border={border}
               disabled
             />
           )

--- a/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -46,7 +46,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
         dataset={dataset}
         onClick={setSelectedComponent}
         selectedComponent={selectedComponent}
-        border
+        border={border}
       />
       <div
         className={classNames('rounded-md bg-white w-full overflow-auto rounded-tl-none rounded-tr-none flex-grow flex flex-col px-4', {

--- a/src/features/workflow/modal/UnsavedChangesModal.tsx
+++ b/src/features/workflow/modal/UnsavedChangesModal.tsx
@@ -5,20 +5,16 @@ interface UnsavedChangesModalProps {
   action: () => void
 }
 
-const UnsavedChangesModal: React.FC<UnsavedChangesModalProps> = ({ action }) => {
-
-
-  return (
-    <ModalLayout
-      title='This Workflow has undeployed changes'
-      type='warning'
-      actionButtonText='Discard Changes'
-      cancelButtonText='Stay'
-      action={action}
-    >
-      <p className='mb-4'>It looks like you've made changes to this workflow that have not been deployed.  These changes will be lost if you leave this page. </p>
-    </ModalLayout>
-  )
-}
+const UnsavedChangesModal: React.FC<UnsavedChangesModalProps> = ({ action }) => (
+  <ModalLayout
+    title='This Workflow has undeployed changes'
+    type='warning'
+    actionButtonText='Discard Changes'
+    cancelButtonText='Stay'
+    action={action}
+  >
+    <p className='mb-4'>It looks like you've made changes to this workflow that have not been deployed.  These changes will be lost if you leave this page. </p>
+  </ModalLayout>
+)
 
 export default UnsavedChangesModal

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,6 +110,10 @@ module.exports = {
           '800': '#5B21B6',
           '900': '#4C1D95',
         },
+        warningyellow: {
+          DEFAULT: '#F2D925',
+          '600': '#DAC325'
+        }
       },
       fontFamily: {
         ...fontFamily,


### PR DESCRIPTION
- Improves warning and danger modals to match mockups
- Improves `Button` adding hover states and clarifying button typs
- fixes a styling bug that was causing an outline on component tabs in the history view

<img width="719" alt="Banners_and_Alerts_and_Home___Qri_Cloud" src="https://user-images.githubusercontent.com/1833820/123998716-c13d9c80-d99f-11eb-9d57-cfad8febe2b3.png">

Closes #214 