### PR TITLE
refactor: extended versionInfo interface…

### DIFF
--- a/src/features/dataset/DatasetFixedLayout.tsx
+++ b/src/features/dataset/DatasetFixedLayout.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
 import { newQriRef } from '../../qri/ref'
-import { selectDsPreview } from '../dsPreview/state/dsPreviewState'
 import { selectSessionUser } from '../session/state/sessionState'
 import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
@@ -18,7 +17,6 @@ const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
   children
 }) => {
   const qriRef = newQriRef(useParams())
-  const dsPreview = useSelector(selectDsPreview)
   const user = useSelector(selectSessionUser)
   const editable = useSelector(selectSessionUserCanEditDataset)
   const isNew = (qriRef.username === 'new')
@@ -35,7 +33,7 @@ const DatasetFixedLayout: React.FC<DatasetFixedLayoutProps> = ({
   return (
     <>
         <div className='flex flex-col flex-grow overflow-hidden p-7'>
-          <DatasetHeader dataset={dsPreview} editable={editable}>
+          <DatasetHeader editable={editable}>
             {headerChildren}
           </DatasetHeader>
           {children}

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -18,8 +18,7 @@ import {
 
 import { selectNavExpanded } from '../app/state/appState'
 import { toggleNavExpanded } from '../app/state/appActions'
-import { selectVersionCount } from '../commits/state/commitState'
-import { selectLogCount } from '../activityFeed/state/activityFeedState'
+import { selectRunCount, selectCommitCount } from "./state/datasetState";
 
 export interface DatasetNavSidebarProps {
   qriRef: QriRef
@@ -27,8 +26,8 @@ export interface DatasetNavSidebarProps {
 
 const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
   const expanded = useSelector(selectNavExpanded)
-  const versionCount = useSelector(selectVersionCount(qriRef))
-  const logCount = useSelector(selectLogCount(qriRef))
+  const versionCount = useSelector(selectCommitCount)
+  const logCount = useSelector(selectRunCount)
   const dispatch = useDispatch()
 
   const toggleExpanded = () => {

--- a/src/features/dataset/DatasetRoutes.tsx
+++ b/src/features/dataset/DatasetRoutes.tsx
@@ -5,8 +5,9 @@
 
 // DatasetPreviewPage fetches the other necessary parts of the preview (body + readme)
 
-import React from 'react'
+import React, {useEffect} from 'react'
 import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router'
+import { useDispatch } from "react-redux";
 
 import WorkflowPage from '../workflow/WorkflowPage'
 import DatasetComponents from '../dsComponents/DatasetComponents'
@@ -16,6 +17,7 @@ import DatasetIssues from '../issues/DatasetIssues'
 import { newQriRef } from '../../qri/ref'
 import DatasetEditor from '../dsComponents/DatasetEditor'
 import DatasetWrapper from '../dsComponents/DatasetWrapper'
+import { loadHeader } from "./state/datasetActions";
 
 const DatasetRoutes: React.FC<{}> = () => {
   const { url } = useRouteMatch()
@@ -26,6 +28,11 @@ const DatasetRoutes: React.FC<{}> = () => {
   // ref. Move all ref constructino into container components to avoid potential
   // bugs
   const qriRef = newQriRef(useParams())
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(loadHeader(qriRef))
+  },[dispatch, qriRef.username, qriRef.name, qriRef.path]);
 
   return (
     <DatasetWrapper>

--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -56,7 +56,7 @@ const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
       </DatasetMiniHeader>
       <div className={classNames('p-7 w-full', contentClassName)}>
         <div ref={stickyHeaderTriggerRef}>
-          <DatasetHeader dataset={headerDataset} editable={editable} showInfo={!dataset}>
+          <DatasetHeader editable={editable} showInfo={!dataset}>
             {headerChildren}
           </DatasetHeader>
         </div>

--- a/src/features/dataset/state/datasetState.ts
+++ b/src/features/dataset/state/datasetState.ts
@@ -5,10 +5,19 @@ import Dataset, { NewDataset } from '../../../qri/dataset';
 import { qriRefFromString } from '../../../qri/ref';
 import { RenameDatasetAction } from './datasetActions';
 import { selectSessionUser } from '../../session/state/sessionState';
+import { newVersionInfo, VersionInfo } from "../../../qri/versionInfo";
 
 export const RENAME_NEW_DATASET = 'RENAME_NEW_DATASET'
 
+export const SET_HEADER = 'SET_HEADER'
+
 export const selectDataset = (state: RootState): Dataset => state.dataset.dataset
+
+export const selectDatasetHeader = (state: RootState): VersionInfo => state.dataset.header
+
+export const selectCommitCount = (state: RootState): number => state.dataset.header.commitCount
+
+export const selectRunCount = (state: RootState): number => state.dataset.header.runCount
 
 export const selectIsDatasetLoading = (state: RootState): boolean => state.dataset.loading
 
@@ -27,15 +36,27 @@ export const selectSessionUserCanEditDataset = (state: RootState): boolean => {
 
 export interface DatasetState {
   dataset: Dataset
+  // TODO(boandriy): header is currently a `VersionInfo`, but will have its own data structure in future iterations
+  header: VersionInfo
   loading: boolean
 }
 
 const initialState: DatasetState = {
   dataset: NewDataset({}),
+  header: newVersionInfo({}),
   loading: true
 }
 
 export const datasetReducer = createReducer(initialState, {
+  'API_HEADER_REQUEST': (state) => {
+    state.header = newVersionInfo({})
+  },
+  'API_HEADER_SUCCESS': (state, action) => {
+    state.header = newVersionInfo(action.payload.data)
+  },
+  SET_HEADER : (state, action) => {
+    state.header = action.payload
+  },
   'API_DATASET_REQUEST': (state) => {
     state.dataset = NewDataset({})
     state.loading = true

--- a/src/qri/versionInfo.ts
+++ b/src/qri/versionInfo.ts
@@ -36,6 +36,16 @@ export interface VersionInfo {
   runID?: string
   runStatus?: RunStatus
   runDuration?: number
+
+  // TODO (boandriy): These fields are only temporarily living on `VersionInfo`.
+  // When we get more user feedback and settle what info
+  // users want about their datasets, these fields may move to a new struct
+  // store, or subsystem.
+  runCount: number // RunCount is the number of times this dataset's transform has been run
+  commitCount: number // CommitCount is the number of commits in this dataset's history
+  downloadCount: number // DownloadCount is the number of times this dataset has been directly downloaded from this Qri node
+  followerCount: number // FollowerCount is the number of followers this dataset has on this Qri node
+  openIssueCount: number // OpenIssueCount is the number of open issues this dataset has on this Qri node
 }
 
 export function newVersionInfo(data: Record<string,any>): VersionInfo {
@@ -69,6 +79,15 @@ export function newVersionInfo(data: Record<string,any>): VersionInfo {
     runID: data.runID,
     runStatus: data.runStatus,
     runDuration: data.runDuration,
+
+    // TODO(boandriy): the following fields are likely to be removed from the VersionInfo
+    // type in the future
+    runCount: data.runCount || 0,
+    commitCount: data.commitCount || 0,
+    downloadCount: data.downloadCount || 0,
+    followerCount: data.followerCount || 0,
+    openIssueCount: data.openIssueCount || 0
+
   }
 }
 


### PR DESCRIPTION
replaced the dataset header/sidebar prop numbers with ones that come from BE.
extended the versionInfo interface to include : 
`RunCount,
  CommitCount,
  DownloadCount,
  FollowerCount,
  OpenIssueCount`