### PR TITLE
feat: style run log, refactor dataset page layout

### DIFF
--- a/src/chrome/Icon.tsx
+++ b/src/chrome/Icon.tsx
@@ -1,49 +1,5 @@
 import React from 'react'
 
-import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome'
-import {
-  faArrowLeft,
-  faArrowRight,
-  faBars,
-  faBolt,
-  faCheckCircle,
-  faCircle,
-  faCloudUploadAlt,
-  faCode,
-  faProjectDiagram,
-  faEllipsisH,
-  faEnvelope,
-  faFont,
-  faHashtag,
-  faHome,
-  faHdd,
-  faList,
-  faCheck,
-  faPen,
-  faMinusCircle,
-  faPlay,
-  faPlus,
-  faPlusCircle,
-  faPauseCircle,
-  faTimes,
-  faToggleOn,
-  faExclamationCircle,
-  faExclamationTriangle,
-  faQuestion,
-  faQuestionCircle,
-  faSearch,
-  faShip,
-  faSortDown,
-  faSpinner,
-  faTable,
-
-  IconDefinition,
-} from '@fortawesome/free-solid-svg-icons'
-
-import {
-  faFile
-} from '@fortawesome/free-regular-svg-icons'
-
 import ActivityFeed from './icon/ActivityFeed'
 import AutomationFilled from './icon/AutomationFilled'
 import Body from './icon/Body'
@@ -80,6 +36,7 @@ import Info from './icon/Info'
 import Lock from './icon/Lock'
 import MyDatasets from './icon/MyDatasets'
 import Page from './icon/Page'
+import Play from './icon/Play'
 import PlayCircle from './icon/PlayCircle'
 import Plus from './icon/Plus'
 import Readme from './icon/Readme'
@@ -105,49 +62,6 @@ interface IconProps {
 
 export type IconSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg'
 
-const faIcons: Record<string, IconDefinition> = {
-  'any': faQuestion,
-  'array': faQuestionCircle,
-  'arrowLeft': faArrowLeft,
-  'arrowRight': faArrowRight,
-  'bars': faBars,
-  'bolt': faBolt,
-  'boolean': faToggleOn,
-  'check': faCheck,
-  'checkCircle': faCheckCircle,
-  'circle': faCircle,
-  'cloudUpload': faCloudUploadAlt,
-  'ellipsisH': faEllipsisH,
-  'envelope': faEnvelope,
-  'exclamationCircle': faExclamationCircle,
-  'exclamationTriangle': faExclamationTriangle,
-  'file': faFile,
-  'hdd': faHdd,
-  'home': faHome,
-  'integer': faHashtag,
-  'list': faList,
-  'minusCircle': faMinusCircle,
-  'null': faQuestionCircle,
-  'number': faHashtag,
-  'numeric': faHashtag,
-  'object': faQuestionCircle,
-  'pauseCircle': faPauseCircle,
-  'pen': faPen,
-  'play': faPlay,
-  'plus': faPlus,
-  'plusCircle': faPlusCircle,
-  'projectDiagram': faProjectDiagram,
-  'search': faSearch,
-  'ship': faShip,
-  'sortDown': faSortDown,
-  'spinner': faSpinner,
-  'string': faFont,
-  'table': faTable,
-  'times': faTimes,
-  'transform': faCode,
-  'unknown': faQuestionCircle,
-}
-
 const sizes: {[key: string]: FontAwesomeIconProps['size']} = {
   'xs': 'xs',
   'sm': 'sm',
@@ -162,8 +76,6 @@ const Icon: React.FunctionComponent<IconProps> = ({
   rotation,
   spin
 }) => {
-
-  const faIconsList = Object.keys(faIcons)
 
   const customIcons: {[key: string]: any} = {
     activityFeed: <ActivityFeed className={className} size={size} />,
@@ -202,6 +114,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
     lock: <Lock className={className} size={size} />,
     myDatasets: <MyDatasets className={className} size={size} />,
     page: <Page className={className} size={size} />,
+    play: <Play className={className} size={size} />,
     playCircle: <PlayCircle className={className} size={size} />,
     plus: <Plus className={className} size={size} />,
     readme: <Readme className={className} size={size} />,
@@ -212,10 +125,6 @@ const Icon: React.FunctionComponent<IconProps> = ({
     tags: <Tags className={className} size={size} />,
     twitter: <Twitter className={className} size={size} />,
     youtube: <Youtube className={className} size={size} />
-  }
-
-  if (faIconsList.includes(icon)) {
-    return <FontAwesomeIcon rotation={rotation} size={sizes[size]} icon={faIcons[icon]} className={className} spin={spin} />
   }
 
   return customIcons[icon] || '?'

--- a/src/chrome/RelativeTimestamp.tsx
+++ b/src/chrome/RelativeTimestamp.tsx
@@ -12,11 +12,10 @@ const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({
   className
 }) => {
   let timeFromNowAbbreviation = formatDistanceToNow(timestamp, { addSuffix: true })
-
   // manipulate the output of date-fns formatDistanceToNow() for shorter screen renders
   timeFromNowAbbreviation = timeFromNowAbbreviation
     .replace('about ', '')
-    .replace(' hours ago', 'h')
+    .replace(/ hours? ago/, 'h')
     .replace('less than ', '<')
     .replace(/ minutes? ago/, 'm')
     .replace('a', '1')

--- a/src/chrome/RelativeTimestamp.tsx
+++ b/src/chrome/RelativeTimestamp.tsx
@@ -10,13 +10,26 @@ interface RelativeTimestampProps {
 const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({
   timestamp,
   className
- }) => (
-  <span
-    className={className}
-    title={format(timestamp, 'MMM d yyyy, h:mm zz')}
-  >
-    {formatDistanceToNow(timestamp, { addSuffix: true })}
-  </span>
-)
+}) => {
+  let timeFromNowAbbreviation = formatDistanceToNow(timestamp, { addSuffix: true })
+
+  // manipulate the output of date-fns formatDistanceToNow() for shorter screen renders
+  timeFromNowAbbreviation = timeFromNowAbbreviation
+    .replace('about ', '')
+    .replace(' hours ago', 'h')
+    .replace('less than ', '<')
+    .replace(/ minutes? ago/, 'm')
+    .replace('a', '1')
+
+  return (
+    <span
+      className={className}
+      title={format(timestamp, 'MMM d yyyy, h:mm zz')}
+    >
+      {timeFromNowAbbreviation}
+    </span>
+  )
+}
+
 
 export default RelativeTimestamp

--- a/src/chrome/icon/Play.tsx
+++ b/src/chrome/icon/Play.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import CustomIcon, { CustomIconProps } from '../CustomIcon'
+
+const Play: React.FC<CustomIconProps> = (props) => (
+  <CustomIcon {...props}>
+    <path d="M4.7063 2L20.2619 12L4.7063 22V2Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </CustomIcon>
+)
+
+export default Play

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { QriRef } from '../../qri/ref'
+import useDimensions from 'react-use-dimensions'
 
 import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
@@ -13,18 +14,24 @@ export interface DatasetActivityFeedProps {
 const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
   qriRef
 }) => {
+
   const logs = useSelector(newDatasetLogsSelector(qriRef))
   const dispatch = useDispatch()
+
+  const [tableContainer, { height: tableContainerHeight }] = useDimensions()
+
 
   useEffect(() => {
     dispatch(loadDatasetLogs(qriRef))
   },[dispatch, qriRef])
 
   return (
-    <div className='w-full px-10 py-20 overflow-y-auto'>
-      <div className='max-w-screen-md mx-auto bg-white rounded-lg'>
-        <ActivityList log={logs} showDatasetName={false} />
-      </div>
+    <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white relative'>
+      <ActivityList
+        log={logs}
+        showDatasetName={false}
+        containerHeight={tableContainerHeight}
+      />
     </div>
   )
 }

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -6,6 +6,8 @@ import useDimensions from 'react-use-dimensions'
 import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
+import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
+
 
 export interface DatasetActivityFeedProps {
   qriRef: QriRef
@@ -26,13 +28,15 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
   },[dispatch, qriRef])
 
   return (
-    <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white relative'>
-      <ActivityList
-        log={logs}
-        showDatasetName={false}
-        containerHeight={tableContainerHeight}
-      />
-    </div>
+    <DatasetFixedLayout>
+      <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white relative'>
+        <ActivityList
+          log={logs}
+          showDatasetName={false}
+          containerHeight={tableContainerHeight}
+        />
+      </div>
+    </DatasetFixedLayout>
   )
 }
 

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -232,31 +232,31 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
             <DropdownMenu
               icon={<Icon icon='ellipsisH' size='md'/>}
               items={[
-                {
-                  label: 'Rename...',
-                  disabled: true,
-                  onClick: () => { handleButtonClick("renaming not yet implemented") },
-                },
-                {
-                  label: 'Duplicate...',
-                  disabled: true,
-                  onClick: () => { handleButtonClick("duplicating not yet implemented")},
-                },
-                {
-                  label: 'Export...',
-                  disabled: true,
-                  onClick: () => { handleButtonClick("export not yet implemented")},
-                },
-                {
-                  label: 'Run Now',
-                  disabled: true,
-                  onClick: () => { handleButtonClick("run now not yet implemented")},
-                },
-                {
-                  label: 'Pause Workflow',
-                  disabled: true,
-                  onClick: () => { handleButtonClick("pause not yet implemented")},
-                },
+                // {
+                //   label: 'Rename...',
+                //   disabled: true,
+                //   onClick: () => { handleButtonClick("renaming not yet implemented") },
+                // },
+                // {
+                //   label: 'Duplicate...',
+                //   disabled: true,
+                //   onClick: () => { handleButtonClick("duplicating not yet implemented")},
+                // },
+                // {
+                //   label: 'Export...',
+                //   disabled: true,
+                //   onClick: () => { handleButtonClick("export not yet implemented")},
+                // },
+                // {
+                //   label: 'Run Now',
+                //   disabled: true,
+                //   onClick: () => { handleButtonClick("run now not yet implemented")},
+                // },
+                // {
+                //   label: 'Pause Workflow',
+                //   disabled: true,
+                //   onClick: () => { handleButtonClick("pause not yet implemented")},
+                // },
                 {
                   label: 'Remove...',
                   onClick: () => {
@@ -279,6 +279,9 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
     }
   ]
 
+  // TODO(chriswhong): implement selectable rows and multi-row actions
+  // uncomment `selectableRows` etc below
+
   return (
     <ReactDataTable
       columns={columns}
@@ -290,12 +293,12 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       fixedHeader
       fixedHeaderScrollHeight={`${String(containerHeight - 68)}px`}
       noHeader
-      selectableRows
-      selectableRowsComponent={forwardRef((props, ref) => (
-        <Icon icon='checkbox' />
-      ))}
-      onSelectedRowsChange={onSelectedRowsChange}
-      clearSelectedRows={clearSelectedTrigger}
+      // selectableRows
+      // selectableRowsComponent={forwardRef((props, ref) => (
+      //   <Icon icon='checkbox' />
+      // ))}
+      // onSelectedRowsChange={onSelectedRowsChange}
+      // clearSelectedRows={clearSelectedTrigger}
       style={{
         background: 'blue'
       }}

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -62,7 +62,7 @@ const customSort = (rows: VersionInfo[], field: string, direction: 'asc' | 'desc
 }
 
 // based on 'caretDown' but needs a custom viewbox and a custom css rule in App.css to show properly in react-data-table
-const customSortIcon = (
+export const customSortIcon = (
   <svg
     viewBox="-6 -6 36 36"
     fill="none"
@@ -73,12 +73,9 @@ const customSortIcon = (
 )
 
 // react-data-table custom styles
-const customStyles = {
+export const customStyles = {
   table: {
-    style: {
-      paddingRight: '26px',
-      paddingLeft: '26px'
-    },
+
   },
   tableWrapper: {
     style: {
@@ -87,7 +84,9 @@ const customStyles = {
   },
   headRow: {
     style: {
-      minHeight: '68px'
+      minHeight: '68px',
+      paddingRight: '26px',
+      paddingLeft: '26px'
     }
   },
   headCells: {
@@ -99,7 +98,9 @@ const customStyles = {
   },
   rows: {
     style: {
-      minHeight: '68px'
+      minHeight: '68px',
+      paddingRight: '26px',
+      paddingLeft: '26px'
     }
   },
   expanderCell: {

--- a/src/features/commits/CommitSummaryHeader.tsx
+++ b/src/features/commits/CommitSummaryHeader.tsx
@@ -20,15 +20,14 @@ const CommitSummaryHeader: React.FC<CommitSummaryHeaderProps> = ({
       <div className='min-height-200 py-4 px-8 rounded-lg bg-white flex'>
         <div className='flex-grow'>
           <div className='text-xs text-gray-400 font-medium mb-2'>Version Info</div>
-          <div className='text-qrinavy text-sm flex items-center mb-2'>
-            <Icon icon='commit' size='sm' className='-ml-2' />
-            <div className='font-medium'>{commitishFromPath(path)}</div>
-            <div className='mx-3 text-gray-400'>|</div>
+          <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
             <div className=''>{commit.title}</div>
           </div>
-          <div className='flex items-centern text-xs text-gray-400'>
+          <div className='flex items-center text-xs text-gray-400'>
             <UsernameWithIcon username={dataset.peername} className='mr-3' />
-            <RelativeTimestampWithIcon timestamp={new Date(commit.timestamp)} className='mr-4' />
+            <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(commit.timestamp)} />
+            <Icon icon='commit' size='sm' className='-ml-2' />
+            <div className=''>{commitishFromPath(path)}</div>
           </div>
         </div>
         <div className='flex items-center'>

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -30,8 +30,8 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
           <Icon icon='automationFilled' size='sm'/>
         </div>
       </div>
-      <div className='flex flex-col text-qrigray-400'>
-        <div className='mb-1'>{logItem.username && <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />}</div>
+      <div className='flex items-center text-qrigray-400'>
+        {logItem.username && <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />}
         <RelativeTimestampWithIcon timestamp={new Date(logItem.timestamp)} />
       </div>
       {/* TODO(chriswhong): restore when we can add component change indicators <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />*/}

--- a/src/features/commits/state/commitState.ts
+++ b/src/features/commits/state/commitState.ts
@@ -1,8 +1,8 @@
 import { createReducer } from '@reduxjs/toolkit'
 
-import { RootState } from '../../../store/store';
-import { humanRef, QriRef, refStringFromQriRef } from '../../../qri/ref';
-import { LogItem } from '../../../qri/log';
+import { RootState } from '../../../store/store'
+import { humanRef, QriRef, refStringFromQriRef } from '../../../qri/ref'
+import { LogItem } from '../../../qri/log'
 
 export function newDatasetCommitsSelector(qriRef: QriRef): (state: RootState) => LogItem[] {
   qriRef = humanRef(qriRef)
@@ -38,7 +38,7 @@ export const commitsReducer = createReducer(initialState, {
   },
   'API_DATASET_COMMITS_SUCCESS': (state, action) => {
     const ls = action.payload.data as LogItem[]
-    state.commits[refStringFromQriRef(action.qriRef)] = ls
+    state.commits[refStringFromQriRef(action.qriRef)] = ls.filter(d => d.path)
     state.loading = false
   },
 })

--- a/src/features/dataset/DatasetFixedLayout.tsx
+++ b/src/features/dataset/DatasetFixedLayout.tsx
@@ -1,25 +1,22 @@
-import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React from 'react'
+import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
-import NavBar from '../navbar/NavBar'
 import { newQriRef } from '../../qri/ref'
-import { loadDataset } from './state/datasetActions'
-import DatasetNavSidebar from './DatasetNavSidebar'
+import { selectDsPreview } from '../dsPreview/state/dsPreviewState'
 import { selectSessionUser } from '../session/state/sessionState'
-import { selectSessionUserCanEditDataset, selectDataset } from './state/datasetState'
+import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
 import DeployingScreen from '../deploy/DeployingScreen'
 
 
-const DatasetPage: React.FC<{}> = ({
+const DatasetFixedLayout: React.FC<{}> = ({
   children
 }) => {
   const qriRef = newQriRef(useParams())
-  const dataset = useSelector(selectDataset)
+  const dsPreview = useSelector(selectDsPreview)
   const user = useSelector(selectSessionUser)
   const editable = useSelector(selectSessionUserCanEditDataset)
-  const dispatch = useDispatch()
   const isNew = (qriRef.username === 'new')
 
   // This covers the case where a user created a new workflow before logging in.
@@ -31,25 +28,15 @@ const DatasetPage: React.FC<{}> = ({
     qriRef.username = user.username
   }
 
-  useEffect(() => {
-    if (isNew) { return }
-    const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
-    dispatch(loadDataset(ref))
-  }, [dispatch, qriRef.username, qriRef.name, qriRef.path, isNew])
-
   return (
-    <div className='flex flex-col h-full w-full' style={{ backgroundColor: '#f3f4f6'}}>
-      <NavBar />
-      <div className='flex overflow-hidden w-full flex-grow'>
-        <DatasetNavSidebar qriRef={qriRef} />
+    <>
         <div className='flex flex-col flex-grow overflow-hidden p-7'>
-          <DatasetHeader dataset={dataset} editable={editable} />
+          <DatasetHeader dataset={dsPreview} editable={editable} />
           {children}
         </div>
         <DeployingScreen qriRef={qriRef} />
-      </div>
-    </div>
+    </>
   )
 }
 
-export default DatasetPage
+export default DatasetFixedLayout

--- a/src/features/dataset/DatasetInfoItem.tsx
+++ b/src/features/dataset/DatasetInfoItem.tsx
@@ -22,7 +22,7 @@ const DatasetInfoItem: React.FC<DatasetInfoItemProps> = ({
 
 
   return (
-    <div className={classNames('text-sm flex items-center inline-block', {
+    <div className={classNames('flex items-center inline-block', {
       'text-qrinavy-500 mr-5': !small,
       'text-qrigray-400 mr-3': small
     })}>

--- a/src/features/dataset/DatasetPage.tsx
+++ b/src/features/dataset/DatasetPage.tsx
@@ -40,7 +40,7 @@ const DatasetPage: React.FC<{}> = ({
   return (
     <div className='flex flex-col h-full w-full' style={{ backgroundColor: '#f3f4f6'}}>
       <NavBar />
-      <div className='flex overflow-hidden w-full'>
+      <div className='flex overflow-hidden w-full flex-grow'>
         <DatasetNavSidebar qriRef={qriRef} />
         <div className='flex flex-col flex-grow overflow-hidden p-7'>
           <DatasetHeader dataset={dataset} editable={editable} />

--- a/src/features/dataset/DatasetRoutes.tsx
+++ b/src/features/dataset/DatasetRoutes.tsx
@@ -1,3 +1,10 @@
+// All dataset routes share DatasetWrapper, which handles the rendering of the
+// dataset menu and fetches dsPreview (the latest version of the dataset)
+// All routes use dsPreview to render the dataset header, so it is always needed
+// regardless of th other dataset content being displayed
+
+// DatasetPreviewPage fetches the other necessary parts of the preview (body + readme)
+
 import React from 'react'
 import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router'
 
@@ -6,9 +13,9 @@ import DatasetComponents from '../dsComponents/DatasetComponents'
 import DatasetActivityFeed from '../activityFeed/DatasetActivityFeed'
 import DatasetPreviewPage from '../dsPreview/DatasetPreviewPage'
 import DatasetIssues from '../issues/DatasetIssues'
-import DatasetPage from './DatasetPage'
 import { newQriRef } from '../../qri/ref'
 import DatasetEditor from '../dsComponents/DatasetEditor'
+import DatasetWrapper from '../dsComponents/DatasetWrapper'
 
 const DatasetRoutes: React.FC<{}> = () => {
   const { url } = useRouteMatch()
@@ -21,54 +28,53 @@ const DatasetRoutes: React.FC<{}> = () => {
   const qriRef = newQriRef(useParams())
 
   return (
-    <Switch>
-      <Route path='/ds/:username/:name' exact>
-        <Redirect to={`${url}/preview`} />
-      </Route>
+    <DatasetWrapper>
+      <Switch>
+        <Route path='/ds/:username/:name' exact>
+          <Redirect to={`${url}/preview`} />
+        </Route>
 
-      <Route path='/ds/:username/:name/workflow'>
-        <WorkflowPage qriRef={qriRef} />
-      </Route>
-      <Route path='/ds/:username/:name/history'>
-        <DatasetPage>
+        <Route path='/ds/:username/:name/workflow'>
+          <WorkflowPage qriRef={qriRef} />
+        </Route>
+
+        <Route path='/ds/:username/:name/history'>
           <DatasetActivityFeed qriRef={qriRef} />
-        </DatasetPage>
-      </Route>
-      <Route path='/ds/:username/:name/preview' exact>
-        <DatasetPreviewPage qriRef={qriRef} />
-      </Route>
-      {process.env.REACT_APP_FEATURE_WIREFRAMES &&
-        <Route path='/ds/:username/:name/issues'>
-          <DatasetPage>
-            <DatasetIssues qriRef={qriRef} />
-          </DatasetPage>
         </Route>
-      }
-      {process.env.REACT_APP_FEATURE_WIREFRAMES &&
-        <Route path='/ds/:username/:name/edit'>
-          <DatasetPage>
-            <DatasetEditor />
-          </DatasetPage>
-        </Route>
-      }
 
-      <Route path='/ds/:username/:name/at/:fs/:hash/components'>
-        <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/at/${qriRef.path}/body`} />
-      </Route>
-      <Route path='/ds/:username/:name/at/:fs/:hash/:component'>
-        <DatasetPage>
+        <Route path='/ds/:username/:name/preview' exact>
+          <DatasetPreviewPage qriRef={qriRef} />
+        </Route>
+
+        {process.env.REACT_APP_FEATURE_WIREFRAMES &&
+          <Route path='/ds/:username/:name/issues'>
+            <DatasetIssues qriRef={qriRef} />
+          </Route>
+        }
+
+        {process.env.REACT_APP_FEATURE_WIREFRAMES &&
+          <Route path='/ds/:username/:name/edit'>
+            <DatasetEditor />
+          </Route>
+        }
+
+        <Route path='/ds/:username/:name/at/:fs/:hash/components'>
+          <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/at/${qriRef.path}/body`} />
+        </Route>
+
+        <Route path='/ds/:username/:name/at/:fs/:hash/:component'>
           <DatasetComponents />
-        </DatasetPage>
-      </Route>
-      <Route path='/ds/:username/:name/components'>
-        <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/body`} />
-      </Route>
-      <Route path='/ds/:username/:name/:component'>
-        <DatasetPage>
+        </Route>
+
+        <Route path='/ds/:username/:name/components'>
+          <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/body`} />
+        </Route>
+
+        <Route path='/ds/:username/:name/:component'>
           <DatasetComponents />
-        </DatasetPage>
-      </Route>
-    </Switch>
+        </Route>
+      </Switch>
+    </DatasetWrapper>
   )
 }
 

--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -12,13 +12,13 @@ import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
 import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
 
-interface DatasetFixedLayoutProps {
+interface DatasetScrollLayoutProps {
   dataset?: Dataset
   headerChildren?: JSX.Element
   contentClassName?: string
 }
 
-const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
+const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
   dataset,
   headerChildren,
   contentClassName = '',
@@ -67,4 +67,4 @@ const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
 
 
 
-export default DatasetFixedLayout
+export default DatasetScrollLayout

--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import { useInView } from 'react-intersection-observer'
+import classNames from 'classnames'
+
+import { newQriRef } from '../../qri/ref'
+import { Dataset } from '../../qri/dataset'
+import { selectDsPreview } from '../dsPreview/state/dsPreviewState'
+import { selectSessionUser } from '../session/state/sessionState'
+import { selectSessionUserCanEditDataset } from './state/datasetState'
+import DatasetHeader from './DatasetHeader'
+import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
+
+interface DatasetFixedLayoutProps {
+  dataset?: Dataset
+  headerChildren?: JSX.Element
+  contentClassName?: string
+}
+
+const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
+  dataset,
+  headerChildren,
+  contentClassName = '',
+  children
+}) => {
+  const qriRef = newQriRef(useParams())
+  const dsPreview = useSelector(selectDsPreview)
+  const user = useSelector(selectSessionUser)
+  const editable = useSelector(selectSessionUserCanEditDataset)
+  const isNew = (qriRef.username === 'new')
+
+  const headerDataset = dataset || dsPreview
+
+  // This covers the case where a user created a new workflow before logging in.
+  // If they login while working on the workflow, the `user` will change, but the
+  // params used to generate the `qriRef` will not (because they are generated
+  // from the url, which has not changed). This check ensures that the correct
+  // username is propagated after login/signup.
+  if (isNew) {
+    qriRef.username = user.username
+  }
+
+  const { ref: stickyHeaderTriggerRef, inView } = useInView({
+    threshold: 0.6,
+    initialInView: true
+  });
+
+  return (
+    <>
+      <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
+        <DatasetMiniHeader dataset={headerDataset} show={!inView} >
+          {headerChildren}
+        </DatasetMiniHeader>
+        <div className={classNames('p-7 w-full', contentClassName)}>
+          <div ref={stickyHeaderTriggerRef}>
+            <DatasetHeader dataset={headerDataset} editable={editable}>
+              {headerChildren}
+            </DatasetHeader>
+          </div>
+          {children}
+        </div>
+      </div>
+    </>
+  )
+}
+
+
+
+export default DatasetFixedLayout

--- a/src/features/dsComponents/DatasetComponents.tsx
+++ b/src/features/dsComponents/DatasetComponents.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { push } from 'connected-react-router'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router'
@@ -11,7 +11,8 @@ import DatasetCommitList from '../commits/DatasetCommitList'
 import CommitSummaryHeader from '../commits/CommitSummaryHeader'
 import TabbedComponentViewer from './TabbedComponentViewer'
 import DownloadDatasetButton from '../download/DownloadDatasetButton'
-
+import { loadDataset } from '../dataset/state/datasetActions'
+import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 
 const DatasetComponents: React.FC<{}> = () => {
   const qriRef = newQriRef(useParams())
@@ -24,21 +25,29 @@ const DatasetComponents: React.FC<{}> = () => {
     dispatch(push(pathToDatasetViewer(dest)))
   }
 
+  useEffect(() => {
+    const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
+    dispatch(loadDataset(ref))
+  }, [dispatch, qriRef.username, qriRef.name, qriRef.path])
+
+
   return (
-    <div className='flex-grow flex overflow-hidden'>
-      <DatasetCommitList qriRef={qriRef} />
-      <div className='flex flex-col flex-grow overflow-hidden'>
-        <CommitSummaryHeader dataset={dataset}>
-          <DownloadDatasetButton qriRef={qriRef} />
-        </CommitSummaryHeader>
-        <TabbedComponentViewer
-          dataset={dataset}
-          loading={loading}
-          selectedComponent={qriRef.component as ComponentName || 'body'}
-          setSelectedComponent={setSelectedComponent}
-        />
+    <DatasetFixedLayout>
+      <div className='flex-grow flex overflow-hidden'>
+        <DatasetCommitList qriRef={qriRef} />
+        <div className='flex flex-col flex-grow overflow-hidden'>
+          <CommitSummaryHeader dataset={dataset}>
+            <DownloadDatasetButton qriRef={qriRef} />
+          </CommitSummaryHeader>
+          <TabbedComponentViewer
+            dataset={dataset}
+            loading={loading}
+            selectedComponent={qriRef.component as ComponentName || 'body'}
+            setSelectedComponent={setSelectedComponent}
+          />
+        </div>
       </div>
-    </div>
+    </DatasetFixedLayout>
   )
 }
 

--- a/src/features/dsComponents/DatasetEditor.tsx
+++ b/src/features/dsComponents/DatasetEditor.tsx
@@ -10,6 +10,7 @@ import TabbedComponentEditor from './TabbedComponentEditor'
 import SaveVersionButton from './buttons/SaveVersionButton'
 import { editDataset, loadEditingDatasetHead } from '../dataset/state/editDatasetActions'
 import { selectDatasetEdits, selectEditingHeadIsLoading } from '../dataset/state/editDatasetState'
+import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 
 const DatasetEditor: React.FC<{}> = () => {
   const qriRef = newQriRef(useParams())
@@ -35,21 +36,23 @@ const DatasetEditor: React.FC<{}> = () => {
   }
 
   return (
-    <div className='flex-grow flex overflow-hidden'>
-      <DatasetCommitList qriRef={qriRef} />
-      <div className='flex flex-col flex-grow overflow-x-hidden'>
-        <CommitSummaryHeader dataset={dataset}>
-          <SaveVersionButton dataset={dataset} />
-        </CommitSummaryHeader>
-        <TabbedComponentEditor
-          dataset={dataset}
-          loading={loading}
-          selectedComponent={component}
-          setSelectedComponent={(c: ComponentName) => { setComponent(c) }}
-          onDatasetChange={dsChangeHandler}
-        />
+    <DatasetFixedLayout>
+      <div className='flex-grow flex overflow-hidden'>
+        <DatasetCommitList qriRef={qriRef} />
+        <div className='flex flex-col flex-grow overflow-x-hidden'>
+          <CommitSummaryHeader dataset={dataset}>
+            <SaveVersionButton dataset={dataset} />
+          </CommitSummaryHeader>
+          <TabbedComponentEditor
+            dataset={dataset}
+            loading={loading}
+            selectedComponent={component}
+            setSelectedComponent={(c: ComponentName) => { setComponent(c) }}
+            onDatasetChange={dsChangeHandler}
+          />
+        </div>
       </div>
-    </div>
+    </DatasetFixedLayout>
   )
 }
 

--- a/src/features/dsComponents/DatasetWrapper.tsx
+++ b/src/features/dsComponents/DatasetWrapper.tsx
@@ -1,0 +1,35 @@
+// all dataset routes need the same info to display in the header
+// our state tree includes dataset, but it really represents the current version
+// of a dataset which can change in the history view
+// for all dataset routes, we can reference the dataset in dsPreview to populate the header
+
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router'
+import { useDispatch } from 'react-redux'
+
+import { newQriRef } from '../../qri/ref'
+import { fetchDsPreview } from '../dsPreview/state/dsPreviewActions'
+import NavBar from '../navbar/NavBar'
+import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
+
+
+const DatasetWrapper: React.FC<{}> = ({ children }) => {
+  const qriRef = newQriRef(useParams())
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(fetchDsPreview(qriRef))
+  }, [ qriRef.username, qriRef.name])
+
+  return (
+    <div className='flex flex-col h-full w-full bg-qrigray-100'>
+      <NavBar />
+      <div className='flex overflow-hidden w-full flex-grow'>
+        <DatasetNavSidebar qriRef={qriRef} />
+      {children}
+      </div>
+    </div>
+  )
+}
+
+export default DatasetWrapper;

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -77,19 +77,16 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                   <ContentBox>
                     <div className='flex items-center border-b pb-4 mb-3'>
                       <div className='flex-grow truncate'>
-                        <ContentBoxTitle title='Version Info' />
-                        <div className='text-qrinavy text-sm flex items-center mb-0'>
-                          <Icon icon='commit' size='sm' className='-ml-1.5' />
-                          <div className='font-medium'>{commitishFromPath(dataset.path)}</div>
+                        <ContentBoxTitle title='Latest Version' />
+                        <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
+                          <div className=''>{dataset.commit?.title}</div>
                         </div>
-                        <div className='text-sm text-qrinavy mb-2 truncate' title={dataset.commit?.title}>{dataset.commit?.title}</div>
-                        <div className='flex items-center text-gray-400 text-xs'>
-                          <RelativeTimestampWithIcon timestamp={new Date(dataset.commit?.timestamp)} className='mr-3' />
-                          <UsernameWithIcon username='chriswhong' className='mt-0.5' />
+                        <div className='flex items-center text-xs text-gray-400'>
+                          <UsernameWithIcon username={dataset.peername} className='mr-3' />
+                          <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
+                          <Icon icon='commit' size='sm' className='-ml-2' />
+                          <div className=''>{commitishFromPath(dataset.path)}</div>
                         </div>
-                      </div>
-                      <div className='ml-4'>
-                        <DownloadDatasetButton qriRef={qriRef} small light />
                       </div>
                     </div>
                     {/* Bottom of the box */}

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import useDimensions from 'react-use-dimensions'
-import { useInView } from 'react-intersection-observer'
 
 import { newQriRef } from '../../qri/ref';
 import { selectDsPreview } from './state/dsPreviewState'
@@ -14,14 +13,11 @@ import DownloadDatasetButton from '../download/DownloadDatasetButton'
 import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
 import BodyPreview from '../dsComponents/body/BodyPreview'
-import DatasetHeader from '../dataset/DatasetHeader'
-import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
-import NavBar from '../navbar/NavBar'
-import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
+
+import DatasetScrollLayout from '../dataset/DatasetScrollLayout'
 import DeployingScreen from '../deploy/DeployingScreen'
 import commitishFromPath from '../../utils/commitishFromPath'
 import Readme from '../dsComponents/readme/Readme'
-import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState'
 import { QriRef } from '../../qri/ref'
 import MetaChips from '../../chrome/MetaChips'
 
@@ -34,12 +30,6 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
 }) => {
   const dispatch = useDispatch()
   const dataset = useSelector(selectDsPreview)
-  const editable = useSelector(selectSessionUserCanEditDataset)
-
-  const { ref: stickyHeaderTriggerRef, inView } = useInView({
-    threshold: 0.6,
-    initialInView: true
-  });
 
   const [versionInfoContainer, { height: versionInfoContainerHeight }] = useDimensions();
   const [expandReadme, setExpandReadme] = useState(false)
@@ -56,21 +46,13 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   }, [dispatch, qriRef.username, qriRef.name, qriRef.path ])
 
   return (
-    <div className='flex flex-col h-full w-full bg-qrigray-100'>
-      <NavBar />
-      <div className='flex overflow-hidden w-full flex-grow'>
-        <DatasetNavSidebar qriRef={qriRef} />
-        {!dataset
+    <>
+        {dataset?.peername === ''
         ? (<div className='w-full h-full p-4 flex justify-center items-center'>
             <Spinner color='#4FC7F3' />
           </div>)
         : (
-          <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
-            <DatasetMiniHeader dataset={dataset} show={!inView} />
-            <div className='max-w-screen-lg mx-auto p-7 w-full h-full'>
-              <div ref={stickyHeaderTriggerRef}>
-                <DatasetHeader dataset={dataset} editable={editable} noBorder />
-              </div>
+            <DatasetScrollLayout contentClassName='max-w-screen-lg mx-auto'>
               <div className='-ml-2 -mr-3 mb-5'>
                 <div className='w-7/12 px-2 inline-block align-top' style={{ height: readmeContainerHeight}}>
                   <ContentBox className='flex flex-col h-full'>
@@ -123,14 +105,10 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                   <BodyPreview dataset={dataset} />
                 </div>
               </ContentBox>
-              {/* bottom padding */}
-              <div className='pb-5 h-0'>&nbsp;</div>
-              </div>
-            </div>
+            </DatasetScrollLayout>
           )}
         <DeployingScreen qriRef={qriRef} />
-      </div>
-    </div>
+        </>
   )
 }
 

--- a/src/features/dsPreview/state/dsPreviewActions.ts
+++ b/src/features/dsPreview/state/dsPreviewActions.ts
@@ -7,6 +7,8 @@ export function loadDsPreview(ref: QriRef): ApiActionThunk {
 
     try {
       await Promise.all([
+        // for the moment we don't get a preview explicitly because we already
+        // have what we need in state.dataset 
         // dispatch(fetchDsPreview(ref)),
         dispatch(fetchDsPreviewBody(ref)),
         dispatch(fetchDsPreviewReadme(ref)),

--- a/src/features/dsPreview/state/dsPreviewActions.ts
+++ b/src/features/dsPreview/state/dsPreviewActions.ts
@@ -7,17 +7,17 @@ export function loadDsPreview(ref: QriRef): ApiActionThunk {
 
     try {
       await Promise.all([
-        dispatch(fetchDsPreview(ref)),
+        // dispatch(fetchDsPreview(ref)),
         dispatch(fetchDsPreviewBody(ref)),
         dispatch(fetchDsPreviewReadme(ref)),
       ])
 
-      return dispatch({ 
+      return dispatch({
         type: 'DS_PREVIEW_SUCCESS',
         ref
       })
     } catch (e) {
-      return dispatch({ 
+      return dispatch({
         type: 'DS_PREVIEW_FAILURE',
         error: e.toString(),
       })
@@ -27,7 +27,7 @@ export function loadDsPreview(ref: QriRef): ApiActionThunk {
 
 export const bodyPageSizeDefault = 50
 
-function fetchDsPreview (ref: QriRef): ApiAction {
+export function fetchDsPreview (ref: QriRef): ApiAction {
   return {
     type: 'preview',
     ref,

--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -1,24 +1,32 @@
 import { createReducer } from '@reduxjs/toolkit'
 
 import { RootState } from '../../../store/store'
-import { Dataset } from '../../../qri/dataset'
+import { Dataset, NewDataset } from '../../../qri/dataset'
 
 export const selectDsPreview = (state: RootState): any => state.dsPreview.preview
 
 export const selectIsDsPreviewLoading = (state: RootState): boolean => state.dsPreview.loading
 
 export interface DsPreviewState {
-  preview?: Dataset
+  preview: Dataset
   loading: boolean
 }
 
 const initialState: DsPreviewState = {
+  preview: NewDataset({}),
   loading: false
 }
 
 export const dsPreviewReducer = createReducer(initialState, {
+
+
+
+  'API_PREVIEW_REQUEST': (state) => {
+    state.preview = NewDataset({})
+    state.loading = true
+  },
+
   'DS_PREVIEW_REQUEST': (state) => {
-    state.preview = undefined
     state.loading = true
   },
   'DS_PREVIEW_SUCCESS': (state) => {
@@ -33,7 +41,10 @@ export const dsPreviewReducer = createReducer(initialState, {
     state.loading = false
   },
   'API_PREVIEW_SUCCESS': (state, action) => {
-    state.preview = action.payload.data
+    state.preview = {
+      ...state.preview,
+      ...action.payload.data
+    }
   },
 
   'API_PREVIEWBODY_REQUEST': (state) => {

--- a/src/features/issues/DatasetIssues.tsx
+++ b/src/features/issues/DatasetIssues.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { QriRef } from '../../qri/ref'
+import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 
 export interface DatasetIssuesProps {
   qriRef: QriRef
@@ -8,7 +9,10 @@ export interface DatasetIssuesProps {
 
 const DatasetIssues: React.FC<DatasetIssuesProps> = ({ qriRef }) => {
   return (
-    <h1 className='text-2xl'>Issues</h1>
+    <DatasetFixedLayout>
+      <h1 className='text-2xl'>Issues</h1>
+    </DatasetFixedLayout>
+
   )
 }
 

--- a/src/features/run/RunStatusBadge.tsx
+++ b/src/features/run/RunStatusBadge.tsx
@@ -40,7 +40,7 @@ const RunStatusBadge: React.FC<RunStatusBadgeProps> = ({ status }) => {
   }
 
   return (
-    <div className={classNames('text-sm font-medium tracking-wider', colorClass)}>{displayStatus}</div>
+    <div className={classNames('text-sm font-semibold tracking-wider', colorClass)}>{displayStatus}</div>
   )
 }
 

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { useSelector, useDispatch } from 'react-redux'
-import { useInView } from 'react-intersection-observer'
 
 import { newQriRef } from '../../qri/ref'
 import Spinner from '../../chrome/Spinner'
 import { loadDataset } from '../dataset/state/datasetActions'
-import DatasetHeader from '../dataset/DatasetHeader'
-import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
-import NavBar from '../navbar/NavBar'
-import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
-import { selectSessionUserCanEditDataset, selectDataset } from '../dataset/state/datasetState'
+import {selectDataset } from '../dataset/state/datasetState'
 import { loadWorkflowByDatasetRef, setWorkflowRef } from './state/workflowActions'
 import { selectLatestRun } from './state/workflowState'
 import { QriRef } from '../../qri/ref'
@@ -18,7 +13,7 @@ import { NewDataset } from '../../qri/dataset'
 import Workflow from './Workflow'
 import RunBar from './RunBar'
 import Scroller from '../scroller/Scroller'
-
+import DatasetScrollLayout from '../dataset/DatasetScrollLayout'
 
 interface WorkflowPageProps {
   qriRef: QriRef
@@ -27,14 +22,8 @@ interface WorkflowPageProps {
 const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
   let dataset = useSelector(selectDataset)
-  const editable = useSelector(selectSessionUserCanEditDataset)
   const latestRun = useSelector(selectLatestRun)
   let { username, name } = useParams()
-
-  const { ref: stickyHeaderTriggerRef, inView } = useInView({
-    threshold: 0.7,
-    initialInView: true
-  });
 
   // if qriRef is empty, this is a new workflow
   const isNew = qriRef.username === '' && qriRef.name === ''
@@ -58,36 +47,24 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
     dispatch(loadDataset(ref))
     dispatch(loadWorkflowByDatasetRef(qriRef))
 
-  }, [ qriRef ])
+  }, [])
 
   const runBar = <RunBar status={latestRun ? latestRun.status : "waiting" } />
 
   return (
-    <div className='flex flex-col h-full w-full bg-qrigray-100'>
-      <NavBar />
-      <div className='flex overflow-hidden w-full flex-grow'>
-        <DatasetNavSidebar qriRef={qriRef} />
-        {!dataset
-        ? (<div className='w-full h-full p-4 flex justify-center items-center'>
-            <Spinner color='#4FC7F3' />
-          </div>)
-        : (
-            <Scroller className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
-              <DatasetMiniHeader dataset={dataset} show={!inView}>
-                {runBar}
-              </DatasetMiniHeader>
-              <div className='p-7 w-full'>
-                <div ref={stickyHeaderTriggerRef}>
-                  <DatasetHeader dataset={dataset} editable={editable} showInfo={!isNew}>
-                    {runBar}
-                  </DatasetHeader>
-                </div>
+    <>
+      {!dataset && !isNew
+      ? (<div className='w-full h-full p-4 flex justify-center items-center'>
+          <Spinner color='#4FC7F3' />
+        </div>)
+      : (
+            <DatasetScrollLayout headerChildren={runBar}>
+              <Scroller>
                 <Workflow qriRef={qriRef} />
-              </div>
-            </Scroller>
-          )}
-      </div>
-    </div>
+              </Scroller>
+            </DatasetScrollLayout>
+        )}
+    </>
   )
 }
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -19,6 +19,8 @@ import DatasetRoutes from './features/dataset/DatasetRoutes';
 import { AnonUser, selectSessionUser } from './features/session/state/sessionState'
 import UserProfile from './features/userProfile/UserProfile'
 import WorkflowPage from './features/workflow/WorkflowPage'
+import DatasetWrapper from './features/dsComponents/DatasetWrapper'
+
 
 const PrivateRoute: React.FC<any>  = ({ path, children }) => {
   const user = useSelector(selectSessionUser)
@@ -45,7 +47,9 @@ export default function Routes () {
         <PrivateRoute path='/activity'><CollectionActivityFeed /></PrivateRoute>
 
         <Route path='/workflow/new'>
-          <WorkflowPage qriRef={{ username: '', name: '' }} />
+          <DatasetWrapper>
+            <WorkflowPage qriRef={{ username: '', name: '' }} />
+          </DatasetWrapper>
         </Route>
 
         <Route path='/ds/new'><TemplateList /></Route>


### PR DESCRIPTION
- style/layout improvements to the dataset run log, making it match the mockups and appear more like the collection list

- refactor dataset view components, consolidating duplicate code and introducing layout components, fixed (history, run log) and scrolling (preview, workflow)

- style tweaks for collection table, commit list, and commit header