### PR TITLE
feat: add loading and error state for /apply

### DIFF
--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -7,7 +7,12 @@ import { RunStatus } from '../../qri/run'
 import RunStatusIcon from '../run/RunStatusIcon'
 import { applyWorkflowTransform } from './state/workflowActions'
 import { deployWorkflow } from '../deploy/state/deployActions'
-import { selectRunMode, selectWorkflow, selectWorkflowDataset } from './state/workflowState'
+import {
+  selectRunMode,
+  selectWorkflow,
+  selectWorkflowDataset,
+  selectApplyStatus
+} from './state/workflowState'
 import { platform } from '../../utils/platform'
 
 export interface RunBarProps {
@@ -23,6 +28,7 @@ const RunBar: React.FC<RunBarProps> = ({
   const runMode = useSelector(selectRunMode)
   const workflow = useSelector(selectWorkflow)
   const workflowDataset = useSelector(selectWorkflowDataset)
+  const applyStatus = useSelector(selectApplyStatus)
 
   const handleRun = () => {
     if (onRun) { onRun() }
@@ -38,12 +44,19 @@ const RunBar: React.FC<RunBarProps> = ({
 
   const isMac = (platform() === 'mac')
 
+  let displayStatus = status
+  // we already have RunStatusIcon to show the status of the run, so we
+  // can use it to indicate that the /apply api call is pending OR if there was
+  // an error with the call
+  if (applyStatus === 'loading') { displayStatus = 'running' }
+  if (applyStatus === 'error') { displayStatus = 'failed' }
+
   return (
     <div>
       <div className='flex w-36 items-center'>
         <div className='mr-4'>
           <div className='inline-block align-middle'>
-            <RunStatusIcon status={status} size='md' className='ml-2' />
+            <RunStatusIcon status={displayStatus} size='md' className='ml-2' />
           </div>
         </div>
         <div className='w-36'>

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -57,12 +57,18 @@ export const selectWorkflowQriRef = (state: RootState): QriRef => {
 export const selectRunMode = (state: RootState): RunMode => state.workflow.runMode
 export const selectWorkflowIsDirty = (state: RootState): boolean => state.workflow.isDirty
 export const selectWorkflowDataset = (state: RootState): Dataset => state.workflow.dataset
+export const selectApplyStatus = (state: RootState): ApplyStatus => state.workflow.applyStatus
 
 
 
 export type RunMode =
   | 'apply'
   | 'save'
+
+export type ApplyStatus =
+  | ''
+  | 'loading'
+  | 'error'
 
 export interface WorkflowState {
   runMode: RunMode
@@ -73,9 +79,11 @@ export interface WorkflowState {
   // with working state to determine isDirty
   workflowBase: WorkflowBase
   isDirty: boolean
-  lastDryRunID?: string,
-  lastRunID?: string,
-  events: EventLogLine[],
+  lastDryRunID?: string
+  lastRunID?: string
+  events: EventLogLine[]
+  // state for the async request to /apply
+  applyStatus: ApplyStatus
 }
 
 const initialState: WorkflowState = {
@@ -97,13 +105,21 @@ const initialState: WorkflowState = {
   isDirty: false,
   lastRunID: '',
   lastDryRunID: '',
-  events: []
+  events: [],
+  applyStatus: ''
 }
 
 export const workflowReducer = createReducer(initialState, {
+  'API_APPLY_REQUEST': (state, action) => {
+    state.applyStatus = 'loading'
+  },
   'API_APPLY_SUCCESS': (state, action) => {
+    state.applyStatus = ''
     const runID = action.payload.data.runID
     state.lastDryRunID = runID
+  },
+  'API_APPLY_FAILURE': (state, action) => {
+    state.applyStatus = 'error'
   },
   'API_RUNNOW_SUCCESS': (state, action) => {
     state.lastRunID = action.payload.data


### PR DESCRIPTION
Adds loading and error states to the api call to `/apply` (Dry Run).  Hijacks the existing `RunStatusIcon` that is already present in `RunBar` to show a loading spinner on request and a red x on failure, on success it will render the `RunStatus` as normal

Closes #276 