### PR TITLE
fix: multiple ui bugs

### DIFF
--- a/src/features/app/modal/Modal.tsx
+++ b/src/features/app/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { ModalType, selectModal } from '../state/appState'
@@ -19,21 +19,31 @@ const Modal: React.FC<any> = () => {
   const dispatch = useDispatch()
   const modal = useSelector(selectModal)
 
-  const handleMaskClick = useCallback((e: MouseEvent) => {
-    if (maskRef && maskRef.current?.contains(e.target as Element)) {
+
+
+  // this is called from from multiple places (esc key press or click outside modal)
+  // and is where we finally check allowClear and
+  const clearModalCallback = useCallback(() => {
+    if (!modal.locked) {
       dispatch(clearModal())
     }
-  }, [dispatch, maskRef])
+  }, [modal.locked, dispatch])
+
+  const handleMaskClick = useCallback((e: MouseEvent) => {
+    if (maskRef && maskRef.current?.contains(e.target as Element)) {
+      clearModalCallback()
+    }
+  }, [maskRef, clearModalCallback])
 
   useEffect(() => {
     const close = (e: KeyboardEvent) => {
       if (e.keyCode === 27) {
-        dispatch(clearModal())
+        clearModalCallback()
       }
     }
     window.addEventListener('keydown', close)
     return () => window.removeEventListener('keydown', close)
-  }, [dispatch])
+  }, [clearModalCallback])
 
   useEffect(() => {
     document.addEventListener("mousedown", handleMaskClick)

--- a/src/features/app/modal/Modal.tsx
+++ b/src/features/app/modal/Modal.tsx
@@ -19,10 +19,6 @@ const Modal: React.FC<any> = () => {
   const dispatch = useDispatch()
   const modal = useSelector(selectModal)
 
-
-
-  // this is called from from multiple places (esc key press or click outside modal)
-  // and is where we finally check allowClear and
   const clearModalCallback = useCallback(() => {
     if (!modal.locked) {
       dispatch(clearModal())

--- a/src/features/app/state/appActions.ts
+++ b/src/features/app/state/appActions.ts
@@ -1,8 +1,13 @@
-import { Modal, ModalType, SET_MODAL, TOGGLE_NAV_EXPANDED } from "./appState";
+import { Modal, ModalType, SET_MODAL, SET_MODAL_LOCKED, TOGGLE_NAV_EXPANDED,  } from "./appState";
 
 export interface ModalAction {
   type: string
   modal: Modal
+}
+
+export interface ModalLockedAction {
+  type: string
+  locked: boolean
 }
 
 export function showModal<P = {}>(type: ModalType, props?: P): ModalAction {
@@ -19,6 +24,13 @@ export function clearModal(): ModalAction {
   return {
     type: SET_MODAL,
     modal: { type: ModalType.none }
+  }
+}
+
+export function setModalLocked(locked: boolean): ModalLockedAction {
+  return {
+    type: SET_MODAL_LOCKED,
+    locked
   }
 }
 

--- a/src/features/app/state/appActions.ts
+++ b/src/features/app/state/appActions.ts
@@ -3,6 +3,7 @@ import { Modal, ModalType, SET_MODAL, SET_MODAL_LOCKED, TOGGLE_NAV_EXPANDED,  } 
 export interface ModalAction {
   type: string
   modal: Modal
+  locked?: boolean
 }
 
 export interface ModalLockedAction {
@@ -10,7 +11,7 @@ export interface ModalLockedAction {
   locked: boolean
 }
 
-export function showModal<P = {}>(type: ModalType, props?: P): ModalAction {
+export function showModal<P = {}>(type: ModalType, props?: P, locked?: boolean = false): ModalAction {
   return {
     type: SET_MODAL,
     modal: {

--- a/src/features/app/state/appState.ts
+++ b/src/features/app/state/appState.ts
@@ -1,8 +1,9 @@
 import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import { ModalAction } from './appActions';
+import { ModalAction, ModalLockedAction } from './appActions';
 
 export const SET_MODAL = 'SET_MODAL'
+export const SET_MODAL_LOCKED = 'SET_MODAL_LOCKED'
 export const TOGGLE_NAV_EXPANDED = 'TOGGLE_NAV_EXPANDED'
 
 export const selectModal = (state: RootState): Modal => state.app.modal
@@ -23,6 +24,9 @@ export enum ModalType {
 
 export interface Modal<P = {}> {
   type: ModalType
+  // locked is used to block closing the modal when clicking outside of it or
+  // when pressing 'esc'
+  locked: boolean
   props?: P
 }
 
@@ -32,13 +36,17 @@ export interface AppState {
 }
 
 const initialState: AppState = {
-  modal: { type: ModalType.none },
+  modal: { type: ModalType.none, locked: false },
   navExpanded: true
 }
 
 export const appReducer = createReducer(initialState, {
   SET_MODAL: (state: AppState, action: ModalAction) => {
     state.modal = action.modal
+  },
+
+  SET_MODAL_LOCKED: (state: AppState, action: ModalLockedAction) => {
+    state.modal.locked = action.locked
   },
 
   TOGGLE_NAV_EXPANDED: (state: AppState) => {

--- a/src/features/trigger/modal/AddTriggerModal.tsx
+++ b/src/features/trigger/modal/AddTriggerModal.tsx
@@ -115,7 +115,11 @@ const AddTriggerModal: React.FC<AddTriggerModalProps> = ({
                 className={classNames('w-full py-4 px-4 rounded flex border items-center mb-4', {
                   'cursor-pointer': !disabled
                 })}
-                onClick={() => { setType(id) }}
+                onClick={() => {
+                  if (!disabled) {
+                    setType(id)
+                  }
+                }}
               >
                 <div className='flex-grow'>
                   <div className={classNames('font-bold', {

--- a/src/features/workflow/Block.tsx
+++ b/src/features/workflow/Block.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
+import classNames from 'classnames'
 
 export interface BlockProps {
   name?: string
   onClick?: () => void
 }
 
-const Block: React.FC<BlockProps> = ({ name, children,onClick }) => (
+const Block: React.FC<BlockProps> = ({ name, onClick, children }) => (
   <div className='px-2 w-full py-2' onClick={onClick}>
-    <div className='bg-white px-3 py-2 shadow-even cursor-pointer rounded-lg h-full'>
+    <div className={classNames('bg-white px-3 py-2 shadow-even rounded-lg h-full', {
+      'cursor-pointer': !!onClick
+    })}>
       { name && <div className='text-sm font-semibold pb-1 text-qrinavy'>{name}</div>}
       {children}
     </div>

--- a/src/features/workflow/modal/DeployModal.tsx
+++ b/src/features/workflow/modal/DeployModal.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 
 import Button from '../../../chrome/Button'
 import Icon from '../../../chrome/Icon'
-import { clearModal } from '../../app/state/appActions'
+import { clearModal, setModalLocked } from '../../app/state/appActions'
 import IconButton from '../../../chrome/IconButton'
 import TextInput from '../../../chrome/forms/TextInput'
 import Checkbox from '../../../chrome/forms/Checkbox'
@@ -18,6 +18,8 @@ import RunStatusIcon from '../../run/RunStatusIcon'
 import { selectDeployStatus } from '../../deploy/state/deployState'
 import { selectSessionUser } from '../../session/state/sessionState'
 import WarningDialog from '../WarningDialog'
+
+
 
 
 const DeployModal: React.FC = () => {
@@ -55,10 +57,15 @@ const DeployModal: React.FC = () => {
   useEffect(() => {
     // the moment of triumph!
     if (deployStatus === 'deployed') {
+      dispatch(setModalLocked(false))
       // navigate to the new dataset's workflow!
       history.push({
         pathname: `/ds/${qriRef.username}/${qriRef.name}/workflow`,
       })
+    }
+
+    if (deployStatus === 'failed') {
+      dispatch(setModalLocked(false))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ deployStatus ])
@@ -77,6 +84,7 @@ const DeployModal: React.FC = () => {
 
   const handleDeployClick = () => {
     setDeploying(true)
+    dispatch(setModalLocked(true))
     dispatch(deployWorkflow(qriRef, workflow, dataset, runNow))
   }
 


### PR DESCRIPTION
Three fixes for issues found in user testing, closes #289 

- Trigger: entire box shows counter cursor, but only “Edit” is clickable
- User should not be able to dismiss deploy modal
- Webhook trigger was clickable (it’s grayed out)