### PR TITLE
No unused UI

### DIFF
--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -7,6 +7,8 @@ import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
+import Button from '../../chrome/Button'
+import Icon from '../../chrome/Icon'
 
 
 export interface DatasetActivityFeedProps {
@@ -27,8 +29,12 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
     dispatch(loadDatasetLogs(qriRef))
   },[dispatch, qriRef])
 
+  const runNowButton = (
+    <Button type='primary'><Icon icon='play' className='mr-2'/>Run Now</Button>
+  )
+
   return (
-    <DatasetFixedLayout>
+    <DatasetFixedLayout headerChildren={runNowButton}>
       <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white relative'>
         <ActivityList
           log={logs}

--- a/src/features/commits/DatasetCommitList.tsx
+++ b/src/features/commits/DatasetCommitList.tsx
@@ -45,14 +45,18 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
         <div className='text-xs text-gray-400 tracking-wider'>{commits.length} {commits.length === 1 ? 'version' : 'versions'}</div>
       </header>
       <ul className='block flex-grow overflow-y-auto pb-40 pr-8'>
-        <HistorySearchBox />
-        {editable && <NewVersionButton qriRef={qriRef} />}
+        {/*
+          TODO(chriswhong): restore when these features become available
+          <HistorySearchBox />
+          {editable && <NewVersionButton qriRef={qriRef} />}
+        */}
         {commits.map((logItem, i) => (
           <DatasetCommitListItem
             key={i}
             logItem={logItem}
             active={logItem.path === path}
-            first={i === 0 && !editable}
+            // first={i === 0 && !editable} (restore when there is <NewVersionButton> at the top of the list)
+            first={i === 0}
             last={i === (commits.length - 1)}
           />
         ))}

--- a/src/features/dataset/DatasetFixedLayout.tsx
+++ b/src/features/dataset/DatasetFixedLayout.tsx
@@ -9,8 +9,12 @@ import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
 import DeployingScreen from '../deploy/DeployingScreen'
 
+interface DatasetFixedLayoutProps {
+  headerChildren?: JSX.Element
+}
 
-const DatasetFixedLayout: React.FC<{}> = ({
+const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
+  headerChildren,
   children
 }) => {
   const qriRef = newQriRef(useParams())
@@ -31,7 +35,9 @@ const DatasetFixedLayout: React.FC<{}> = ({
   return (
     <>
         <div className='flex flex-col flex-grow overflow-hidden p-7'>
-          <DatasetHeader dataset={dsPreview} editable={editable} />
+          <DatasetHeader dataset={dsPreview} editable={editable}>
+            {headerChildren}
+          </DatasetHeader>
           {children}
         </div>
         <DeployingScreen qriRef={qriRef} />

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -8,7 +8,7 @@ import EditableLabel from '../../chrome/EditableLabel'
 import { renameDataset } from './state/datasetActions'
 import { Dataset, qriRefFromDataset } from '../../qri/dataset'
 import DatasetInfoItem from './DatasetInfoItem'
-import Button from '../../chrome/Button'
+import DownloadDatasetButton from '../download/DownloadDatasetButton'
 import TextLink from '../../chrome/TextLink'
 import { validateDatasetName } from '../session/state/formValidation'
 
@@ -64,26 +64,14 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
                 value={qriRef.name}
                 validator={validateDatasetName}
               />
-              {editable &&
-                <DropdownMenu
-                  icon={<Icon className='ml-3 opacity-60' size='sm' icon='sortDown' />}
-                  items={[
-                    {
-                      label: 'Duplicate...',
-                      disabled: true,
-                      onClick: () => { handleButtonClick("duplicating not yet implemented") }
-                    }
-                  ]}
-                />}
             </div>
           )}
-
 
           <div className='text-2xl text-qrinavy-500 font-black group hover:text'>
             {dataset.meta?.title || dataset.name}
           </div>
           {showInfo && (
-            <div className='flex mt-3'>
+            <div className='flex mt-3 text-sm'>
               <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' />
               <DatasetInfoItem icon='disk' label='59 MB' />
               <DatasetInfoItem icon='download' label='418 downloads' />
@@ -92,9 +80,11 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
             </div>
           )}
         </div>
-        <div className='flex items-center content-center'>
+        <div className='flex items-center content-center pl-6'>
           {children || (
             <>
+              {/*
+                TODO(chriswhong) - Reinstate Share and Follow buttons when these features are available
               <Button className='mr-3' type='dark'>
                 Follow
               </Button>
@@ -102,6 +92,8 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
                 <Icon icon='globe' size='lg' className='mr-2' /> Share
               </Button>
               <Icon icon='ellipsesVertical' size='lg' className='ml-2' />
+              */}
+              <DownloadDatasetButton qriRef={qriRef} type='primary' />
             </>
           )}
         </div>

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -47,12 +47,15 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
         <div className='flex items-center content-center'>
           {children || (
             <>
-              <Button className='mr-3' type='dark'>
-                Follow
-              </Button>
-              <Button className='mr-3' type='secondary'>
-                <Icon icon='globe' size='lg' className='mr-2' /> Share
-              </Button>
+              {/*
+                TODO(chriswhong): restore when these features are implemented
+                <Button className='mr-3' type='dark'>
+                  Follow
+                </Button>
+                <Button className='mr-3' type='secondary'>
+                  <Icon icon='globe' size='lg' className='mr-2' /> Share
+                </Button>
+              */}
               <DownloadDatasetButton qriRef={qriRef} type='primary' small />
             </>
           )}

--- a/src/features/download/DownloadDatasetButton.tsx
+++ b/src/features/download/DownloadDatasetButton.tsx
@@ -24,9 +24,10 @@ export interface DownloadDatasetButtonProps {
 
 const DownloadDatasetButton: React.FC<DownloadDatasetButtonProps> = ({
   qriRef,
+  small=false,
+  type='primary-outline',
   asIconLink=false,
   body=false,
-  small=false
 }) => {
   const dispatch = useDispatch()
 
@@ -47,8 +48,8 @@ const DownloadDatasetButton: React.FC<DownloadDatasetButtonProps> = ({
     }
   } else { // returns <Button>
     let buttonContent = (
-      <Button type='primary-outline' size='sm' className='px-1.5'>
-        {small ? <Icon icon='download' /> : 'Download'}
+      <Button type={type} size='sm' className='px-1.5'>
+        <Icon icon='download' /> {!small && <span className='ml-2'>Download</span>}
       </Button>
     )
 

--- a/src/features/dsComponents/DatasetComponents.tsx
+++ b/src/features/dsComponents/DatasetComponents.tsx
@@ -32,7 +32,7 @@ const DatasetComponents: React.FC<{}> = () => {
 
 
   return (
-    <DatasetFixedLayout>
+    <DatasetFixedLayout headerChildren={<></>}>
       <div className='flex-grow flex overflow-hidden'>
         <DatasetCommitList qriRef={qriRef} />
         <div className='flex flex-col flex-grow overflow-hidden'>

--- a/src/features/navbar/NavBar.tsx
+++ b/src/features/navbar/NavBar.tsx
@@ -26,7 +26,8 @@ const NavBar: React.FC<NavBarProps> = ({
 
 
   const buttonItems = [
-    { text: 'Dashboard', link: '/dashboard', icon: 'dashboard'},
+    // TODO(chriswhong) - reinstate dashboard when this feature is available
+    // { text: 'Dashboard', link: '/dashboard', icon: 'dashboard'},
     { text: 'My Datasets', link: '/collection', icon: 'myDatasets'}
   ]
 

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -35,7 +35,7 @@ const SessionUserMenu: React.FC<{}> = () => {
   }
 
   const icon = <div
-    className='rounded-2xl inline-block bg-cover flex-shrink-0' 
+    className='rounded-2xl inline-block bg-cover flex-shrink-0'
     style={{
       height: '30px',
       width: '30px',
@@ -46,13 +46,14 @@ const SessionUserMenu: React.FC<{}> = () => {
     <div className="relative flex items-center font-medium">
       <TextLink to='https://qri.io/docs'>Help</TextLink>
       <DropdownMenu icon={icon} className='ml-8' items={[
-        {
-          label: <Link to={`/${user.username}`}>Profile</Link>
-        },
+        // TODO(chriswhong): restore when Profiles are implemented
+        // {
+        //   label: <Link to={`/${user.username}`}>Profile</Link>
+        // },
         {
           label: <ExternalLink to='https://qri.io/contact'>Send Feedback</ExternalLink>
         },
-        { 
+        {
           label: 'Log Out',
           onClick: () => { dispatch(logOut()) }
         }


### PR DESCRIPTION
Merge #239 first

- Comments out unused UI elements (Dashboard link in header, search box above history list, etc) which were mocked up but did not function
- Improves contextual buttons on dataset routes:
  - Preview gets a Download Button
  - History get no button
  - Workflow gets a Dry Run Button
  - Run Log gets a Run Now Button
- Make version info box on previews match version info header in history view 
- Removes fontawesome icons which should no longer be in use in the app