### PR TITLE
Run now

### DIFF
--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -70,7 +70,6 @@ const ActivityList: React.FC<ActivityListProps> = ({
       name: 'Commit',
       selector: 'name',
       cell: (row: LogItem) => {
-        console.log('row', row)
         if (!['failed', 'unchanged'].includes(row.runStatus)) {
           const versionLink = `/ds/${row.username}/${row.name}/at${row.path}/body`
           return (

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -9,8 +9,7 @@ import { newDatasetLogsSelector } from './state/activityFeedState'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 import { runNow } from '../workflow/state/workflowActions'
 import { selectLatestRun } from '../workflow/state/workflowState'
-import Button from '../../chrome/Button'
-import Icon from '../../chrome/Icon'
+import RunNowButton from './RunNowButton'
 
 
 export interface DatasetActivityFeedProps {
@@ -32,18 +31,17 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
     dispatch(loadDatasetLogs(qriRef))
   },[dispatch, qriRef])
 
+  useEffect(() => {
+    dispatch(loadDatasetLogs(qriRef))
+  },[latestRun?.status])
+
   const handleRunNowClick = () => {
     dispatch(runNow(qriRef))
-    // figure out the right time to refresh the logs
-    dispatch(loadDatasetLogs(qriRef))
   }
 
-  const runNowButton = (
-    <Button type='primary' onClick={handleRunNowClick}><Icon icon='play' className='mr-2'/>Run Now</Button>
-  )
 
   return (
-    <DatasetFixedLayout headerChildren={runNowButton}>
+    <DatasetFixedLayout headerChildren={<RunNowButton status={latestRun?.status} onClick={handleRunNowClick} />}>
       <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white relative'>
         <ActivityList
           log={logs}

--- a/src/features/activityFeed/RunNowButton.tsx
+++ b/src/features/activityFeed/RunNowButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import Button from '../../chrome/Button'
+import Icon from '../../chrome/Icon'
+import { RunStatus } from '../../qri/run'
+
+export interface RunNowButtonProps {
+  status: RunStatus
+  onClick: () => void
+}
+
+const RunNowButton: React.FC<RunNowButtonProps> = ({
+  status,
+  onClick
+}) => {
+  let text = 'Run Now'
+  if (status === 'running') {
+    text = 'Running'
+  }
+  return (
+    <Button type='primary' disabled={status === 'running'} onClick={onClick}>
+      <Icon icon={ status === 'running' ? 'loader' : 'play'} className='mr-2'/>
+      {text}
+    </Button>
+  )
+}
+
+export default RunNowButton

--- a/src/features/activityFeed/state/activityFeedActions.ts
+++ b/src/features/activityFeed/state/activityFeedActions.ts
@@ -14,13 +14,14 @@ export function loadDatasetLogs(qriRef: QriRef): ApiActionThunk {
 
 function fetchDatasetLogs(qriRef: QriRef): ApiAction {
   return {
-    type: 'dataset_logs',
+    type: 'dataset_activity',
     qriRef,
     [CALL_API]: {
       endpoint: `ds/activity`,
       method: 'POST',
       body: {
-        ref: `${qriRef.username}/${qriRef.name}`
+        ref: `${qriRef.username}/${qriRef.name}`,
+        pageSize: 100
       },
       map: mapLogs
     }

--- a/src/features/activityFeed/state/activityFeedState.ts
+++ b/src/features/activityFeed/state/activityFeedState.ts
@@ -1,12 +1,19 @@
 import { createReducer } from '@reduxjs/toolkit'
 
 import { RootState } from '../../../store/store';
-import { QriRef, refStringFromQriRef } from '../../../qri/ref';
+import { QriRef, humanRef, refStringFromQriRef } from '../../../qri/ref';
 import { LogItem } from '../../../qri/log';
 
 export function newDatasetLogsSelector(qriRef: QriRef): (state: RootState) => LogItem[] {
   return (state: RootState) => {
     return state.activityFeed.datasetLogs[refStringFromQriRef(qriRef)] || []
+  }
+}
+
+export function selectLogCount(qriRef: QriRef): (state: RootState) => number {
+  qriRef = humanRef(qriRef)
+  return (state: RootState) => {
+    return state.activityFeed.datasetLogs[refStringFromQriRef(qriRef)]?.length
   }
 }
 
@@ -19,7 +26,7 @@ const initialState: ActivityFeedState = {
 }
 
 export const activityFeedReducer = createReducer(initialState, {
-  'API_DATASET_LOGS_SUCCESS': (state, action) => {
+  'API_DATASET_ACTIVITY_SUCCESS': (state, action) => {
     const ls = action.payload.data as LogItem[]
     state.datasetLogs[refStringFromQriRef(action.qriRef)] = ls
   },

--- a/src/features/commits/state/commitActions.ts
+++ b/src/features/commits/state/commitActions.ts
@@ -14,7 +14,7 @@ export function loadDatasetCommits(qriRef: QriRef): ApiActionThunk {
 
 function fetchDatasetCommits(qriRef: QriRef): ApiAction {
   return {
-    type: 'dataset_commits',
+    type: 'dataset_activity',
     qriRef,
     [CALL_API]: {
       endpoint: `ds/activity`,

--- a/src/features/commits/state/commitState.ts
+++ b/src/features/commits/state/commitState.ts
@@ -11,6 +11,13 @@ export function newDatasetCommitsSelector(qriRef: QriRef): (state: RootState) =>
   }
 }
 
+export function selectVersionCount(qriRef: QriRef): (state: RootState) => number {
+  qriRef = humanRef(qriRef)
+  return (state: RootState) => {
+    return state.commits.commits[refStringFromQriRef(qriRef)]?.length
+  }
+}
+
 export function selectDatasetCommitsLoading(state: RootState): boolean {
   return state.commits.loading
 }
@@ -28,15 +35,15 @@ const initialState: CommitsState = {
 }
 
 export const commitsReducer = createReducer(initialState, {
-  'API_DATASET_COMMITS_REQUEST': (state, action) => {
+  'API_DATASET_ACTIVITY_REQUEST': (state, action) => {
     state.loading = true
   },
-  'API_DATASET_COMMITS_FAILURE': (state, action) => {
+  'API_DATASET_ACTIVITY_FAILURE': (state, action) => {
     state.loading = false
     // TODO (b5): capture error from API response
     state.loadError = 'failed to load commits'
   },
-  'API_DATASET_COMMITS_SUCCESS': (state, action) => {
+  'API_DATASET_ACTIVITY_SUCCESS': (state, action) => {
     const ls = action.payload.data as LogItem[]
     state.commits[refStringFromQriRef(action.qriRef)] = ls.filter(d => d.path)
     state.loading = false

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -17,6 +17,8 @@ import {
 
 import { selectNavExpanded } from '../app/state/appState'
 import { toggleNavExpanded } from '../app/state/appActions'
+import { selectVersionCount } from '../commits/state/commitState'
+import { selectLogCount } from '../activityFeed/state/activityFeedState'
 
 export interface DatasetNavSidebarProps {
   qriRef: QriRef
@@ -24,6 +26,8 @@ export interface DatasetNavSidebarProps {
 
 const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
   const expanded = useSelector(selectNavExpanded)
+  const versionCount = useSelector(selectVersionCount(qriRef))
+  const logCount = useSelector(selectLogCount(qriRef))
   const dispatch = useDispatch()
 
   const toggleExpanded = () => {
@@ -39,7 +43,6 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
   // determine if the workflow is new by reading /new at the end of the pathname
   const segments = useLocation().pathname.split('/')
   const isNewWorkflow = segments[segments.length - 1] === 'new'
-
 
   return (
     <div className={`side-nav pl-9 h-full bg-white relative pt-9 flex-shrink-0 ${expanded ? 'w-52' : 'w-24'}`}>
@@ -88,6 +91,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
         label='History'
         to={pathToDatasetViewer(qriRef)}
         expanded={expanded}
+        number={versionCount}
         tooltip={
           <TooltipContent
             text='Components'
@@ -115,6 +119,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
         label='Run Log'
         to={pathToActivityFeed(qriRef.username, qriRef.name)}
         expanded={expanded}
+        number={logCount}
         tooltip={
           <TooltipContent
             text='Activity Feed'

--- a/src/features/dataset/DatasetSideNavItem.tsx
+++ b/src/features/dataset/DatasetSideNavItem.tsx
@@ -12,6 +12,7 @@ export interface DatasetSideNavItemProps {
   to: string
   expanded: boolean
   tooltip?: React.ReactNode
+  number?: number
   disabled?: boolean
 }
 
@@ -22,6 +23,7 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({
   to,
   expanded=true,
   tooltip,
+  number,
   disabled = false
 }) => {
   const { pathname } = useLocation();
@@ -31,7 +33,17 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({
     <>
       <span data-tip data-for={id}>
         <div className='flex items-center'>
-          <Icon className='mr-2' size='md' icon={icon} />
+          <div className='relative'>
+            {number && (
+              <div
+                className='text-center bg-qrigray-400 px-1 py-0.5 rounded-sm text-white leading-none absolute -top-0 right-1'
+                style={{
+                  fontSize: 9
+                }}
+              >{number}</div>
+            )}
+            <Icon className='mr-2' size='md' icon={icon} />
+          </div>
           <span style={{
             fontSize: '16px',
             width: expanded ? 'auto' : 0,

--- a/src/features/dsComponents/DatasetWrapper.tsx
+++ b/src/features/dsComponents/DatasetWrapper.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux'
 import { newQriRef } from '../../qri/ref'
 import { fetchDsPreview } from '../dsPreview/state/dsPreviewActions'
 import { loadWorkflowByDatasetRef } from '../workflow/state/workflowActions'
+import { loadDatasetLogs } from '../activityFeed/state/activityFeedActions'
 import NavBar from '../navbar/NavBar'
 import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 
@@ -21,6 +22,7 @@ const DatasetWrapper: React.FC<{}> = ({ children }) => {
   useEffect(() => {
     dispatch(fetchDsPreview(qriRef))
     dispatch(loadWorkflowByDatasetRef(qriRef))
+    dispatch(loadDatasetLogs(qriRef))
   }, [ qriRef.username, qriRef.name])
 
   return (

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -6,7 +6,7 @@ import { Location } from 'history'
 
 import WorkflowOutline from './WorkflowOutline'
 import {
-  selectLatestRun,
+  selectLatestDryRun,
   selectRunMode,
   selectWorkflow,
   selectWorkflowIsDirty,
@@ -34,7 +34,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const location = useLocation<WorkflowLocationState>()
   const workflow = useSelector(selectWorkflow)
   const workflowDataset = useSelector(selectWorkflowDataset)
-  const latestRun = useSelector(selectLatestRun)
+  const latestRun = useSelector(selectLatestDryRun)
   const runMode = useSelector(selectRunMode)
   const isDirty = useSelector(selectWorkflowIsDirty)
 

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -2,12 +2,10 @@ import React, { useEffect } from 'react'
 import { useParams } from 'react-router'
 import { useSelector, useDispatch } from 'react-redux'
 
-import { newQriRef } from '../../qri/ref'
 import Spinner from '../../chrome/Spinner'
-import { loadDataset } from '../dataset/state/datasetActions'
 import { selectWorkflowDataset } from '../workflow/state/workflowState'
-import { loadWorkflowByDatasetRef, setWorkflowRef } from './state/workflowActions'
-import { selectLatestRun } from './state/workflowState'
+import { setWorkflowRef } from './state/workflowActions'
+import { selectLatestDryRun } from './state/workflowState'
 import { QriRef } from '../../qri/ref'
 import { NewDataset } from '../../qri/dataset'
 import Workflow from './Workflow'
@@ -22,7 +20,7 @@ interface WorkflowPageProps {
 const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
   let dataset = useSelector(selectWorkflowDataset)
-  const latestRun = useSelector(selectLatestRun)
+  const latestRun = useSelector(selectLatestDryRun)
   let { username, name } = useParams()
 
   // if qriRef is empty, this is a new workflow

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -170,6 +170,7 @@ function calculateIsDirty(state: WorkflowState) {
 function changeWorkflowTrigger(state: WorkflowState, action: WorkflowTriggerAction) {
   // TODO(chriswhong): allow for more than one trigger
   state.workflow.triggers = [action.trigger]
+  state.isDirty = calculateIsDirty(state)
   return
 }
 

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -32,7 +32,6 @@ export const TEMP_SET_WORKFLOW_EVENTS = 'TEMP_SET_WORKFLOW_EVENTS'
 
 export const selectLatestDryRun = (state: RootState): Run | undefined => {
   if (state.workflow.lastDryRunID) {
-    // console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
     return NewRunFromEventLog(state.workflow.lastDryRunID, state.workflow.events)
   }
   return undefined
@@ -40,7 +39,6 @@ export const selectLatestDryRun = (state: RootState): Run | undefined => {
 
 export const selectLatestRun = (state: RootState): Run | undefined => {
   if (state.workflow.lastRunID) {
-    // console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
     return NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events)
   }
   return undefined

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -30,6 +30,14 @@ export const SET_RUN_MODE = 'SET_RUN_MODE'
 // of the workflow without having to have a working api
 export const TEMP_SET_WORKFLOW_EVENTS = 'TEMP_SET_WORKFLOW_EVENTS'
 
+export const selectLatestDryRun = (state: RootState): Run | undefined => {
+  if (state.workflow.lastDryRunID) {
+    // console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
+    return NewRunFromEventLog(state.workflow.lastDryRunID, state.workflow.events)
+  }
+  return undefined
+}
+
 export const selectLatestRun = (state: RootState): Run | undefined => {
   if (state.workflow.lastRunID) {
     // console.log('calculating event log for id', state.workflow.lastRunID, 'from events', state.workflow.events, NewRunFromEventLog(state.workflow.lastRunID, state.workflow.events))
@@ -69,6 +77,7 @@ export interface WorkflowState {
   // with working state to determine isDirty
   workflowBase: WorkflowBase
   isDirty: boolean
+  lastDryRunID?: string,
   lastRunID?: string,
   events: EventLogLine[],
 }
@@ -91,13 +100,14 @@ const initialState: WorkflowState = {
   },
   isDirty: false,
   lastRunID: '',
+  lastDryRunID: '',
   events: []
 }
 
 export const workflowReducer = createReducer(initialState, {
   'API_APPLY_SUCCESS': (state, action) => {
     const runID = action.payload.data.runID
-    state.lastRunID = runID
+    state.lastDryRunID = runID
   },
   'API_RUNNOW_SUCCESS': (state, action) => {
     state.lastRunID = action.payload.data


### PR DESCRIPTION
Merge #244 first

- Wires up `Run Now` button in Run Log
- calculates `isDirty` on trigger changes (previously was only updating on changes to steps
- introduce `latestDryRun` to workflow, allowing us to select the dry run in the workflow editor, and a regular run in Run Log
- Adds small number UI to Dataset Nav Items, useful for showing version count, etc
- Consolidates commits and logs api calls to use the same action type, so that the commit list can be updated at the same time as the activity list