### PR TITLE
fix: filtering out toasts for dry runs

### DIFF
--- a/src/features/workflow/state/workflowState.ts
+++ b/src/features/workflow/state/workflowState.ts
@@ -46,7 +46,7 @@ export const selectRunsFromEventLog = (state: RootState): Run[] => {
   const { events } = state.workflow
   const unique = [...new Set(events.map(d => d.sessionID))]
   return unique.map((d) => {
-    return NewRunFromEventLog(d, events)
+    return NewRunFromEventLog(d, events.filter(e => e.data.mode !== 'apply'))
   })
 }
 


### PR DESCRIPTION
filtering out toasts for dry runs on workflow

fixes #257 