### PR TITLE
refactor: prevent unnecessary calls to /activity

### DIFF
--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { QriRef } from '../../qri/ref'
 import useDimensions from 'react-use-dimensions'
 
+import { QriRef } from '../../qri/ref'
 import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
@@ -10,6 +10,7 @@ import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 import { runNow } from '../workflow/state/workflowActions'
 import { selectLatestRun } from '../workflow/state/workflowState'
 import RunNowButton from './RunNowButton'
+import useDidMountEffect from '../../utils/useDidMountEffect'
 
 
 export interface DatasetActivityFeedProps {
@@ -26,12 +27,18 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
 
   const [tableContainer, { height: tableContainerHeight }] = useDimensions()
 
+  // TODO(chriswhong): we are already dispatching loadDatsetLogs() in DatasetWrapper
+  // because we need the same activity list for both the commit list and the run log
+  // once we have a top-level dataset metainfo response, this component will need
+  // to call for data on its own
+  // useEffect(() => {
+  //   dispatch(loadDatasetLogs(qriRef))
+  // },[dispatch, qriRef])
 
-  useEffect(() => {
-    dispatch(loadDatasetLogs(qriRef))
-  },[dispatch, qriRef])
 
-  useEffect(() => {
+  // useDidMountEffect behaves like useEffect but does not run on the first render
+  // this will fetch a new activitylist when latestRun.status changes, keeping the run log fresh
+  useDidMountEffect(() => {
     dispatch(loadDatasetLogs(qriRef))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   },[latestRun?.status])

--- a/src/utils/useDidMountEffect.tsx
+++ b/src/utils/useDidMountEffect.tsx
@@ -1,0 +1,15 @@
+// useDidMountEffect behaves like useEffect but does not run on the first render
+
+import { useEffect, useRef } from 'react'
+
+const useDidMountEffect = (func: () => void, deps: any[]) => {
+    const didMount = useRef(false)
+
+    useEffect(() => {
+      if (didMount.current) func()
+      else didMount.current = true
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps)
+}
+
+export default useDidMountEffect


### PR DESCRIPTION
Might conflict with #310, we must settle on which calls are happening where before proceeding.

- comments out the call to `/activity` in `DatasetActivityFeed`. This will come back into play once we figure out the top-level dataset metainfo call, at which time `DatasetActivityFeed` will need to fetch the run log on its own.  For now it happens in `DatasetWrapper`

- adds a react hook util `useDidMountEffect`, which behaves like `useEffect` but will not run on the first render.  This can be used to trigger a call to `/activity` when the current dataset has a change in status to its latest run, updating the run log.