### PR TITLE
fix: handle no ref on apply

### DIFF
--- a/src/features/workflow/state/workflowActions.ts
+++ b/src/features/workflow/state/workflowActions.ts
@@ -113,11 +113,11 @@ export function applyWorkflowTransform(w: Workflow, d: Dataset): ApiActionThunk 
         endpoint: 'auto/apply',
         method: 'POST',
         body: {
-          ref: `${qriRef.username}/${qriRef.name}`,
-          wait: true,
+          ref: (qriRef.username && qriRef.name) ? `${qriRef.username}/${qriRef.name}` : '',
+          wait: false,
           transform: {
             scriptBytes: btoa(workflowScriptString(w)),
-            steps: d.transform.steps
+            steps: d.transform?.steps
           }
         },
       }


### PR DESCRIPTION
- handles no `qriRef` in the `applyWorkflowTransform` restoring the ability to dry run
- adds `wait: false` to the `applyWorkflowTransform` api call so that the response comes back immediately and the step-based `RunStatus` indicators function properly