### PR TITLE
feat: improve rename UI in datasetHeader

### DIFF
--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -44,7 +44,6 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
       .then(({ type }) => {
         if (type === 'API_RENAME_SUCCESS') {
           const newPath = history.location.pathname.replace(dataset.name, value)
-          console.log('routing from ', history.location.pathname, ' to ', newPath)
           history.replace(newPath)
         }
       })
@@ -52,35 +51,39 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
 
   return (
     <div className="w-full">
-      <div className='flex'>
-        <div className='flex-grow pb-5'>
-          <div className='text-md text-gray-400 relative flex items-center group hover:text pb-1 font-mono h-10'>
-            <TextLink to={`/${qriRef.username}`} className='whitespace-nowrap' colorClassName='text-qrigray-400 hover:text-qrigray-800'>{qriRef.username || 'new'}</TextLink>/
-            <EditableLabel
-              readOnly={!editable}
-              name='name'
-              onChange={handleRename}
-              value={qriRef.name}
-              validator={validateDatasetName}
-            />
-            {editable &&
-              <DropdownMenu
-                icon={<Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />}
-                items={[
-                  {
-                    label: 'Duplicate...',
-                    disabled: true,
-                    onClick: () => { handleButtonClick("duplicating not yet implemented") }
-                  }
-                ]}
-              />}
-          </div>
+      <div className='flex mb-5'>
+        <div className='flex-grow'>
+          {/* don't show the username/name when creating a new dataset with the workflow editor */}
+          { qriRef.username && (
+            <div className='text-md text-gray-400 relative flex items-center group hover:text pb-1 font-mono h-10'>
+              <TextLink to={`/${qriRef.username}`} className='whitespace-nowrap' colorClassName='text-qrigray-400 hover:text-qrigray-800'>{qriRef.username}</TextLink>/
+              <EditableLabel
+                readOnly={!editable}
+                name='name'
+                onChange={handleRename}
+                value={qriRef.name}
+                validator={validateDatasetName}
+              />
+              {editable &&
+                <DropdownMenu
+                  icon={<Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />}
+                  items={[
+                    {
+                      label: 'Duplicate...',
+                      disabled: true,
+                      onClick: () => { handleButtonClick("duplicating not yet implemented") }
+                    }
+                  ]}
+                />}
+            </div>
+          )}
 
-          <div className='text-2xl text-qrinavy-500 font-black group hover:text mb-3'>
+
+          <div className='text-2xl text-qrinavy-500 font-black group hover:text'>
             {dataset.meta?.title || dataset.name}
           </div>
           {showInfo && (
-            <div className='flex'>
+            <div className='flex mt-3'>
               <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' />
               <DatasetInfoItem icon='disk' label='59 MB' />
               <DatasetInfoItem icon='download' label='418 downloads' />

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -31,15 +31,19 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
       borderTopLeftRadius: '20px',
       transition: 'top 150ms cubic-bezier(0.4, 0, 0.2, 1)'
     }}>
-      <div className='px-7 pt-4 pb-3 flex z-10'>
+      <div className='px-7 pt-4 pb-3 flex items-center z-10'>
         <div className='flex-grow'>
-          <div className='text-xs text-gray-400 font-mono'>
-            <TextLink to={`/${dataset.peername}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{dataset.peername || 'new'}</TextLink>/{dataset.name}
-          </div>
+          { qriRef.username && (
+            <div className='text-xs text-gray-400 font-mono'>
+              <TextLink to={`/${dataset.peername}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{dataset.peername || 'new'}</TextLink>/{dataset.name}
+            </div>
+          )}
           <div className='text-normal text-qrinavy font-semibold'>
             {dataset.meta?.title || dataset.name}
           </div>
         </div>
+
+
         <div className='flex items-center content-center'>
           {children || (
             <>

--- a/src/features/dataset/state/datasetActions.ts
+++ b/src/features/dataset/state/datasetActions.ts
@@ -1,5 +1,5 @@
 import Dataset, { NewDataset } from "../../../qri/dataset"
-import { QriRef, refStringFromQriRef } from "../../../qri/ref"
+import { QriRef, refStringFromQriRef, humanRef } from "../../../qri/ref"
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api"
 import { RENAME_NEW_DATASET } from "./datasetState"
 import { API_BASE_URL } from '../../../store/api'
@@ -8,10 +8,6 @@ export const bodyPageSizeDefault = 50
 
 export function mapDataset(d: object | []): Dataset {
   return NewDataset((d as Record<string,any>))
-}
-
-export function mapBody (d: {data: Body}): Body {
-  return d.data
 }
 
 export function loadDataset(ref: QriRef): ApiActionThunk {
@@ -66,8 +62,7 @@ function fetchBody (ref: QriRef, page: number, pageSize: number): ApiAction {
         name: ref.name,
         path: ref.path,
         selector: ['body']
-      },
-      map: mapBody
+      }
     }
   }
 }
@@ -96,7 +91,7 @@ export interface RenameDatasetAction {
   next: QriRef
 }
 
-export function renameDataset(current: QriRef, next: QriRef): ApiActionThunk | Promise<RenameDatasetAction> {
+export function renameDataset(current: QriRef, next: QriRef): ApiActionThunk {
   // if no path exists, assume a new dataset & client-side-only rename
   // TODO(b5): once QriRefs have an initID field, use that as the proper check
   // for "newness"
@@ -112,11 +107,11 @@ export function renameDataset(current: QriRef, next: QriRef): ApiActionThunk | P
     const action = {
       type: 'rename',
       [CALL_API]: {
-        endpoint: 'rename',
+        endpoint: 'ds/rename',
         method: 'POST',
         body: {
-          current,
-          next,
+          current: refStringFromQriRef(humanRef(current)),
+          next: refStringFromQriRef(humanRef(next)),
         },
         // TODO(b5): this return value is a versionInfo
         map: mapDataset

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -58,7 +58,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
     dispatch(loadDataset(ref))
     dispatch(loadWorkflowByDatasetRef(qriRef))
 
-  }, [])
+  }, [ qriRef ])
 
   const runBar = <RunBar status={latestRun ? latestRun.status : "waiting" } />
 


### PR DESCRIPTION
Fixes/improves the rename UI (user can rename a dataset they own by clicking the dataset name in any of the dataset views)

Changes the header when the user is creating a new dataset from workflow