### PR TITLE
feat: AddTrigger Modal

### DIFF
--- a/src/chrome/DropdownMenu.tsx
+++ b/src/chrome/DropdownMenu.tsx
@@ -1,48 +1,24 @@
-// DropdownMenu can be used a controlled input to choose from multiple values (e.g. choosing trigger options)
-// or as a list of links/function triggers (e.g. the user menu)
-// DropdownMenu only renders the list of options on click, the element to be clicked must be passed in as a child
-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 
-import ExternalLink from './ExternalLink'
 import Icon from './Icon'
-
-export interface DropDownMenuItem {
-  // label is the text that will be displayed to the user
-  label: string
-  // disabled will show the item, but it will not be clickable
-  disabled?: boolean
-  // icon: options are found in the `Icon` component
-  icon?: string
-  // value will be passed to the onChange function
-  value?: string
-  // if link exists in a DropDownMenuItem, clicking the item will not trigger onChange,
-  // and will navigate to the link
-  link?: string
-  // if onClick exists in a DropDownMenuItem, clicking the item will not trigger onChange,
-  // and will execute the onClick function
-  onClick?: () => void
-}
+import DropdownMenuItem, { DropdownMenuItemProps } from './DropdownMenuItem';
 
 interface DropdownMenuProps {
-  // the value of the selected menu item, which will be shown as highlighted
-  selectedValue?: string
-  items: DropDownMenuItem[]
   alignLeft?: boolean
   className?: string
-  onChange?: (value: string) => void
+  icon?: string | React.ReactElement
+  items: DropdownMenuItemProps[]
 }
 
-// itemProps will be passed into the onClick handler for each item in the dropdown
+// DropdownMenu shows menu when a given "icon" prop is clicked. the element to 
+// be clicked must be passed in as the "icon" prop. pass contents of the menu as
+// children
 const DropdownMenu: React.FC<DropdownMenuProps> = ({
-  selectedValue,
-  items,
+  icon,
   alignLeft=false,
   className='',
-  onChange=() => {},
-  children
+  items
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
@@ -64,74 +40,18 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   return (
     <div ref={ref} className={classNames('relative inline-block text-left w-full', className)}>
       <div onClick={() => { setOpen(!open) }} className='cursor-pointer flex items-center'>
-        {children}
+        {(typeof icon === 'string') ? <Icon icon={icon} /> : icon}
       </div>
       {open && (
         <div
-          className={`origin-top-right absolute top-8 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-20 ${alignLeft ? 'left-0' : 'right-0'}`}
+          className={classNames(`origin-top-right absolute top-8 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-30`, { 'left-0': alignLeft, 'right-0': !alignLeft })}
           role="menu"
           aria-orientation="vertical"
           aria-labelledby="options-menu"
           style={{ minWidth: '9rem' }}
         >
           <div className="py-1 flex flex-col" onClick={ () => setOpen(false) }>
-            {items && items.map(({
-              link,
-              value,
-              onClick,
-              label,
-              icon = '',
-              disabled = false
-            }, i) => {
-
-              const menuItemClassName = classNames('text-left text-xs px-2 py-0.5 mx-2 my-1 whitespace-nowrap rounded-md', {
-                'hover:pointer text-qrigray-400 hover:bg-gray-100': !disabled,
-                'text-qrigray-300': disabled
-              })
-
-              const content = <span className={classNames({ 'text-qripink font-semibold': selectedValue && (selectedValue === value) })}>{icon && <Icon icon={icon} className='mr-2' size='sm' />}{label}</span>
-
-              if (link) {
-                if (link.startsWith('http')) {
-                  return (
-                    <ExternalLink to={link} key={i} className={menuItemClassName}>
-                      <button  role="menuitem">
-                        {content}
-                      </button>
-                    </ExternalLink>
-                  )
-                }
-
-                return (
-                  <Link to={link} key={i} className={menuItemClassName}>
-                    <button role="menuitem">
-                      {content}
-                    </button>
-                  </Link>
-                )
-              }
-
-              const handleItemClick = () => {
-                if (onClick) {
-                  onClick()
-                }
-
-                if (onChange && value) {
-                  onChange(value)
-                }
-              }
-
-              return (
-                <button
-                  onClick={handleItemClick}
-                  className={menuItemClassName}
-                  role="menuitem"
-                  key={i}
-                >
-                  {content}
-                </button>
-              )
-            })}
+            {items.map((props, i) => <DropdownMenuItem key={i} {...props} />)}
           </div>
         </div>
       )}

--- a/src/chrome/DropdownMenuItem.tsx
+++ b/src/chrome/DropdownMenuItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import classNames from 'classnames'
+
+import Icon from './Icon'
+
+export const dropdownBaseClass = 'text-left text-xs px-2 py-0.5 mx-2 my-1 whitespace-nowrap rounded-md'
+
+export interface DropdownMenuItemProps {
+  active?: boolean
+  // label is the text that will be displayed to the user
+  label: string | React.ReactElement
+  // disabled will show the item, but it will not be clickable
+  disabled?: boolean
+  // icon: options are found in the `Icon` component
+  icon?: string
+  // if onClick exists in a DropDownMenuItem, clicking the item will not trigger onChange,
+  // and will execute the onClick function
+  onClick?: () => void
+}
+
+const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
+  label,
+  active = false,
+  disabled = false,
+  icon,
+  onClick,
+  children
+}) => (
+  <button
+    onClick={() => { onClick && onClick() }}
+    className={classNames(dropdownBaseClass, {
+      'hover:pointer text-qrigray-400 hover:bg-gray-100': !disabled,
+      'text-qrigray-300': disabled
+    })}
+    role="menuitem"
+  >
+    {(typeof label === 'string')
+      ? <span className={classNames({'text-qripink font-semibold': active })}>
+          {icon && <Icon icon={icon} className='mr-2' size='sm' />}{label}
+        </span> 
+      : label}
+  </button>
+)
+
+export default DropdownMenuItem

--- a/src/chrome/Icon.tsx
+++ b/src/chrome/Icon.tsx
@@ -48,6 +48,7 @@ import ActivityFeed from './icon/ActivityFeed'
 import AutomationFilled from './icon/AutomationFilled'
 import Body from './icon/Body'
 import Brackets from './icon/Brackets'
+import Calendar from './icon/Calendar'
 import CaretLeft from './icon/CaretLeft'
 import CaretRight from './icon/CaretRight'
 import CaretDown from './icon/CaretDown'
@@ -167,6 +168,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
     automationFilled: <AutomationFilled className={className} size={size} />,
     body: <Body className={className} size={size} />,
     brackets: <Brackets className={className} size={size} />,
+    calendar: <Calendar className={className} size={size} />,
     caretLeft: <CaretLeft className={className} size={size} />,
     caretRight: <CaretRight className={className} size={size} />,
     caretDown: <CaretDown className={className} size={size} />,

--- a/src/chrome/Select.tsx
+++ b/src/chrome/Select.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import DropdownMenu from './DropdownMenu'
+import Icon from './Icon'
+
+export interface SelectOption {
+  label: string
+  value: string
+}
+
+export interface SelectProps {
+  value: string
+  options: SelectOption[]
+  onChange: (p: string) => void
+}
+
+const Select: React.FC<SelectProps> = ({
+  value,
+  options,
+  onChange
+}) => {
+  const label = (
+  <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer w-full flex items-center'>
+    <div className='flex-grow'>{options.find((o) => o.value === value)?.label}</div>
+    <Icon icon='caretDown' size='2xs' className='ml-3' />
+  </div>)
+
+  return (
+    <DropdownMenu 
+      icon={label}
+      alignLeft
+      items={options.map((option) => {
+        return {
+          ...option,
+          onClick: () => { onChange(option.value) }
+        }
+      })}
+      >
+    </DropdownMenu>
+  )
+}
+
+export default Select

--- a/src/chrome/icon/Calendar.tsx
+++ b/src/chrome/icon/Calendar.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import CustomIcon, { CustomIconProps } from '../CustomIcon'
+
+const Calendar: React.FC<CustomIconProps> = (props) => (
+  <CustomIcon {...props}>
+    <path d="M18.5556 12.5556V5.45679C18.5556 4.50222 17.7817 3.72839 16.8272 3.72839H4.72839C3.77383 3.72839 3 4.50222 3 5.45679V17.5556C3 18.5101 3.77383 19.2839 4.72839 19.2839H10.7778" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M14.2345 2V5.45679" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M7.32104 2V5.45679" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M3 8.91351H18.5556" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    <circle cx="15.2222" cy="16.4444" r="4.80556" stroke="currentColor" strokeWidth="1.5"/>
+    <path d="M15.2223 13.6667V16.9075L16.6112 18.2964" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+  </CustomIcon>
+)
+
+export default Calendar

--- a/src/features/app/modal/Modal.tsx
+++ b/src/features/app/modal/Modal.tsx
@@ -10,6 +10,7 @@ import LogInModal from '../../session/modal/LogInModal'
 import SignUpModal from '../../session/modal/SignUpModal'
 import WorkflowSplashModal from '../../workflow/modal/SplashModal'
 import DeployModal from '../../workflow/modal/DeployModal'
+import AddTriggerModal from '../../trigger/modal/AddTriggerModal'
 
 import { clearModal } from '../state/appActions'
 
@@ -25,7 +26,7 @@ const Modal: React.FC<any> = () => {
   }, [dispatch, maskRef])
 
   useEffect(() => {
-    const close = (e) => {
+    const close = (e: KeyboardEvent) => {
       if (e.keyCode === 27) {
         dispatch(clearModal())
       }
@@ -71,6 +72,8 @@ const Modal: React.FC<any> = () => {
                   return <WorkflowSplashModal {...modal.props} />
               case ModalType.deploy:
                   return <DeployModal {...modal.props} />
+              case ModalType.addTrigger:
+                  return <AddTriggerModal {...modal.props} />
               default:
                 return null
             }

--- a/src/features/app/state/appState.ts
+++ b/src/features/app/state/appState.ts
@@ -17,7 +17,8 @@ export enum ModalType {
   logIn = 'logIn',
   signUp = 'signUp',
   workflowSplash = 'workflowSplash',
-  deploy = 'deploy'
+  deploy = 'deploy',
+  addTrigger = 'addTrigger'
 }
 
 export interface Modal<P = {}> {

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -9,7 +9,7 @@ import { ModalType } from '../app/state/appState'
 import Icon from '../../chrome/Icon'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
-import DropdownMenu, { DropDownMenuItem } from '../../chrome/DropdownMenu'
+import DropdownMenu from '../../chrome/DropdownMenu'
 import { pathToDatasetPreview } from '../dataset/state/datasetPaths'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { VersionInfo } from '../../qri/versionInfo';
@@ -225,53 +225,52 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       width: '60px',
       // eslint-disable-next-line react/display-name
       cell: (row: VersionInfo) => {
-        const hamburgerItems: DropDownMenuItem[] = [
-          {
-            onClick: () => { handleButtonClick("renaming not yet implemented") },
-            label: 'Rename...',
-            disabled: true
-          },
-          {
-            onClick: () => { handleButtonClick("duplicating not yet implemented")},
-            label: 'Duplicate...',
-            disabled: true
-          },
-          {
-            onClick: () => { handleButtonClick("export not yet implemented")},
-            label: 'Export...',
-            disabled: true
-          },
-          {
-            onClick: () => { handleButtonClick("run now not yet implemented")},
-            label: 'Run Now',
-            disabled: true
-          },
-          {
-            onClick: () => { handleButtonClick("pause not yet implemented")},
-            label: 'Pause Workflow',
-            disabled: true
-          },
-          {
-            onClick: () => {
-              dispatch(
-                showModal(
-                  ModalType.removeDataset,
-                  {
-                    username: row.username,
-                    name: row.name
-                  }
-                )
-              )
-            },
-            id: 'remove',
-            label: 'Remove...'
-          }
-        ]
         return (
           <div className='mx-auto text-gray-500'>
-            <DropdownMenu items={hamburgerItems}>
-              <Icon icon='ellipsisH' size='md'/>
-            </DropdownMenu>
+            <DropdownMenu
+              icon={<Icon icon='ellipsisH' size='md'/>}
+              items={[
+                {
+                  label: 'Rename...',
+                  disabled: true,
+                  onClick: () => { handleButtonClick("renaming not yet implemented") },
+                },
+                {
+                  label: 'Duplicate...',
+                  disabled: true,
+                  onClick: () => { handleButtonClick("duplicating not yet implemented")},
+                },
+                {
+                  label: 'Export...',
+                  disabled: true,
+                  onClick: () => { handleButtonClick("export not yet implemented")},
+                },
+                {
+                  label: 'Run Now',
+                  disabled: true,
+                  onClick: () => { handleButtonClick("run now not yet implemented")},
+                },
+                {
+                  label: 'Pause Workflow',
+                  disabled: true,
+                  onClick: () => { handleButtonClick("pause not yet implemented")},
+                },
+                {
+                  label: 'Remove...',
+                  onClick: () => {
+                    dispatch(
+                      showModal(
+                        ModalType.removeDataset,
+                        {
+                          username: row.username,
+                          name: row.name
+                        }
+                      )
+                    )
+                  },
+                }
+              ]}
+            />
           </div>
         )
       }

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -228,27 +228,27 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         const hamburgerItems: DropDownMenuItem[] = [
           {
             onClick: () => { handleButtonClick("renaming not yet implemented") },
-            text: 'Rename...',
+            label: 'Rename...',
             disabled: true
           },
           {
             onClick: () => { handleButtonClick("duplicating not yet implemented")},
-            text: 'Duplicate...',
+            label: 'Duplicate...',
             disabled: true
           },
           {
             onClick: () => { handleButtonClick("export not yet implemented")},
-            text: 'Export...',
+            label: 'Export...',
             disabled: true
           },
           {
             onClick: () => { handleButtonClick("run now not yet implemented")},
-            text: 'Run Now',
+            label: 'Run Now',
             disabled: true
           },
           {
             onClick: () => { handleButtonClick("pause not yet implemented")},
-            text: 'Pause Workflow',
+            label: 'Pause Workflow',
             disabled: true
           },
           {
@@ -263,7 +263,8 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
                 )
               )
             },
-            text: 'Remove...'
+            id: 'remove',
+            label: 'Remove...'
           }
         ]
         return (

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -50,7 +50,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   const menuItems = [
     {
       onClick: () => { handleButtonClick("duplicating not yet implemented") },
-      text: 'Duplicate...',
+      label: 'Duplicate...',
       disabled: true
     }
   ]

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -31,12 +31,11 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
 }) => {
   const dispatch = useDispatch()
   const history = useHistory()
+  const qriRef = qriRefFromDataset(dataset)
 
   const handleButtonClick = (message: string) => {
     alert(message)
   }
-
-  const qriRef = qriRefFromDataset(dataset)
 
   const handleRename = (_:string, value:string) => {
     dispatch(renameDataset(qriRef, { username: dataset.username, name: value }))
@@ -47,14 +46,6 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
     history.replace(newPath)
   }
 
-  const menuItems = [
-    {
-      onClick: () => { handleButtonClick("duplicating not yet implemented") },
-      label: 'Duplicate...',
-      disabled: true
-    }
-  ]
-
   return (
     <div className="w-full">
       <div className='flex'>
@@ -62,9 +53,17 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
           <div className='text-md text-gray-400 relative flex items-baseline group hover:text pb-1 font-mono'>
             <TextLink to={`/${qriRef.username}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{qriRef.username || 'new'}</TextLink>/
             <EditableLabel readOnly={!editable} name='name' onChange={handleRename} value={qriRef.name} />
-            {editable && <DropdownMenu items={menuItems}>
-              <Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />
-            </DropdownMenu>}
+            {editable &&
+              <DropdownMenu
+                icon={<Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />}
+                items={[
+                  {
+                    label: 'Duplicate...',
+                    disabled: true,
+                    onClick: () => { handleButtonClick("duplicating not yet implemented") } 
+                  }
+                ]}
+              />}
           </div>
 
           <div className='text-2xl text-qrinavy-500 font-black group hover:text mb-3'>

--- a/src/features/dataset/DatasetTitleMenu.tsx
+++ b/src/features/dataset/DatasetTitleMenu.tsx
@@ -36,7 +36,7 @@ const DatasetTitleMenu: React.FC<DatasetTitleMenuProps> = ({
   const menuItems = [
     {
       onClick: () => { handleButtonClick("duplicating not yet implemented") },
-      text: 'Duplicate...',
+      label: 'Duplicate...',
       disabled: true
     }
   ]

--- a/src/features/dataset/DatasetTitleMenu.tsx
+++ b/src/features/dataset/DatasetTitleMenu.tsx
@@ -33,22 +33,22 @@ const DatasetTitleMenu: React.FC<DatasetTitleMenuProps> = ({
     history.replace(newPath)
   }
 
-  const menuItems = [
-    {
-      onClick: () => { handleButtonClick("duplicating not yet implemented") },
-      label: 'Duplicate...',
-      disabled: true
-    }
-  ]
-
   return (
     <div className="relative">
       <p className=' font-bold text-white relative flex items-baseline group hover:text'>
         <span className='opacity-70'>{qriRef.username} / </span>
         <EditableLabel readOnly={!editable} name='name' onChange={handleRename} value={qriRef.name} />
-        {editable && <DropdownMenu items={menuItems}>
-          <Icon icon='sortDown' className='ml-3'/>
-        </DropdownMenu>}
+        {editable && 
+          <DropdownMenu 
+            icon={<Icon icon='sortDown' className='ml-3'/>}
+            items={[
+              {
+                label: 'Duplicate...',
+                disabled: true,
+                onClick: () => { handleButtonClick("duplicating not yet implemented") }
+              }
+            ]}
+          />}
       </p>
     </div>
   )

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -34,16 +34,16 @@ const SessionUserMenu: React.FC<{}> = () => {
 
   const menuItems = [
     {
-      text: 'Profile',
+      label: 'Profile',
       link: `/${user.username}`
     },
     {
-      text: 'Send Feedback',
+      label: 'Send Feedback',
       link: 'https://qri.io/contact'
     },
     {
       onClick: () => { dispatch(logOut()) },
-      text: 'Log Out',
+      label: 'Log Out',
     }
   ]
 

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
 import DropdownMenu from '../../chrome/DropdownMenu'
@@ -8,6 +9,7 @@ import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import Button from '../../chrome/Button'
 import TextLink from '../../chrome/TextLink'
+import ExternalLink from '../../chrome/ExternalLink'
 
 const SessionUserMenu: React.FC<{}> = () => {
   const user = useSelector(selectSessionUser)
@@ -32,33 +34,29 @@ const SessionUserMenu: React.FC<{}> = () => {
     )
   }
 
-  const menuItems = [
-    {
-      label: 'Profile',
-      link: `/${user.username}`
-    },
-    {
-      label: 'Send Feedback',
-      link: 'https://qri.io/contact'
-    },
-    {
-      onClick: () => { dispatch(logOut()) },
-      label: 'Log Out',
-    }
-  ]
+  const icon = <div
+    className='rounded-2xl inline-block bg-cover flex-shrink-0' 
+    style={{
+      height: '30px',
+      width: '30px',
+      backgroundImage: `url(${user.profile})`
+    }}></div>
 
   return (
     <div className="relative flex items-center font-medium">
-      <TextLink
-        to='https://qri.io/docs'
-      >Help</TextLink>
-      <DropdownMenu items={menuItems} className='ml-8'>
-        <div className='rounded-2xl inline-block bg-cover flex-shrink-0' style={{
-          height: '30px',
-          width: '30px',
-          backgroundImage: `url(${user.profile})`
-        }}></div>
-      </DropdownMenu>
+      <TextLink to='https://qri.io/docs'>Help</TextLink>
+      <DropdownMenu icon={icon} className='ml-8' items={[
+        {
+          label: <Link to={`/${user.username}`}>Profile</Link>
+        },
+        {
+          label: <ExternalLink to='https://qri.io/contact'>Send Feedback</ExternalLink>
+        },
+        { 
+          label: 'Log Out',
+          onClick: () => { dispatch(logOut()) }
+        }
+      ]} />
     </div>
   )
 }

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -87,12 +87,12 @@ const Search: React.FC<{}> = () => {
 
   const menuItems = [
     {
-      text: 'Dataset Name',
+      label: 'Dataset Name',
       active: sort === 'name',
       onClick: () => { updateQueryParams({ sort: 'name' }) }
     },
     {
-      text: 'Recently Updated',
+      label: 'Recently Updated',
       active: sort === 'recentlyupdated',
       onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
     }

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -85,19 +85,6 @@ const Search: React.FC<{}> = () => {
     history.push({ search: newParamsObject.toString() })
   }
 
-  const menuItems = [
-    {
-      label: 'Dataset Name',
-      active: sort === 'name',
-      onClick: () => { updateQueryParams({ sort: 'name' }) }
-    },
-    {
-      label: 'Recently Updated',
-      active: sort === 'recentlyupdated',
-      onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
-    }
-  ]
-
   // shown if user lands on /search with no query params
   let resultsContent = (
     <div className='text-center font-semibold text-sm'>
@@ -130,6 +117,11 @@ const Search: React.FC<{}> = () => {
     }
   }
 
+  const sortIcon = <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
+    Sort By
+    <Icon icon='caretDown' size='2xs' className='ml-3' />
+  </div>
+
   return (
     <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6'}}>
       <NavBar showSearch={false} />
@@ -154,12 +146,22 @@ const Search: React.FC<{}> = () => {
                     )}
                   </div>
                 </div>
-                <DropdownMenu items={menuItems} className='ml-8'>
-                  <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
-                    Sort By
-                    <Icon icon='caretDown' size='2xs' className='ml-3' />
-                  </div>
-                </DropdownMenu>
+                <DropdownMenu 
+                  icon={sortIcon}
+                  className='ml-8'
+                  items={[
+                      {
+                        label: 'Dataset Name',
+                        active: sort === 'name',
+                        onClick: () => { updateQueryParams({ sort: 'name' }) }
+                      },
+                      {
+                        label: 'Recently Updated',
+                        active: sort === 'recentlyupdated',
+                        onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
+                      }
+                    ]}
+                  />
               </>
             ):(
               <>&nbsp;</>

--- a/src/features/trigger/CronTrigger.tsx
+++ b/src/features/trigger/CronTrigger.tsx
@@ -9,11 +9,11 @@ import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import { parseHourlyStart, parseDailyStart,  } from './util'
 
-export interface CronTriggerDisplayProps {
+export interface CronTriggerProps {
   trigger: WorkflowTrigger
 }
 
-const CronTriggerDisplay: React.FC<CronTriggerDisplayProps> = ({
+const CronTrigger: React.FC<CronTriggerProps> = ({
   trigger
 }) => {
 
@@ -72,4 +72,4 @@ const CronTriggerDisplay: React.FC<CronTriggerDisplayProps> = ({
   )
 }
 
-export default CronTriggerDisplay
+export default CronTrigger

--- a/src/features/trigger/CronTriggerDisplay.tsx
+++ b/src/features/trigger/CronTriggerDisplay.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { useDispatch } from 'react-redux'
+
+import Icon from '../../chrome/Icon'
+import TextLink from '../../chrome/TextLink'
+import { WorkflowTrigger } from '../../qrimatic/workflow'
+import Block from '../workflow/Block'
+import { showModal } from '../app/state/appActions'
+import { ModalType } from '../app/state/appState'
+import { parseHourlyStart, parseDailyStart,  } from './util'
+
+export interface CronTriggerDisplayProps {
+  trigger: WorkflowTrigger
+}
+
+const CronTriggerDisplay: React.FC<CronTriggerDisplayProps> = ({
+  trigger
+}) => {
+
+  const dispatch = useDispatch()
+
+  // on edit, open AddTriggerModal and pass in the correct type and array of WorkflowTrigger
+  const handleEditClick = () => {
+    dispatch(showModal(ModalType.addTrigger, {
+      type: 'cron',
+      triggers: [ trigger ]
+    }))
+  }
+
+  // split the ISO8601 repeating interval (R/{starttime}/{interval})
+  const [, startTime, interval] = trigger.periodicity.split('/')
+
+
+  let displayInterval, displayStartTime
+
+  switch (interval) {
+    case 'PT10M':
+      displayInterval = 'Every 10 minutes'
+      // no startTime for 10-minute intervals, they will always run on the 10s, but this is not made explicit
+      break
+    case 'P1H':
+      displayInterval = 'Every hour'
+      displayStartTime = parseHourlyStart(startTime)
+      break
+    case 'P1D':
+      displayInterval = 'Every day'
+      displayStartTime = parseDailyStart(startTime)
+      break
+    default:
+      displayInterval = ''
+  }
+
+  return (
+    <Block>
+      <div className='flex'>
+        <div className='flex-grow'>
+          <div className='text-sm font-semibold pb-1 text-qrinavy'>Schedule</div>
+          <div className='text-qrigray-400 text-xs flex items-center'>
+            <Icon icon='calendar' size='sm' className='mr-1 pt-1' />
+            <div>{displayInterval} {displayStartTime}</div>
+          </div>
+        </div>
+        <div className='flex ml-2'>
+          <TextLink
+            className='text-qrigray-400 text-xs self-end mb-0.5'
+            colorClassName='text-qrigray-400 hover:text-qrigray-600'
+            onClick={handleEditClick}
+          >Edit</TextLink>
+        </div>
+      </div>
+    </Block>
+  )
+}
+
+export default CronTriggerDisplay

--- a/src/features/trigger/CronTriggerEditor.tsx
+++ b/src/features/trigger/CronTriggerEditor.tsx
@@ -1,32 +1,111 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { TriggerEditorProps } from './WorkflowTriggersEditor'
-import Block from '../workflow/Block'
+import DropdownMenu from '../../chrome/DropdownMenu'
+import Icon from '../../chrome/Icon'
+import { CronTrigger } from '../../qrimatic/workflow'
+import { Schedule, scheduleFromPeriodicity, hourlyItems, triggerFromSchedule, periodicityItems } from './util'
 
-const CronTriggerEditor: React.FC<TriggerEditorProps> = ({
+interface CronTriggerEditorProps extends TriggerEditorProps {
+  trigger: CronTrigger
+}
+
+const CronTriggerEditor: React.FC<CronTriggerEditorProps> = ({
+  // for setting the initial state
   trigger,
   onChange
 }) => {
+  // store the UI selections in local state
+  // we'll convert them to the correct format for the trigger in useEffect()
+  const [ schedule, setSchedule] = useState<Schedule>(scheduleFromPeriodicity(trigger.periodicity))
+
+  useEffect(() => {
+    // when the user interacts with the UI, convert the selected values into a
+    // valid trigger and send the new trigger up to AddTriggerModal
+    onChange(triggerFromSchedule(schedule))
+  }, [ schedule ])
+
+  const handlePeriodicityChange = (value: string) => {
+    setSchedule({
+      ...schedule,
+      periodicity: value,
+    })
+  }
+
+  const handleMinutesChange = (value: string) => {
+    setSchedule({
+      ...schedule,
+      minutes: value,
+    })
+  }
+
+  const handleTimeChange = (value: string) => {
+    setSchedule({
+      ...schedule,
+      time: value,
+    })
+  }
+
+  const selectedPeriodicityItem = periodicityItems.find((d) => d.value === schedule.periodicity)
+
+  if (selectedPeriodicityItem === undefined) {
+    throw new TypeError('invalid periodicity value')
+  }
+
+  const selectedHourlyItem = hourlyItems.find((d) => d.value === schedule.minutes)
+
+  if (selectedHourlyItem === undefined) {
+    throw new TypeError('invalid hourly minutes value')
+  }
+
+
+  const DropdownContent:React.FC = ({ children }) => (
+    <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer w-full flex items-center'>
+      <div className='flex-grow'>{children}</div>
+      <Icon icon='caretDown' size='2xs' className='ml-3' />
+    </div>
+  )
+
   return (
-    <Block name='Schedule'>
-      <span className="text-sm leading-6 font-medium text-gray-700 mr-1" id="modal-headline">Run this script every</span>
-      <select className='text-gray-800 font-semibold border-b bg-gray-100' value={trigger.periodicity} onChange={(e: any) => {
-        onChange({
-          type: trigger.type,
-          id: trigger.id,
-          workflowID: trigger.workflowID,
-          periodicity: e.target.value,
-        })
-      }}>
-        <option value="">--</option>
-        <option value="R/PT10M">10 Minutes</option>
-        <option value="R/PT1H">Hour</option>
-        <option value="R/PT1D">Day</option>
-        <option value="R/PT1W">Week</option>
-        <option value="R/PT1M">Month</option>
-        <option value="R/PT3M">Quarter</option>
-      </select>
-    </Block>
+    <div>
+      <div className="text-sm leading-6 font-medium text-gray-700 mr-1" id="modal-headline">When should Qri run this workflow?</div>
+      <div className='flex flex-wrap -mx-1'>
+        <div className='my-1 px-1 w-1/2'>
+          <DropdownMenu items={periodicityItems} onChange={handlePeriodicityChange} selectedValue={selectedPeriodicityItem.value} alignLeft>
+            <DropdownContent>
+              {selectedPeriodicityItem.label}
+            </DropdownContent>
+          </DropdownMenu>
+        </div>
+        <div className='my-1 px-1 w-1/2'>
+          {
+            // show minutes selector
+            schedule.periodicity === 'hourly' && (
+              <DropdownMenu items={hourlyItems} onChange={handleMinutesChange} selectedValue={selectedHourlyItem.value} alignLeft>
+                <DropdownContent>
+                  {selectedHourlyItem.label}
+                </DropdownContent>
+              </DropdownMenu>
+            )
+          }
+          {
+            // show a time selector
+            schedule.periodicity === 'daily' && (
+              <input
+                className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 w-full'
+                style={{
+                  paddingTop: 6.75,
+                  paddingBottom: 6.75
+                }}
+                type='time'
+                value={schedule.time}
+                onChange={(e) => { handleTimeChange(e.target.value)}}
+              />
+            )
+          }
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/features/trigger/WorkflowTriggersEditor.tsx
+++ b/src/features/trigger/WorkflowTriggersEditor.tsx
@@ -6,10 +6,10 @@ import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import ScrollAnchor from '../scroller/ScrollAnchor'
 import Block from '../workflow/Block'
-import { changeWorkflowTrigger } from '../workflow/state/workflowActions'
-import CronTriggerEditor from './CronTriggerEditor'
+import CronTriggerDisplay from './CronTriggerDisplay'
 import ContentBox from '../../chrome/ContentBox'
-import IconButton from '../../chrome/IconButton'
+import Icon from '../../chrome/Icon'
+import Button from '../../chrome/Button'
 
 export interface WorkflowTriggersEditorProps {
   triggers?: WorkflowTrigger[]
@@ -20,25 +20,15 @@ export interface TriggerEditorProps {
   onChange: (t: WorkflowTrigger) => void
 }
 
-// const triggerItems = [
-//   {
-//     name: 'Run on a Schedule',
-//     description: 'Run the workflow every day at 11:30am'
-//   },
-//   {
-//     name: 'Run when another dataset is updated',
-//     description: 'The workflow will run whenever b5/world_bank_population is updated'
-//   },
-//   {
-//     name: 'Run with a webhook',
-//     description: 'The workflow will run when this webhook is called: https://qrimatic.qri.io/my-dataset'
-//   },
-// ]
-
 const WorkflowTriggersEditor: React.FC<WorkflowTriggersEditorProps> = ({
   triggers = []
 }) => {
   const dispatch = useDispatch()
+
+  const handleAddClick = () => {
+    dispatch(showModal(ModalType.addTrigger))
+  }
+
   return (
     <ContentBox className='mb-7' paddingClassName='px-5 py-4'>
       <ScrollAnchor id='triggers'/>
@@ -47,16 +37,23 @@ const WorkflowTriggersEditor: React.FC<WorkflowTriggersEditorProps> = ({
           <h2 className='text-2xl font-medium text-qrinavy mb-1'>Triggers</h2>
           <div className='text-sm text-qrigray-400 mb-3'>Customize your workflow to execute on a schedule, or based on other events</div>
         </div>
-        <div className='flex items-center'>
-          {/* TODO(chriswhong): build UI for adding triggers */}
-          <IconButton icon='plus' onClick={() => {}} />
-        </div>
+        {/*
+          TODO(chriswhong): allow for adding other types of triggers.
+          For now, we only allow one cron trigger so disable add when it exists
+        */}
+        {triggers.length === 0 && (
+          <div className='flex items-center'>
+            <Button onClick={handleAddClick}>
+              <Icon icon='plus' size='sm'/>
+            </Button>
+          </div>
+        )}
       </div>
       <div className='flex flex-wrap -mx-2 overflow-hidden -mx-2 overflow-hidden'>
         {triggers.map((trigger: WorkflowTrigger, i) => {
           switch (trigger.type) {
             case 'cron':
-              return <CronTriggerEditor key={i} trigger={trigger} onChange={(t: WorkflowTrigger) => { dispatch(changeWorkflowTrigger(i, t)) }}/>
+              return <CronTriggerDisplay key={i} trigger={trigger} />
             default:
               return <Block {...trigger} key={i} onClick={() => { dispatch(showModal(ModalType.schedulePicker))}} />
           }

--- a/src/features/trigger/WorkflowTriggersEditor.tsx
+++ b/src/features/trigger/WorkflowTriggersEditor.tsx
@@ -6,7 +6,7 @@ import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import ScrollAnchor from '../scroller/ScrollAnchor'
 import Block from '../workflow/Block'
-import CronTriggerDisplay from './CronTriggerDisplay'
+import CronTrigger from './CronTrigger'
 import ContentBox from '../../chrome/ContentBox'
 import Icon from '../../chrome/Icon'
 import Button from '../../chrome/Button'
@@ -49,11 +49,11 @@ const WorkflowTriggersEditor: React.FC<WorkflowTriggersEditorProps> = ({
           </div>
         )}
       </div>
-      <div className='flex flex-wrap -mx-2 overflow-hidden -mx-2 overflow-hidden'>
+      <div className='flex flex-wrap -mx-2 overflow-hidden'>
         {triggers.map((trigger: WorkflowTrigger, i) => {
           switch (trigger.type) {
             case 'cron':
-              return <CronTriggerDisplay key={i} trigger={trigger} />
+              return <CronTrigger key={i} trigger={trigger} />
             default:
               return <Block {...trigger} key={i} onClick={() => { dispatch(showModal(ModalType.schedulePicker))}} />
           }

--- a/src/features/trigger/modal/AddTriggerModal.tsx
+++ b/src/features/trigger/modal/AddTriggerModal.tsx
@@ -10,7 +10,7 @@ import CronTriggerEditor from '../../trigger/CronTriggerEditor'
 import { WorkflowTrigger, WorkflowTriggerType } from '../../../qrimatic/workflow'
 import { changeWorkflowTrigger } from '../../workflow/state/workflowActions'
 
-interface AddTriggerModalProps {
+export interface AddTriggerModalProps {
   type?: WorkflowTriggerType | ''
   triggers?: WorkflowTrigger[]
 }
@@ -19,8 +19,6 @@ const AddTriggerModal: React.FC<AddTriggerModalProps> = ({
   type: initialType = '',
   triggers: initialTriggers
 }) => {
-
-
   const dispatch = useDispatch()
 
   // type sets the initial display of this modal.

--- a/src/features/trigger/modal/AddTriggerModal.tsx
+++ b/src/features/trigger/modal/AddTriggerModal.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react'
+import classNames from 'classnames'
+import { useDispatch } from 'react-redux'
+
+import IconButton from '../../../chrome/IconButton'
+import Icon from '../../../chrome/Icon'
+import Button from '../../../chrome/Button'
+import { clearModal } from '../../app/state/appActions'
+import CronTriggerEditor from '../../trigger/CronTriggerEditor'
+import { WorkflowTrigger, WorkflowTriggerType } from '../../../qrimatic/workflow'
+import { changeWorkflowTrigger } from '../../workflow/state/workflowActions'
+
+interface AddTriggerModalProps {
+  type?: WorkflowTriggerType | ''
+  triggers?: WorkflowTrigger[]
+}
+
+const AddTriggerModal: React.FC<AddTriggerModalProps> = ({
+  type: initialType = '',
+  triggers: initialTriggers
+}) => {
+
+
+  const dispatch = useDispatch()
+
+  // type sets the initial display of this modal.
+  // if no triggers are present in a workflow, it can be called with no type and
+  // will show the UI for choosing what type of trigger to add
+  // if called with type='cron', it will allow for editing an existing schedule trigger
+  const [ type, setType ] = useState<AddTriggerModalProps['type']>(initialType)
+
+  // this will be the default cron trigger setting when the user chooses "schedule"
+  // from the list of available triggers
+  const defaultCronTrigger: WorkflowTrigger = {
+    type: 'cron',
+    periodicity: 'R/2021-01-01T02:00:00.000Z/P1D'
+  }
+
+  // manage a collection of triggers in local state until they are "saved"
+  const [ triggers, setTriggers ] = useState<WorkflowTrigger[]>(initialTriggers || [ defaultCronTrigger ])
+
+  const handleCancelButtonClick = () => {
+    dispatch(clearModal())
+  }
+
+  // on save, commit our local collection of triggers to the store
+  // and close the modal
+  const handleSaveButtonClick = () => {
+    dispatch(changeWorkflowTrigger(0, triggers[0]))
+    dispatch(clearModal())
+  }
+
+  // treat individual trigger editors as controlled inputs
+  // this will be passed in as onChange and will update the trigger in local state
+  // TODO(chriswhong): handle multiple triggers, for now we assume an array of one WorkflowTrigger
+  const handleTriggerChange = (t: WorkflowTrigger) => {
+    setTriggers([t])
+  }
+
+  // this interface and the array of triggerTypes below are used to render
+  // the UI for choosing which type of
+  interface TriggerType {
+    id: WorkflowTriggerType
+    // used in the button for choosing which type of trigger to add/edit
+    buttonLabel: string
+    description: string
+    disabled?: boolean
+    // header text and content for the modal when this trigger type is being edited
+    label: string
+    content?: JSX.Element
+  }
+
+  const triggerTypes: TriggerType[] = [
+    {
+      id: 'cron',
+      buttonLabel: 'Schedule',
+      description: 'run your workflow at a specific interval (e.g. daily at 11pm)',
+      label: 'Schedule Trigger',
+      content: ( <CronTriggerEditor trigger={triggers[0]} onChange={handleTriggerChange} /> )
+    },
+    {
+      id: 'webhook',
+      buttonLabel: 'Webhook',
+      description: 'trigger your script from an external environment',
+      disabled: true,
+      label: 'Webhook Triggers',
+    },
+    {
+      id: 'dataset',
+      buttonLabel: 'Upstream Dataset',
+      description: 'set an upstream dataset to listen for changes',
+      disabled: true,
+      label: 'Upstream Dataset Triggers',
+    }
+  ]
+
+  // check whether the UI pane for adding a specific type of trigger should be in view
+  const currentTriggerType = triggerTypes.find(({ id }) => id === type)
+
+  return (
+    <div className='w-96' style={{ minHeight: 430 }}>
+      <div className={classNames('absolute w-full bg-white p-8 transition-all duration-300', {
+        'left-0': type === '',
+        '-left-full': type !== ''
+      })}>
+        <div className='flex'>
+          <div className='flex-grow'>
+            <h3 className={classNames('text-2xl leading-6 font-black text-qrinavy mb-5')}>Add a Trigger</h3>
+          </div>
+          <IconButton icon='close' onClick={handleCancelButtonClick} />
+        </div>
+        <div className="mb-5 text-base text-qrinavy">
+          {triggerTypes.map(({ id, buttonLabel, description, disabled = false }) => {
+            return (
+              <div
+                key={id}
+                className={classNames('w-full py-4 px-4 rounded flex border items-center mb-4', {
+                  'cursor-pointer': !disabled
+                })}
+                onClick={() => { setType(id) }}
+              >
+                <div className='flex-grow'>
+                  <div className={classNames('font-bold', {
+                    'text-qrinavy': !disabled,
+                    'text-qrigray-300': disabled
+                  })}>{buttonLabel}</div>
+                  <div className={classNames('text-sm', {
+                    'text-qrigray-300': disabled
+                  })}>{description}</div>
+                </div>
+                <Icon icon='caretRight' className={classNames({ 'text-qrigray-300': disabled })} />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      {currentTriggerType && (
+        <div className={classNames('bg-white p-8 transition-all flex flex-col')} style={{ minHeight: 430 }}>
+          <div className='flex-grow'>
+            <div className='flex'>
+              <div className='flex-grow'>
+                <h3 className={classNames('text-2xl leading-6 font-black mb-5')}>{currentTriggerType.label}</h3>
+              </div>
+            </div>
+            <div className="mb-5 text-base text-qrinavy">
+              {currentTriggerType.content}
+            </div>
+          </div>
+          <div>
+            <Button className='w-full mb-3' type='secondary' onClick={handleSaveButtonClick}>Save</Button>
+            <Button className='w-full' type='light' onClick={handleCancelButtonClick}>Cancel</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AddTriggerModal

--- a/src/features/trigger/util.ts
+++ b/src/features/trigger/util.ts
@@ -1,0 +1,185 @@
+import getMinutes from 'date-fns/getMinutes'
+import format from 'date-fns/format'
+
+import { DropDownMenuItem } from '../../chrome/DropdownMenu'
+import { WorkflowTrigger } from '../../qrimatic/workflow'
+
+// for hourly cron triggers, only these values are valid for specifying the minutes
+export type HourlyTriggerMinutes = '00' | '15' | '30' | '45'
+
+// gets the minutes from an ISO8601 time string, returns them as a two-digit string
+export const getTwoDigitMinutes = (time: string) => {
+  return getMinutes(new Date(time))
+    .toLocaleString('en-US', {
+      minimumIntegerDigits: 2,
+      useGrouping: false
+    }) as HourlyTriggerMinutes
+}
+
+interface HourlyTriggerMinutesMenuItem extends DropDownMenuItem {
+  value: HourlyTriggerMinutes
+}
+
+// used to specify the minutes for hourly triggers
+// this is used as labels/values for DropdownMenu, and as a lookup object
+export const hourlyItems: HourlyTriggerMinutesMenuItem[] = [
+  {
+    label: 'on the hour',
+    value: '00'
+  },
+  {
+    label: 'on the 1/4-hour',
+    value: '15'
+  },
+  {
+    label: 'on the half-hour',
+    value: '30'
+  },
+  {
+    label: 'on the 3/4-hour',
+    value: '45'
+  }
+]
+
+// given a starttime as an ISO8601 timestamp, get the minutes and return the corresponding label
+export const parseHourlyStart = (startTime: string) => {
+  const minutes: HourlyTriggerMinutes = getTwoDigitMinutes(startTime)
+  return hourlyItems.find(d => d.value === minutes)?.label
+}
+
+// given a starttime as an ISO8601 timestamp, return a human readable timestamp (4:30 PM)
+export const parseDailyStart = (startTime: string) => {
+  return `at ${format(new Date(startTime), 'p')}`
+}
+
+// takes an ISO8601 scheduled interval, returns scheduleUIConfig object
+export const scheduleFromPeriodicity = (periodicity: string) => {
+  const [, startTime, interval] = periodicity.split('/')
+
+  const defaultScheduleUIConfig = {
+    periodicity: 'daily',
+    minutes: '00',
+    time: '21:00'
+  }
+
+  switch (interval) {
+    case 'PT10M':
+      return {
+        ...defaultScheduleUIConfig,
+        periodicity: 'ten-minutes',
+        minutes: '00',
+      } as Schedule
+    case 'P1H':
+      return {
+        ...defaultScheduleUIConfig,
+        periodicity: 'hourly',
+        minutes: getTwoDigitMinutes(startTime)
+      } as Schedule
+    case 'P1D':
+      return {
+        ...defaultScheduleUIConfig,
+        periodicity: 'daily',
+        time: format(new Date(startTime), 'HH:mm'),
+      } as Schedule
+  }
+}
+
+export const periodicityItems: DropDownMenuItem[] = [
+  {
+    label: 'Every 10 Minutes',
+    value: 'ten-minutes'
+  },
+  {
+    label: 'Every Hour',
+    value: 'hourly'
+  },
+  {
+    label: 'Every Day',
+    value: 'daily'
+  },
+  // {
+  //   id: 'weekly',
+  //   label: 'Every Week',
+  //   value: '1W'
+  // },
+  // {
+  //   id: 'monthly',
+  //   label: 'Month',
+  //   value: '1M'
+  // }
+]
+
+// Schedule stores the value for each UI element used to create cron triggers
+// periodicity is always defined, minutes is needed when periodicity is 'hourly',
+// time is needed when periodicity is 'daily'
+// no additional info is needed when periodicty is 'ten-minutes', script will run on the 10s
+export interface Schedule {
+  periodicity: string
+  minutes: string
+  time: string
+}
+
+// convert the UI values into a valid CronTrigger
+export const triggerFromSchedule = (schedule: Schedule) => {
+  // convert the UI settings into a valid WorkflowTrigger
+  let periodicity
+  let startTime
+  const today = new Date()
+
+  // for every 10 minutes, periodicity is 'R/PT10M'
+  if (schedule.periodicity === 'ten-minutes') {
+
+    // get most recent previous hour, the ten-minutes interval will run at 00, 10, 20, 30, ...
+    const startTime = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      today.getHours(),
+      0,
+      0
+    ).toISOString()
+
+    periodicity = `R/${startTime}/PT10M`
+  }
+
+  // for hourly, periodicity is R/PT1H and startTime is the next instance of the minutes selected by the user
+  if (schedule.periodicity === 'hourly') {
+
+    // get most recent previous hour, add minutes, convert to ISO8601
+    startTime = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      today.getHours(),
+      parseInt(schedule.minutes),
+      0
+    ).toISOString()
+
+    periodicity = `R/${startTime}/P1H`
+  }
+
+  if (schedule.periodicity === 'daily') {
+    // time is in HH:MM format in local time (24 hour hours)
+    const [hours, minutes] = schedule.time.split(':')
+
+    // get ISO8601 string for today at the specified hours+minutes
+    const startTime = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      parseInt(hours),
+      parseInt(minutes),
+      0
+    ).toISOString()
+
+    periodicity = `R/${startTime}/P1D`
+  }
+
+  const trigger: WorkflowTrigger = {
+    type: 'cron',
+    enabled: true,
+    periodicity,
+  }
+
+  return trigger
+}

--- a/src/features/userProfile/UserProfileDatasetList.tsx
+++ b/src/features/userProfile/UserProfileDatasetList.tsx
@@ -40,12 +40,12 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
 
   const menuItems = [
     {
-      text: 'Dataset Name',
+      label: 'Dataset Name',
       active: sort === 'name',
       onClick: () => { onParamsUpdate({ sort: 'name' }) }
     },
     {
-      text: 'Recently Updated',
+      label: 'Recently Updated',
       active: sort === 'recentlyupdated',
       onClick: () => { onParamsUpdate({ sort: 'recentlyupdated' }) }
     }

--- a/src/features/userProfile/UserProfileDatasetList.tsx
+++ b/src/features/userProfile/UserProfileDatasetList.tsx
@@ -30,33 +30,23 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
     loading
   } = paginatedResults
 
-  const {
-    page,
-  } = pageInfo
-
-  const {
-    sort
-  } = userProfileParams
-
-  const menuItems = [
-    {
-      label: 'Dataset Name',
-      active: sort === 'name',
-      onClick: () => { onParamsUpdate({ sort: 'name' }) }
-    },
-    {
-      label: 'Recently Updated',
-      active: sort === 'recentlyupdated',
-      onClick: () => { onParamsUpdate({ sort: 'recentlyupdated' }) }
-    }
-  ]
-
+  const { page } = pageInfo
+  const { sort } = userProfileParams
   const totalPages = Math.ceil( pageInfo.resultCount / pageInfo.pageSize )
 
   // handle page change from PageControl
   const handlePageChange = ({ selected: pageIndex }: PageChangeObject) => {
     onParamsUpdate({ page: pageIndex + 1 })
   }
+
+  const handleSortChange = (sort: 'name' | 'recentlyupdated') => {
+    onParamsUpdate({ sort, page: pageIndex })
+  }
+
+  const dropdownSortIcon = <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
+    Sort By
+    <Icon icon='caretDown' size='2xs' className='ml-3' />
+  </div>
 
   return (
     <>
@@ -77,12 +67,22 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
             }
 
           </div>
-          <DropdownMenu items={menuItems} className='ml-8'>
-            <div className='border border-qrigray-300 rounded-lg text-qrigray-400 text-xs font-normal px-2 py-2 cursor-pointer'>
-              Sort By
-              <Icon icon='caretDown' size='2xs' className='ml-3' />
-            </div>
-          </DropdownMenu>
+          <DropdownMenu
+            icon={dropdownSortIcon}
+            className='ml-8'
+            items={[
+              {
+                label: 'Dataset Name',
+                active: sort === 'name',
+                onClick: () => { handleSortChange('name') }
+              },
+              {
+                label: 'Recently Updated',
+                active: sort === 'recentlyupdated',
+                onClick: () => { handleSortChange('recentlyupdated') },
+              }
+            ]}
+          />
         </div>
         <DatasetList datasets={results} loading={loading} />
       </ContentBox>

--- a/src/features/workflow/Block.tsx
+++ b/src/features/workflow/Block.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 
 export interface BlockProps {
-  name: string
+  name?: string
   onClick?: () => void
 }
 
 const Block: React.FC<BlockProps> = ({ name, children,onClick }) => (
-  <div className='px-2 w-1/3 py-2' onClick={onClick}>
+  <div className='px-2 w-full py-2' onClick={onClick}>
     <div className='bg-white px-3 py-2 shadow-even cursor-pointer rounded-lg h-full'>
-      <div className='text-sm font-semibold pb-1'>{name}</div>
+      { name && <div className='text-sm font-semibold pb-1 text-qrinavy'>{name}</div>}
       {children}
     </div>
   </div>

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -124,9 +124,8 @@ export const workflowReducer = createReducer(initialState, {
 })
 
 function changeWorkflowTrigger(state: WorkflowState, action: WorkflowTriggerAction) {
-  if (state.workflow.triggers && state.workflow.triggers.length > action.index) {
-    state.workflow.triggers[action.index] = action.trigger
-  }
+  // TODO(chriswhong): allow for more than one trigger
+  state.workflow.triggers = [action.trigger]
   return
 }
 

--- a/src/qrimatic/workflow.ts
+++ b/src/qrimatic/workflow.ts
@@ -19,7 +19,7 @@ export interface Workflow {
   latestStart?: string
   latestEnd?: string
   status: WorkflowStatus
-  
+
   triggers?: WorkflowTrigger[]
   steps?: TransformStep[]
   onComplete?: WorkflowHook[]
@@ -49,8 +49,14 @@ export function NewWorkflow(data: Record<string,any>): Workflow {
   }
 }
 
+export type WorkflowTriggerType = 'cron' | 'webhook' | 'dataset'
+
+export interface CronTrigger extends WorkflowTrigger {
+  periodicity: string // ISO8601 repeating interval (R/{starttime}/{interval})
+}
+
 export interface WorkflowTrigger {
-  type:       string,
+  type:       WorkflowTriggerType,
   disabled?:   boolean,
 
   runCount?:      number,
@@ -84,7 +90,7 @@ export function NewWorkflowHook(data: Record<string,any>): WorkflowHook {
 }
 
 export function workflowScriptString(w: Workflow): string {
-  if (!w.steps) { 
+  if (!w.steps) {
     return ''
   }
 
@@ -96,7 +102,7 @@ export function workflowScriptString(w: Workflow): string {
   }, '')
 }
 
-export type DeployStatus = 
+export type DeployStatus =
   | 'undeployed'
   | 'deployed'
   | 'deploying'
@@ -114,7 +120,7 @@ export function workflowDeployStatus(w?: Workflow): DeployStatus {
   return 'deployed'
 }
 
-export type WorkflowStatus = 
+export type WorkflowStatus =
 | 'running'
 | 'succeeded'
 | 'failed'
@@ -137,7 +143,7 @@ export function newWorkflowInfo(data: Record<string,any>): WorkflowInfo {
     profileId: data.profileId || '',
     name: data.name || '',
     path: data.path || '',
-    
+
     fsiPath: data.fsiPath || '',
     foreign: data.foreign,
     published: data.published,
@@ -168,7 +174,7 @@ export function workflowInfoFromWorkflow(wf: Workflow): WorkflowInfo {
     profileId: wf.versionInfo?.profileId || '',
     name: wf.versionInfo?.name || '',
     path: wf.versionInfo?.path || '',
-    
+
     fsiPath: wf.versionInfo?.fsiPath || '',
     foreign: wf.versionInfo?.foreign,
     published: wf.versionInfo?.published,
@@ -189,6 +195,6 @@ export function workflowInfoFromWorkflow(wf: Workflow): WorkflowInfo {
     id: wf.id,
     latestStart: wf.latestStart,
     latestEnd: wf.latestEnd,
-    status: wf.status 
+    status: wf.status
   }
 }


### PR DESCRIPTION
Allows the user to add a trigger via the `AddTrigger` modal, which includes an initial pane to help the user choose which type of trigger they would like to add.

The only available trigger at the moment is `CronTrigger`, which uses the `periodicity` key to store an ISO8601 repeating interval string.

This PR expands `CronTriggerEditor` to add intuitive UI for 10-minute, hourly (with 00,15,30,45 minutes specified), and daily (with a time of day specified) intervals.  We can add more later, but these three values will be a good starting point.

There are various utilities for mapping between the values uses in the cron editor UI and the ISO8601 repeating interval stored in state and used by the backend.

`CronTriggerDisplay` is also added, which reads the ISO8601 repeating interval and displays human friendly text for when the trigger will run in the Workflow Editor.  User can click to edit, opening the AddTrigger modal as an editor.

Closes #70 