### PR TITLE
fix: reset isDirty after fetching preview and workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/classnames": "^2.2.11",
+    "@types/deep-equal": "1.0.1",
     "@types/jest": "^26.0.20",
     "@types/markdown-it": "12.2.0",
     "@types/node": "^12.0.0",

--- a/src/features/workflow/state/workflowActions.ts
+++ b/src/features/workflow/state/workflowActions.ts
@@ -151,7 +151,7 @@ export function setWorkflow(workflow: Workflow): SetWorkflowAction {
 
 export interface SetTemplateAction {
   type: string
-  workflow: Workflow
+  dataset: Dataset
 }
 
 export function setTemplate(dataset: Dataset): SetTemplateAction {

--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -128,7 +128,10 @@ export const workflowReducer = createReducer(initialState, {
     const d = action.payload.data as Dataset
     // TODO (b5) - this should check peername *and* confirm the loaded version is HEAD
     state.dataset = d
+
+    // set the values to compare with and caclulate isDirty
     state.workflowBase.steps = d.transform?.steps
+    state.isDirty = calculateIsDirty(state)
   },
   'API_WORKFLOW_REQUEST': (state, action) => {
     // reset workflow and lastRunID to initialState values
@@ -152,6 +155,11 @@ export const workflowReducer = createReducer(initialState, {
     // ref check
     // const steps = state.workflow.steps
     state.workflow = w
+
+    // set the values to compare with and caclulate isDirty
+    state.workflowBase.triggers = w.triggers
+    state.workflowBase.hooks = w.hooks
+    state.isDirty = calculateIsDirty(state)
     // state.workflow.steps = steps
   },
   'API_DEPLOY_SUCCESS': (state, action) => {
@@ -159,7 +167,7 @@ export const workflowReducer = createReducer(initialState, {
   },
   SET_TEMPLATE: (state: WorkflowState, action: SetTemplateAction) => {
     state.dataset = action.dataset
-    state.workflowBase.steps = action.dataset.transform.steps
+    state.workflowBase.steps = action.dataset.transform?.steps
     return
   },
   'RESET_WORKFLOW_STATE': (state: WorkflowState, action: SetTemplateAction) => {
@@ -170,7 +178,7 @@ export const workflowReducer = createReducer(initialState, {
 function calculateIsDirty(state: WorkflowState) {
   const workflowCompare = {
     triggers: state.workflow.triggers,
-    steps: state.dataset.transform.steps,
+    steps: state.dataset.transform?.steps,
     hooks: state.workflow.hooks
   }
   return !DeepEqual(workflowCompare, state.workflowBase)
@@ -184,15 +192,13 @@ function changeWorkflowTrigger(state: WorkflowState, action: WorkflowTriggerActi
 }
 
 function changeWorkflowTransformStep(state: WorkflowState, action: SetWorkflowStepAction) {
-  if (state.dataset.transform.steps) {
+  if (state.dataset.transform?.steps) {
     state.dataset.transform.steps[action.index].script = action.script
   }
 
   state.isDirty = calculateIsDirty(state)
   // clear out events after an edit to reset dry run RunStatus
   state.events = []
-
-
 
   return
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/deep-equal@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"
+  integrity sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==
+
 "@types/eslint@^7.2.6":
   version "7.2.13"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.13.tgz#e0ca7219ba5ded402062ad6f926d491ebb29dd53"
@@ -3025,7 +3030,7 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/markdown-it@^12.2.0":
+"@types/markdown-it@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.0.tgz#f609929ac1e50cf0d039473fb331ebc62e313b34"
   integrity sha512-YEpywby5S2wt64C2E3bcpLvtIV8BuCj+4AGtL7tU51V8Vr1qwm+cX9gFfWRyclgLC0UK/7w2heYmhymDi+snzw==


### PR DESCRIPTION
- Ensures that `workflowBase` is properly updated after fetching dataset preview and workflow, and that `isDirty` is false when navigating to a dataset.

- Cleans up some typescript errors

Closes #280