### PR TITLE
feat: add dropUp option to DropdownMenu

### DIFF
--- a/src/chrome/DropdownMenu.tsx
+++ b/src/chrome/DropdownMenu.tsx
@@ -9,16 +9,18 @@ interface DropdownMenuProps {
   className?: string
   icon?: string | React.ReactElement
   items: DropdownMenuItemProps[]
+  dropUp?: boolean
 }
 
-// DropdownMenu shows menu when a given "icon" prop is clicked. the element to 
+// DropdownMenu shows menu when a given "icon" prop is clicked. the element to
 // be clicked must be passed in as the "icon" prop. pass contents of the menu as
 // children
 const DropdownMenu: React.FC<DropdownMenuProps> = ({
   icon,
   alignLeft=false,
   className='',
-  items
+  items,
+  dropUp=false
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
@@ -42,19 +44,26 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
       <div onClick={() => { setOpen(!open) }} className='cursor-pointer flex items-center'>
         {(typeof icon === 'string') ? <Icon icon={icon} /> : icon}
       </div>
-      {open && (
-        <div
-          className={classNames(`origin-top-right absolute top-8 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-30`, { 'left-0': alignLeft, 'right-0': !alignLeft })}
-          role="menu"
-          aria-orientation="vertical"
-          aria-labelledby="options-menu"
-          style={{ minWidth: '9rem' }}
-        >
-          <div className="py-1 flex flex-col" onClick={ () => setOpen(false) }>
-            {items.map((props, i) => <DropdownMenuItem key={i} {...props} />)}
-          </div>
+      <div
+        className={classNames(` transition-all duration-100 transform origin-top-right absolute rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-30`,
+          {
+            'left-0': alignLeft,
+            'right-0': !alignLeft,
+            'origin-top-right top-8': !dropUp,
+            'origin-bottom-right bottom-8': dropUp,
+            'opacity-0 invisible -translate-y-2 scale-95': !open,
+            'opacity-100 translate-y-0 scale-100 visible': open
+          }
+        )}
+        role="menu"
+        aria-orientation="vertical"
+        aria-labelledby="options-menu"
+        style={{ minWidth: '9rem' }}
+      >
+        <div className="py-1 flex flex-col" onClick={ () => setOpen(false) }>
+          {items.map((props, i) => <DropdownMenuItem key={i} {...props} />)}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -198,11 +198,13 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       omit: simplified,
       width: '60px',
       // eslint-disable-next-line react/display-name
-      cell: (row: VersionInfo) => {
+      cell: (row: VersionInfo, i: number) => {
+        const isLastRow = (i === (filteredWorkflows.length - 1))
         return (
           <div className='mx-auto text-qrigray-400'>
             <DropdownMenu
               icon={<Icon icon='more' />}
+              dropUp={isLastRow}
               items={[
                 // {
                 //   label: 'Rename...',


### PR DESCRIPTION
- Adds an optional `dropUp` prop to `DropdownMenu`, useful for making sure a dropdown in an item in a scrolling list is not cut off by the container boundary (implements this in CollectionTable) Closes #288 
- Adds a simple CSS animation to dropdown menus