### PR TITLE
feat: auto refresh access token

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "history": "^4.10.1",
     "install": "^0.13.0",
     "json-schema": "^0.3.0",
+    "jwt-decode": "3.1.2",
     "monaco-editor-webpack-plugin": "^4.0.0",
     "node-fetch": "^2.6.1",
     "node-sass": "4.14.1",

--- a/src/features/session/state/sessionActions.ts
+++ b/src/features/session/state/sessionActions.ts
@@ -16,6 +16,7 @@ export function logIn (username: string, password: string): ApiActionThunk {
       }
 
       const token = tokenResponse.payload.data.access_token
+      const refreshToken = tokenResponse.payload.data.refresh_token
 
       // get user data
       // pass access_token directly to fetchUserProfile so it can be used immediately
@@ -36,7 +37,8 @@ export function logIn (username: string, password: string): ApiActionThunk {
       return dispatch({
         type: 'LOGIN_SUCCESS',
         user,
-        token
+        token,
+        refreshToken
       })
     } catch (e) {
       return dispatch({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -69,8 +69,11 @@ function setAuthState(state: any) {
   try {
     if (state.session.token) {
       localStorage.setItem('state.auth.token', JSON.stringify((state.session || {}).token));
+      localStorage.setItem('state.auth.refreshToken', JSON.stringify((state.session || {}).refreshToken));
+
     } else {
       localStorage.removeItem('state.auth.token')
+      localStorage.removeItem('state.auth.refreshToken')
     }
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5170,6 +5170,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9841,6 +9846,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -13211,6 +13221,13 @@ react-textarea-autosize@^8.3.0, react-textarea-autosize@^8.3.2:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-toastify@7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.4.tgz#7d0b743f2b96f65754264ca6eae31911a82378db"
+  integrity sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-tooltip@4.2.13:
   version "4.2.13"


### PR DESCRIPTION
Modifies API middleware to check the user's `accessToken` on all requests.  If it expires in the next 5 minutes, use the `refreshToken` to request a new `accessToken` and update state/localstorage with the new value.

Includes a TODO for delaying subsequent requests while a refresh is happening (pages that fire multiple requests when a token is near expiration will fire multiple calls to refresh to the token)

