### PR TITLE
refactor: Componentize DatasetCommitInfo

### DIFF
--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import classNames from 'classnames'
+
+import Icon from './Icon'
+import RelativeTimestampWithIcon from './RelativeTimestampWithIcon'
+import UsernameWithIcon from './UsernameWithIcon'
+import commitishFromPath from '../utils/commitishFromPath'
+import { Dataset } from '../qri/dataset'
+
+interface DatasetCommitInfoProps {
+  dataset: Dataset
+  // small yields the same info with smaller text, used in history list and run log
+  small?: boolean
+}
+
+const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
+  dataset,
+  small=false
+}) => {
+  return (
+    <div className={classNames({
+      'text-sm': !small,
+      'text-xs': small
+    })}>
+      <div className={classNames('text-qrinavy font-semibold flex justify-between items-center mb-2')}>
+        <div>{dataset.commit?.title}</div>
+        <div className='flex-grow-0 text-qrigreen'>
+          <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
+        </div>
+      </div>
+      <div className='flex items-center text-gray-400'>
+        <UsernameWithIcon username={dataset.username} className='mr-2' iconWidth={small ? 14 : 18} iconOnly={small} />
+        <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
+        {dataset.path && (
+          <div className='flex items-center leading-tight'>
+            <Icon icon='commit' size={small ? 'xs' : 'sm'} className='-ml-2' />
+            <div>{commitishFromPath(dataset.path)}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DatasetCommitInfo

--- a/src/chrome/RelativeTimestamp.tsx
+++ b/src/chrome/RelativeTimestamp.tsx
@@ -25,12 +25,12 @@ const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({
     .replace('a', '1')
 
   return (
-    <span
+    <div
       className={className}
       title={format(timestamp, 'MMM d yyyy, h:mm zz')}
     >
       {timeFromNowAbbreviation}
-    </span>
+    </div>
   )
 }
 

--- a/src/chrome/RelativeTimestampWithIcon.tsx
+++ b/src/chrome/RelativeTimestampWithIcon.tsx
@@ -14,7 +14,8 @@ const RelativeTimestampWithIcon: React.FC<RelativeTimestampWithIconProps> = ({
   className
  }) => (
    <div className={classNames('flex items-center leading-tight tracking-wider', className)}>
-     <Icon icon='clock' size='2xs' className='mr-0.5' /><RelativeTimestamp timestamp={timestamp} />
+     <Icon icon='clock' size='2xs' className='mr-0.5' />
+     <RelativeTimestamp timestamp={timestamp} />
    </div>
 )
 

--- a/src/chrome/UsernameWithIcon.tsx
+++ b/src/chrome/UsernameWithIcon.tsx
@@ -5,21 +5,23 @@ interface UsernameWithIconProps {
   username: string
   className?: string
   iconWidth?: number
+  iconOnly?: boolean
 }
 
 // TODO(chriswhong): make the prop a user object, or pass in icon URL as a separate prop
 const UsernameWithIcon: React.FunctionComponent<UsernameWithIconProps> = ({
   username,
   className,
-  iconWidth = 18
+  iconWidth = 18,
+  iconOnly = false
 }) => (
-   <div className={classNames('flex items-center tracking-wider leading-snug', className)}>
-     <div className='rounded-xl inline-block mr-1.5 bg-cover flex-shrink-0' style={{
+   <div className={classNames('flex items-center tracking-wider', className)}>
+     <div className='rounded-xl inline-block bg-cover flex-shrink-0' style={{
        height: iconWidth,
        width: iconWidth,
        backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
      }}></div>
-     <p className='truncate'>{username}</p>
+     {!iconOnly &&  <p className='ml-1.5 truncate'>{username}</p>}
    </div>
 )
 

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -5,10 +5,11 @@ import ReactDataTable from 'react-data-table-component'
 import DurationFormat from '../../chrome/DurationFormat'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import Icon from '../../chrome/Icon'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { LogItem } from '../../qri/log'
+import { NewDataset } from '../../qri/dataset'
 import { customStyles, customSortIcon } from '../../features/collection/CollectionTable'
-import commitishFromPath from '../../utils/commitishFromPath'
 
 
 interface ActivityListProps {
@@ -66,17 +67,19 @@ const ActivityList: React.FC<ActivityListProps> = ({
       name: 'Commit',
       selector: (row: LogItem) => row.message,
       cell: (row: LogItem) => {
+        const dataset = NewDataset({
+          username: row.username,
+          path: row.path,
+          commit: {
+            title: row.message,
+            timestamp:row.timestamp
+          }
+        })
         if (!['failed', 'unchanged'].includes(row.runStatus)) {
           const versionLink = `/ds/${row.username}/${row.name}/at${row.path}/body`
           return (
             <Link to={versionLink}>
-              <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
-                <div className=''>{row.message}</div>
-              </div>
-              <div className='flex items-center text-xs text-gray-400'>
-                <Icon icon='commit' size='sm' className='-ml-2' />
-                <div className=''>{commitishFromPath(row.path)}</div>
-              </div>
+              <DatasetCommitInfo dataset={dataset} small />
             </Link>
           )
         } else {

--- a/src/features/commits/CommitSummaryHeader.tsx
+++ b/src/features/commits/CommitSummaryHeader.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 
 import Dataset from '../../qri/dataset'
-import Icon from '../../chrome/Icon'
-import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
-import UsernameWithIcon from '../../chrome/UsernameWithIcon'
-import commitishFromPath from '../../utils/commitishFromPath'
+import DatasetVersionInfo from '../../chrome/DatasetCommitInfo'
 
 export interface CommitSummaryHeaderProps {
   dataset: Dataset
@@ -18,19 +15,11 @@ const CommitSummaryHeader: React.FC<CommitSummaryHeaderProps> = ({
   if (commit) {
     return (
       <div className='min-height-200 py-4 px-8 rounded-lg bg-white flex'>
-        <div className='flex-grow'>
+        <div className=''>
           <div className='text-xs text-gray-400 font-medium mb-2'>Version Info</div>
-          <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
-            <div className=''>{commit.title}</div>
-          </div>
-          <div className='flex items-center text-xs text-gray-400'>
-            <UsernameWithIcon username={dataset.peername} className='mr-3' />
-            <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(commit.timestamp)} />
-            <Icon icon='commit' size='sm' className='-ml-2' />
-            <div className=''>{commitishFromPath(path)}</div>
-          </div>
+          <DatasetVersionInfo dataset={dataset} />
         </div>
-        <div className='flex items-center'>
+        <div className='flex-grow flex items-center justify-end'>
           {children}
         </div>
       </div>

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
-import { Link } from 'react-router-dom';
-import classNames from 'classnames';
+import { Link } from 'react-router-dom'
+import classNames from 'classnames'
 
-import { LogItem } from '../../qri/log';
-import { newQriRef } from '../../qri/ref';
-import { pathToDatasetViewer } from '../dataset/state/datasetPaths';
-// import ComponentChangeIndicatorGroup from './ComponentChangeIndicatorGroup';
-import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon';
-import UsernameWithIcon from '../../chrome/UsernameWithIcon';
-
-import Icon from '../../chrome/Icon';
+import { LogItem } from '../../qri/log'
+import { newQriRef } from '../../qri/ref'
+import { NewDataset } from '../../qri/dataset'
+import { pathToDatasetViewer } from '../dataset/state/datasetPaths'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 
 export interface DatasetCommitProps {
   logItem: LogItem
@@ -22,20 +19,18 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
   active = false,
   isLink = true
 }) => {
+  // create a Dataset to pass into DatasetCommitInfo
+  const dataset = NewDataset({
+    username: logItem.username,
+    path: logItem.path,
+    commit: {
+      title: logItem.title,
+      timestamp: logItem.timestamp
+    }
+  })
+
   const content = (
-    <>
-      <div className='flex justify-between'>
-        <div className='font-medium mb-1 pr-2'>{logItem.title}</div>
-        <div className='flex-grow-0 text-qrigreen'>
-          <Icon icon='automationFilled' size='sm'/>
-        </div>
-      </div>
-      <div className='flex items-center text-qrigray-400'>
-        {logItem.username && <UsernameWithIcon username={logItem.username} iconWidth={14} className='mr-2' />}
-        <RelativeTimestampWithIcon timestamp={new Date(logItem.timestamp)} />
-      </div>
-      {/* TODO(chriswhong): restore when we can add component change indicators <ComponentChangeIndicatorGroup status={[2,1,2,3,4]} />*/}
-    </>
+    <DatasetCommitInfo dataset={dataset} small />
   )
 
   const containerClassNames = classNames('block rounded-md px-3 py-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-qrigray-400 border border-qrigray-300')
@@ -62,6 +57,5 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
   )
 
 }
-
 
 export default DatasetCommit

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -7,18 +7,16 @@ import { selectDsPreview } from './state/dsPreviewState'
 import { loadDsPreview } from './state/dsPreviewActions'
 import Spinner from '../../chrome/Spinner'
 import ContentBox from '../../chrome/ContentBox'
-import Icon from '../../chrome/Icon'
 import ContentBoxTitle from '../../chrome/ContentBoxTitle'
-import RelativeTimestampWithIcon from '../../chrome/RelativeTimestampWithIcon'
-import UsernameWithIcon from '../../chrome/UsernameWithIcon'
+
 import BodyPreview from '../dsComponents/body/BodyPreview'
 
 import DatasetScrollLayout from '../dataset/DatasetScrollLayout'
 import DeployingScreen from '../deploy/DeployingScreen'
-import commitishFromPath from '../../utils/commitishFromPath'
 import Readme from '../dsComponents/readme/Readme'
 import { QriRef } from '../../qri/ref'
 import MetaChips from '../../chrome/MetaChips'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 
 interface DatasetPreviewPageProps {
   qriRef: QriRef
@@ -69,15 +67,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                     <div className='flex items-center border-b pb-4 mb-3'>
                       <div className='flex-grow truncate'>
                         <ContentBoxTitle title='Latest Version' />
-                        <div className='text-qrinavy font-semibold text-sm flex items-center mb-2'>
-                          <div className=''>{dataset.commit?.title}</div>
-                        </div>
-                        <div className='flex items-center text-xs text-gray-400'>
-                          <UsernameWithIcon username={dataset.username} className='mr-3' />
-                          <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
-                          <Icon icon='commit' size='sm' className='-ml-2' />
-                          <div className=''>{commitishFromPath(dataset.path)}</div>
-                        </div>
+                        <DatasetCommitInfo dataset={dataset} />
                       </div>
                     </div>
                     {/* Bottom of the box */}


### PR DESCRIPTION
Builds on work in #279 which should be merged first

Adds a new component `DatasetCommitInfo`, providing a two-row layout with a commit's title, automation status, user, relative timestamp, and commit.

Some version of this commit summary layout was in place in preview, multiple places in history, and in the run log when a run results in a commit.  This standardizes the layout, ensuring that the commit info looks consistent across all of these locations in the app.

<img width="894" alt="Home___Qri_Cloud" src="https://user-images.githubusercontent.com/1833820/130858357-2afd61b6-1230-4f44-9be7-d1b81f2ceda7.png">
