### PR TITLE
feat: fix scroll triggers

### DIFF
--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { useSelector } from 'react-redux'
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { useInView } from 'react-intersection-observer'
 import classNames from 'classnames'
@@ -11,17 +11,21 @@ import { selectSessionUser } from '../session/state/sessionState'
 import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
 import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
+import Scroller from '../scroller/Scroller'
+import { resetScroller } from '../scroller/state/scrollerActions'
 
 interface DatasetScrollLayoutProps {
   dataset?: Dataset
   headerChildren?: JSX.Element
   contentClassName?: string
+  useScroller?: boolean
 }
 
 const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
   dataset,
   headerChildren,
   contentClassName = '',
+  useScroller = false,
   children
 }) => {
   const qriRef = newQriRef(useParams())
@@ -46,22 +50,34 @@ const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
     initialInView: true
   });
 
-  return (
+  const content = (
     <>
-      <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
-        <DatasetMiniHeader dataset={headerDataset} show={!inView} >
-          {headerChildren}
-        </DatasetMiniHeader>
-        <div className={classNames('p-7 w-full', contentClassName)}>
-          <div ref={stickyHeaderTriggerRef}>
-            <DatasetHeader dataset={headerDataset} editable={editable} showInfo={!dataset}>
-              {headerChildren}
-            </DatasetHeader>
-          </div>
-          {children}
+      <DatasetMiniHeader dataset={headerDataset} show={!inView} >
+        {headerChildren}
+      </DatasetMiniHeader>
+      <div className={classNames('p-7 w-full', contentClassName)}>
+        <div ref={stickyHeaderTriggerRef}>
+          <DatasetHeader dataset={headerDataset} editable={editable} showInfo={!dataset}>
+            {headerChildren}
+          </DatasetHeader>
         </div>
+        {children}
       </div>
     </>
+  )
+
+  if (useScroller) {
+    return (
+      <Scroller className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
+        {content}
+      </Scroller>
+    )
+  }
+
+  return (
+    <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
+      {content}
+    </div>
   )
 }
 

--- a/src/features/scroller/Scroller.tsx
+++ b/src/features/scroller/Scroller.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 
 import { selectScrollerPos } from './state/scrollerState'
+import { resetScroller } from './state/scrollerActions'
+
 
 export interface ScrollerProps {
   // optional className to pass in styling
@@ -14,17 +16,27 @@ export interface ScrollerProps {
 // element should be scrolled to
 // The `ScrollElement` will pick up on that change & if it is the correct
 // element, will update the state to say where it should be positioned
-// The `Scroller` will pick up on that position change and `scrollTo` the 
+// The `Scroller` will pick up on that position change and `scrollTo` the
 // given position
 const Scroller: React.FC<ScrollerProps> = ({className, children})=> {
   const ref = useRef<HTMLDivElement>(null)
   const pos = useSelector(selectScrollerPos)
+  const dispatch = useDispatch()
 
+  // scroll when scrollerPos changes
   useEffect(() => {
     if (ref.current) {
-      ref.current.scrollTo({top: pos, behavior: 'smooth'})
+      ref.current.scrollTo({ top: pos, behavior: 'smooth' })
     }
   }, [pos])
+
+  // when this instance of Scroller goes away, reset the scroller state
+  useEffect(() => {
+    return () => {
+      dispatch(resetScroller())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <div ref={ref} className={className}>

--- a/src/features/scroller/state/scrollerActions.ts
+++ b/src/features/scroller/state/scrollerActions.ts
@@ -1,11 +1,15 @@
-import { SET_SCROLLER_POS, SET_SCROLL_ELEMENT } from "./scrollerState";
+import {
+  SET_SCROLLER_POS,
+  SET_SCROLL_ELEMENT,
+  RESET_SCROLLER
+} from "./scrollerState";
 
 export interface SetScrollerPosAction {
   type: string
   scrollerPos: number
 }
 
- export function setScrollerPos(scrollerPos: number): SetScrollerPosAction {
+export function setScrollerPos(scrollerPos: number): SetScrollerPosAction {
   return {
     type: SET_SCROLLER_POS,
     scrollerPos,
@@ -21,5 +25,11 @@ export interface SetScrollAnchorAction {
   return {
     type: SET_SCROLL_ELEMENT,
     id
+  }
+}
+
+export function resetScroller() {
+  return {
+    type: RESET_SCROLLER
   }
 }

--- a/src/features/scroller/state/scrollerState.ts
+++ b/src/features/scroller/state/scrollerState.ts
@@ -9,6 +9,7 @@ export const SCROLLER_DEFAULT_TOP_OFFSET = 80
 
 export const SET_SCROLLER_POS = 'SET_SCROLLER_POS'
 export const SET_SCROLL_ELEMENT = 'SET_SCROLL_ELEMENT'
+export const RESET_SCROLLER = 'RESET_SCROLLER'
 
 export interface ScrollerState {
   // scrollPos, when this changes it triggers the workflow editor to adjust it's
@@ -36,4 +37,7 @@ export const scrollerReducer = createReducer(initialState, {
   SET_SCROLL_ELEMENT: (state: ScrollerState, action: SetScrollAnchorAction) => {
     state.scrollAnchorID = action.id
   },
+  RESET_SCROLLER: () => {
+    return initialState
+  }
 })

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -10,7 +10,6 @@ import { QriRef } from '../../qri/ref'
 import { NewDataset } from '../../qri/dataset'
 import Workflow from './Workflow'
 import RunBar from './RunBar'
-import Scroller from '../scroller/Scroller'
 import DatasetScrollLayout from '../dataset/DatasetScrollLayout'
 
 interface WorkflowPageProps {
@@ -53,10 +52,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
           <Spinner color='#4FC7F3' />
         </div>)
       : (
-            <DatasetScrollLayout dataset={dataset} headerChildren={runBar}>
-              <Scroller>
-                <Workflow qriRef={qriRef} />
-              </Scroller>
+            <DatasetScrollLayout dataset={dataset} headerChildren={runBar} useScroller>
+              <Workflow qriRef={qriRef} />
             </DatasetScrollLayout>
         )}
     </>


### PR DESCRIPTION
- Restores scroll triggers (click outline to scroll to that section) in workflows
- Moves `Scroller` component usage into `DatasetScrollLayout` as it needs to be where the scrolling is actually happening.
- Adds a `useScroller` prop to `DatasetScrollLayout`, allowing it to be used without a `Scroller` on dataset preview pages.
- Adds `resetScroller` action and reducer to reset the scroller position to `0` and clear the `scrollAnchorID`
- Adds a `useEffect` hook to `Scroller` to call `resetScroller` when the component unmounts.