### PR TITLE
Refactor workflow state

### DIFF
--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -5,11 +5,15 @@ import numeral from 'numeral'
 
 import DurationFormat from '../../chrome/DurationFormat'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
+import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
+import UsernameWithIcon from '../../chrome/UsernameWithIcon'
 import Icon from '../../chrome/Icon'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { LogItem } from '../../qri/log'
 import { customStyles, customSortIcon } from '../../features/collection/CollectionTable'
 import DatasetInfoItem from '../dataset/DatasetInfoItem'
+import commitishFromPath from '../../utils/commitishFromPath'
+
 
 interface ActivityListProps {
   log: LogItem[]
@@ -66,17 +70,17 @@ const ActivityList: React.FC<ActivityListProps> = ({
       name: 'Commit',
       selector: 'name',
       cell: (row: LogItem) => {
+        console.log('row', row)
         if (!['failed', 'unchanged'].includes(row.runStatus)) {
           const versionLink = `/ds/${row.username}/${row.name}/at${row.path}/body`
           return (
             <Link to={versionLink}>
-              <div className='font-semibold text-sm mb-1 text-qrinavy'>
-                {row.path && <div><Icon icon='commit' size='sm'/> {row.path.split('/')[2].substring(0, 8)}</div>}
+              <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
+                <div className=''>{row.message}</div>
               </div>
-              <div className='flex text-xs overflow-y-hidden'>
-                <DatasetInfoItem icon='disk' label={numeral(row.bodySize).format('0.0 b')} small />
-                <DatasetInfoItem icon='rows' label={numeral(row.bodyRows).format('0,0a')} small />
-                <DatasetInfoItem icon='page' label={row.bodyFormat} small />
+              <div className='flex items-center text-xs text-gray-400'>
+                <Icon icon='commit' size='sm' className='-ml-2' />
+                <div className=''>{commitishFromPath(row.path)}</div>
               </div>
             </Link>
           )

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -7,6 +7,8 @@ import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
+import { runNow } from '../workflow/state/workflowActions'
+import { selectLatestRun } from '../workflow/state/workflowState'
 import Button from '../../chrome/Button'
 import Icon from '../../chrome/Icon'
 
@@ -20,6 +22,7 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
 }) => {
 
   const logs = useSelector(newDatasetLogsSelector(qriRef))
+  const latestRun = useSelector(selectLatestRun)
   const dispatch = useDispatch()
 
   const [tableContainer, { height: tableContainerHeight }] = useDimensions()
@@ -29,8 +32,14 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
     dispatch(loadDatasetLogs(qriRef))
   },[dispatch, qriRef])
 
+  const handleRunNowClick = () => {
+    dispatch(runNow(qriRef))
+    // figure out the right time to refresh the logs
+    dispatch(loadDatasetLogs(qriRef))
+  }
+
   const runNowButton = (
-    <Button type='primary'><Icon icon='play' className='mr-2'/>Run Now</Button>
+    <Button type='primary' onClick={handleRunNowClick}><Icon icon='play' className='mr-2'/>Run Now</Button>
   )
 
   return (

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -35,7 +35,7 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
         <div className='flex-grow'>
           { qriRef.username && (
             <div className='text-xs text-gray-400 font-mono'>
-              <TextLink to={`/${dataset.peername}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{dataset.peername || 'new'}</TextLink>/{dataset.name}
+              <TextLink to={`/${dataset.username}`} colorClassName='text-qrigray-400 hover:text-qrigray-800'>{dataset.username || 'new'}</TextLink>/{dataset.name}
             </div>
           )}
           <div className='text-normal text-qrinavy font-semibold'>

--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -54,7 +54,7 @@ const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
         </DatasetMiniHeader>
         <div className={classNames('p-7 w-full', contentClassName)}>
           <div ref={stickyHeaderTriggerRef}>
-            <DatasetHeader dataset={headerDataset} editable={editable}>
+            <DatasetHeader dataset={headerDataset} editable={editable} showInfo={!dataset}>
               {headerChildren}
             </DatasetHeader>
           </div>

--- a/src/features/deploy/state/deployActions.ts
+++ b/src/features/deploy/state/deployActions.ts
@@ -1,6 +1,7 @@
 import { CALL_API, ApiActionThunk} from '../../../store/api'
 import { QriRef, refStringFromQriRef } from '../../../qri/ref'
 import { Workflow, workflowScriptString } from '../../../qrimatic/workflow'
+import { Dataset } from '../../../qri/dataset'
 import {
   DEPLOY_START,
   DEPLOY_END,
@@ -24,7 +25,7 @@ export interface DeployEventAction {
   sessionID: string
 }
 
-export function deployWorkflow(qriRef: QriRef, w: Workflow, run: boolean): ApiActionThunk {
+export function deployWorkflow(qriRef: QriRef, w: Workflow, d: Dataset, run: boolean): ApiActionThunk {
   // this is where we strip the steps from the workflow and add them to dataset
   return async (dispatch, getState) => {
     return dispatch({
@@ -41,7 +42,7 @@ export function deployWorkflow(qriRef: QriRef, w: Workflow, run: boolean): ApiAc
             name: qriRef.name,
             transform: {
               scriptBytes: btoa(workflowScriptString(w)),
-              steps: w.steps
+              steps: d.transform.steps
             }
           }
         },

--- a/src/features/dsComponents/DatasetWrapper.tsx
+++ b/src/features/dsComponents/DatasetWrapper.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from 'react-redux'
 
 import { newQriRef } from '../../qri/ref'
 import { fetchDsPreview } from '../dsPreview/state/dsPreviewActions'
+import { loadWorkflowByDatasetRef } from '../workflow/state/workflowActions'
 import NavBar from '../navbar/NavBar'
 import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 
@@ -19,6 +20,7 @@ const DatasetWrapper: React.FC<{}> = ({ children }) => {
 
   useEffect(() => {
     dispatch(fetchDsPreview(qriRef))
+    dispatch(loadWorkflowByDatasetRef(qriRef))
   }, [ qriRef.username, qriRef.name])
 
   return (

--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -1,3 +1,8 @@
+// we are currently using dsPreview as the place to store top-level info for the
+// active dataset (the dataset the user is using a /ds route for)
+// it is used to populate the header info, to store whether the dataset has a
+// workflow, etc
+
 import { createReducer } from '@reduxjs/toolkit'
 
 import { RootState } from '../../../store/store'
@@ -9,11 +14,13 @@ export const selectIsDsPreviewLoading = (state: RootState): boolean => state.dsP
 
 export interface DsPreviewState {
   preview: Dataset
+  hasWorkflow: boolean
   loading: boolean
 }
 
 const initialState: DsPreviewState = {
   preview: NewDataset({}),
+  hasWorkflow: false,
   loading: false
 }
 
@@ -58,5 +65,8 @@ export const dsPreviewReducer = createReducer(initialState, {
     state.preview.readme = { script: atob(action.payload.data) }
   },
   'API_PREVIEWREADME_FAILURE': (state, action) => {
+  },
+  'API_WORKFLOW_SUCCESS': (state, action) => {
+    state.hasWorkflow = true
   },
 })

--- a/src/features/template/templates.ts
+++ b/src/features/template/templates.ts
@@ -28,27 +28,27 @@ def transform(ds, ctx):
   ]
 }
 
-export const CSVDownload: Workflow = {
-  runCount: 0,
-  disabled: false,
-
-  triggers: [],
-  steps: [
-    { syntax: 'starlark', category: 'setup', name: 'setup', script: `# load starlark dependencies
+export const CSVDownload: Dataset = {
+  meta: {
+    title: 'New Dataset from Workflow'
+  },
+  transform: {
+    steps: [
+      { syntax: 'starlark', category: 'setup', name: 'setup', script: `# load starlark dependencies
 load("http.star", "http")
 load("encoding/csv.star", "csv")` },
-    { syntax: 'starlark', category: 'download', name: 'download', script: `# get the popular baby names dataset as a csv
+      { syntax: 'starlark', category: 'download', name: 'download', script: `# get the popular baby names dataset as a csv
 def download(ctx):
   csvDownloadUrl = "https://data.cityofnewyork.us/api/views/25th-nujf/rows.csv?accessType=DOWNLOAD"
   return http.get(csvDownloadUrl).body()` },
-    { syntax: 'starlark', category: 'transform', name: 'transform', script: `# set the body
+      { syntax: 'starlark', category: 'transform', name: 'transform', script: `# set the body
 def transform(ds, ctx):
   # ctx.download is whatever download() returned
   csv = ctx.download
   # set the dataset body
   ds.set_body(csv, parse_as='csv')`}
-  ],
-  hooks: []
+    ]
+  }
 }
 
 export const APICall: Workflow = {

--- a/src/features/trigger/util.ts
+++ b/src/features/trigger/util.ts
@@ -1,7 +1,7 @@
 import getMinutes from 'date-fns/getMinutes'
 import format from 'date-fns/format'
 
-import { WorkflowTrigger } from '../../qrimatic/workflow'
+import { CronTrigger } from '../../qrimatic/workflow'
 import { SelectOption } from '../../chrome/Select'
 
 // for hourly cron triggers, only these values are valid for specifying the minutes
@@ -81,7 +81,7 @@ export interface Schedule {
 }
 
 // convert the UI values into a valid CronTrigger
-export const triggerFromSchedule = (schedule: Schedule): WorkflowTrigger => {
+export const triggerFromSchedule = (schedule: Schedule): CronTrigger => {
   // convert the UI settings into a valid WorkflowTrigger
   let periodicity
   let startTime
@@ -99,11 +99,11 @@ export const triggerFromSchedule = (schedule: Schedule): WorkflowTrigger => {
         0,
         0
       ).toISOString()
-    
+
       periodicity = `R/${startTime}/PT10M`
       break
     case 'P1H':
-      // for hourly, periodicity is R/P1H and startTime is the next instance of 
+      // for hourly, periodicity is R/P1H and startTime is the next instance of
       // the minutes selected by the user
       // get most recent previous hour, add minutes, convert to ISO8601
       startTime = new Date(
@@ -137,7 +137,7 @@ export const triggerFromSchedule = (schedule: Schedule): WorkflowTrigger => {
 
   return {
     type: 'cron',
-    enabled: true,
+    active: true,
     periodicity,
   }
 }

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -7,7 +7,7 @@ import { RunStatus } from '../../qri/run'
 import RunStatusIcon from '../run/RunStatusIcon'
 import { applyWorkflowTransform } from './state/workflowActions'
 import { deployWorkflow } from '../deploy/state/deployActions'
-import { selectRunMode, selectWorkflow } from './state/workflowState'
+import { selectRunMode, selectWorkflow, selectWorkflowDataset } from './state/workflowState'
 import { platform } from '../../utils/platform'
 
 export interface RunBarProps {
@@ -22,11 +22,12 @@ const RunBar: React.FC<RunBarProps> = ({
   const dispatch = useDispatch()
   const runMode = useSelector(selectRunMode)
   const workflow = useSelector(selectWorkflow)
+  const workflowDataset = useSelector(selectWorkflowDataset)
 
   const handleRun = () => {
     if (onRun) { onRun() }
     if (runMode === 'apply') {
-      dispatch(applyWorkflowTransform(workflow))
+      dispatch(applyWorkflowTransform(workflow, workflowDataset))
     }
     else if (runMode === 'save') {
       dispatch(deployWorkflow(workflow))

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -1,12 +1,19 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Prompt, Redirect } from 'react-router'
 import { useLocation } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { Location } from 'history'
 
 import WorkflowOutline from './WorkflowOutline'
-import { selectLatestRun, selectRunMode, selectWorkflow, selectWorkflowIsDirty } from './state/workflowState'
-import { setWorkflow } from './state/workflowActions'
+import {
+  selectLatestRun,
+  selectRunMode,
+  selectWorkflow,
+  selectWorkflowIsDirty,
+  selectWorkflowDataset
+} from './state/workflowState'
+
+import { setTemplate } from './state/workflowActions'
 import { selectTemplate } from '../template/templates'
 import { QriRef } from '../../qri/ref'
 import WorkflowEditor from './WorkflowEditor'
@@ -26,6 +33,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
   const location = useLocation<WorkflowLocationState>()
   const workflow = useSelector(selectWorkflow)
+  const workflowDataset = useSelector(selectWorkflowDataset)
   const latestRun = useSelector(selectLatestRun)
   const runMode = useSelector(selectRunMode)
   const isDirty = useSelector(selectWorkflowIsDirty)
@@ -35,7 +43,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   useEffect(() => {
     if (location.state?.template) {
       const template = selectTemplate(location.state.template)
-      dispatch(setWorkflow(template))
+      dispatch(setTemplate(template))
     }
 
     if (location.state?.showSplashModal) {
@@ -70,8 +78,8 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
           when={true}
           message={handleBlockedNavigation}
         />
-        <WorkflowOutline workflow={workflow} run={latestRun} runMode={runMode} />
-        <WorkflowEditor qriRef={qriRef} workflow={workflow} run={latestRun} runMode={runMode} isDirty={isDirty} />
+        <WorkflowOutline workflow={workflow} dataset={workflowDataset} run={latestRun} runMode={runMode} />
+        <WorkflowEditor qriRef={qriRef} workflow={workflow} dataset={workflowDataset} run={latestRun} runMode={runMode} isDirty={isDirty} />
         { redirectTo && <Redirect to={redirectTo} /> }
       </div>
     </>

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -22,6 +22,7 @@ export interface WorkflowEditorProps {
   qriRef: QriRef
   runMode: RunMode
   workflow: Workflow
+  dataset: Dataset
   isDirty: boolean
   run?: Run
 }
@@ -30,6 +31,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   qriRef,
   runMode,
   workflow,
+  dataset,
   isDirty,
   run
 }) => {
@@ -109,7 +111,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                   <div className='text-sm text-qrigray-400 mb-3'>Use code to download source data, transform it, and commit the next version of this dataset</div>
                 </div>
               </div>
-              {workflow.steps && workflow.steps.map((step, i) => {
+              {dataset?.transform?.steps && dataset.transform.steps.map((step, i) => {
                 let r
                 if (run) {
                   r = (run?.steps && run?.steps.length >= i) ? run.steps[i] : NewRunStep({ status: "waiting" })
@@ -128,7 +130,8 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                       setCollapseStates(update)
                     }}
                     onChangeScript={(i:number, script:string) => {
-                      if (workflow && workflow.steps) {
+
+                      if (dataset?.transform?.steps) {
                         dispatch(changeWorkflowTransformStep(i, script))
                       }
                     }}

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -14,12 +14,14 @@ import DatasetCommit from '../commits/DatasetCommit'
 export interface WorkflowOutlineProps {
   runMode: RunMode
   workflow?: Workflow
+  dataset: Dataset
   run?: Run
 }
 
 const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
   runMode,
   workflow,
+  dataset,
   run
 }) => {
   const [showing, setShowing] = useState(true)
@@ -52,7 +54,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
             </ScrollTrigger>
           </div>
           <div className='mb-2'>
-            {workflow && workflow.steps?.map((step: TransformStep, i: number) => {
+            {dataset?.transform?.steps && dataset.transform.steps.map((step: TransformStep, i: number) => {
               let r
               if (run) {
                 r = (run?.steps && run?.steps.length >= i && run.steps[i]) ? run.steps[i] : NewRunStep({ status: "waiting" })

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -5,7 +5,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { newQriRef } from '../../qri/ref'
 import Spinner from '../../chrome/Spinner'
 import { loadDataset } from '../dataset/state/datasetActions'
-import {selectDataset } from '../dataset/state/datasetState'
+import { selectWorkflowDataset } from '../workflow/state/workflowState'
 import { loadWorkflowByDatasetRef, setWorkflowRef } from './state/workflowActions'
 import { selectLatestRun } from './state/workflowState'
 import { QriRef } from '../../qri/ref'
@@ -21,7 +21,7 @@ interface WorkflowPageProps {
 
 const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
-  let dataset = useSelector(selectDataset)
+  let dataset = useSelector(selectWorkflowDataset)
   const latestRun = useSelector(selectLatestRun)
   let { username, name } = useParams()
 
@@ -41,12 +41,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
 
   // don't fetch the dataset if this is a new workflow
   useEffect(() => {
+    // ensures that workflowDataset username and name match the route
     dispatch(setWorkflowRef(qriRef))
-    if (isNew) { return }
-    const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
-    dispatch(loadDataset(ref))
-    dispatch(loadWorkflowByDatasetRef(qriRef))
-
   }, [])
 
   const runBar = <RunBar status={latestRun ? latestRun.status : "waiting" } />
@@ -58,7 +54,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
           <Spinner color='#4FC7F3' />
         </div>)
       : (
-            <DatasetScrollLayout headerChildren={runBar}>
+            <DatasetScrollLayout dataset={dataset} headerChildren={runBar}>
               <Scroller>
                 <Workflow qriRef={qriRef} />
               </Scroller>

--- a/src/features/workflow/modal/DeployModal.tsx
+++ b/src/features/workflow/modal/DeployModal.tsx
@@ -12,7 +12,7 @@ import TextInput from '../../../chrome/forms/TextInput'
 import Checkbox from '../../../chrome/forms/Checkbox'
 import { deployWorkflow } from '../../deploy/state/deployActions'
 import { setWorkflowRef } from '../state/workflowActions'
-import { selectWorkflow, selectWorkflowQriRef } from '../state/workflowState'
+import { selectWorkflow, selectWorkflowQriRef, selectWorkflowDataset } from '../state/workflowState'
 import { validateDatasetName } from '../../session/state/formValidation'
 import { Workflow } from '../../../qrimatic/workflow'
 import RunStatusIcon from '../../run/RunStatusIcon'
@@ -20,16 +20,14 @@ import { selectDeployStatus } from '../../deploy/state/deployState'
 import { selectSessionUser } from '../../session/state/sessionState'
 import WarningDialog from '../WarningDialog'
 
-interface DeployModalProps {
-  workflow: Workflow
-}
 
-const DeployModal: React.FC<DeployModalProps> = () => {
+const DeployModal: React.FC = () => {
   const dispatch = useDispatch()
   const history = useHistory()
 
   const qriRef = useSelector(selectWorkflowQriRef)
   const workflow = useSelector(selectWorkflow)
+  const dataset = useSelector(selectWorkflowDataset)
   const deployStatus = useSelector(selectDeployStatus(qriRef))
   const { username } = useSelector(selectSessionUser)
 
@@ -80,7 +78,7 @@ const DeployModal: React.FC<DeployModalProps> = () => {
 
   const handleDeployClick = () => {
     setDeploying(true)
-    dispatch(deployWorkflow(qriRef, workflow, runNow))
+    dispatch(deployWorkflow(qriRef, workflow, dataset, runNow))
   }
 
   // determine whether all conditions are met for proceeding

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -77,7 +77,7 @@ const initialState: WorkflowState = {
   runMode: 'apply',
   workflow: {
     id: '',
-    initID: 'new_dataset',
+    initID: '',
     active: true,
 
     triggers: [],
@@ -114,7 +114,6 @@ export const workflowReducer = createReducer(initialState, {
   SET_WORKFLOW_REF: (state, action: SetWorkflowRefAction) => {
     state.dataset.username = action.qriRef.username
     state.dataset.name = action.qriRef.name
-    state.workflow.initID = `${action.qriRef.username}/${action.qriRef.name}`
   },
   // listen for dataset fetching actions, if the reference of the fetched dataset
   // matches the ref the workbench reducer is tuned to, load the transform script

--- a/src/qri/dataset.ts
+++ b/src/qri/dataset.ts
@@ -5,7 +5,7 @@ import fileSize, { abbreviateNumber } from '../utils/fileSize'
 
 
 export interface Dataset {
-  peername: string
+  username: string
   name: string
   path: string
   commit?: Commit
@@ -23,7 +23,7 @@ export default Dataset
 
 export function qriRefFromDataset(dataset: Dataset): QriRef {
   return {
-    username: dataset.peername,
+    username: dataset.peername || dataset.username,
     name: dataset.name,
     path: dataset.path
   }
@@ -31,7 +31,7 @@ export function qriRefFromDataset(dataset: Dataset): QriRef {
 
 export function isDatasetEmpty(ds: Dataset): boolean {
   return (
-    !ds.peername &&
+    !ds.username &&
     !ds.name &&
     !ds.path &&
     !ds.commit &&

--- a/src/qrimatic/workflow.ts
+++ b/src/qrimatic/workflow.ts
@@ -9,22 +9,12 @@ export type RunStatus =
 
 export interface Workflow {
   id: string
-  ref: string
+  initID?: string
   ownerID?: string
-  datasetID?: string
-
-  disabled: boolean
-  runCount: number
-
-  latestStart?: string
-  latestEnd?: string
-  status: WorkflowStatus
-
+  created?: string
+  active: boolean
   triggers?: WorkflowTrigger[]
-  steps?: TransformStep[]
   hooks?: WorkflowHook[]
-
-  versionInfo?: VersionInfo
 }
 
 // stores only the things we need to track to compute dirty/drafting state
@@ -37,22 +27,12 @@ export interface WorkflowBase {
 export function NewWorkflow(data: Record<string,any>): Workflow {
   return {
     id: data.id || '',
-    ref: data.ref || '',
-    datasetID: data.datasetID,
+    initID: data.initID,
     ownerID: data.ownerID,
-
-    disabled: data.disabled || false,
-    runCount: data.runCount || 0,
-
-    latestStart: data.latestStart,
-    latestEnd: data.latestEnd,
-    status: data.status,
-
+    created: data.created,
+    active: data.active,
     triggers: data.triggers && data.triggers.map(NewWorkflowTrigger),
-    steps: data.steps && data.steps.map(NewTransformStep),
     hooks: data.hooks && data.hooks.map(NewWorkflowHook),
-
-    versionInfo: data.versionInfo
   }
 }
 
@@ -63,22 +43,19 @@ export interface CronTrigger extends WorkflowTrigger {
 }
 
 export interface WorkflowTrigger {
-  type:       WorkflowTriggerType,
-  disabled?:   boolean,
-
-  runCount?:      number,
-  lastRunID?:     string,
-  lastRunStart?:  string,
-  lastRunStatus?: string,
-  [key: string]: any
+  id: string
+  active?:  boolean,
+  type: WorkflowTriggerType,
+  nextRunStart: string
 }
 
 export function NewWorkflowTrigger(data: Record<string,any>): WorkflowTrigger {
   return {
     id: data.id || '',
-    workflowID: data.workflowID || '',
+    active: data.active || true,
     type: data.type,
-    disabled: data.disabled || false,
+    nextRunStart: data.nextRunStart,
+    ...data
   }
 }
 


### PR DESCRIPTION
- Cleans up interface for `Workflow` to match backend. 
- Introduces `workflowDataset` into state, which is populated with HEAD but also where edits to transform steps can be mutated when the user is editing.  This is sent along with `workflow` when deploying.

- changes the layout of commits in the Run Log to match the commit layout used in preview/history
- Elevates the api call to workflow to `DatasetWrapper` and sets `hasWorkflow` in dsPreview so we always know if the current dataset has a workflow