### PR TITLE
feat: prevent endless loop on search, small layout fix

### DIFF
--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -40,7 +40,8 @@ const Search: React.FC<{}> = () => {
   // if the query string ever changes, fetch new data
   useEffect(() => {
     dispatch(loadSearchResults(searchParams))
-  }, [q, page, sort, dispatch, searchParams])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, page, sort])
 
   // handle new search term input
   const handleSearchSubmit = (newQ:string) => {
@@ -146,22 +147,24 @@ const Search: React.FC<{}> = () => {
                     )}
                   </div>
                 </div>
-                <DropdownMenu 
-                  icon={sortIcon}
-                  className='ml-8'
-                  items={[
-                      {
-                        label: 'Dataset Name',
-                        active: sort === 'name',
-                        onClick: () => { updateQueryParams({ sort: 'name' }) }
-                      },
-                      {
-                        label: 'Recently Updated',
-                        active: sort === 'recentlyupdated',
-                        onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
-                      }
-                    ]}
+                <div>
+                  <DropdownMenu
+                    icon={sortIcon}
+                    className='ml-8'
+                    items={[
+                        {
+                          label: 'Dataset Name',
+                          active: sort === 'name',
+                          onClick: () => { updateQueryParams({ sort: 'name' }) }
+                        },
+                        {
+                          label: 'Recently Updated',
+                          active: sort === 'recentlyupdated',
+                          onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
+                        }
+                      ]}
                   />
+                </div>
               </>
             ):(
               <>&nbsp;</>


### PR DESCRIPTION
- fixes and endless loop (and endless api calls) when loading `/search`
- fixes a layout bug that was causing the sort dropdown to appear in the wrong place