### PR TITLE
feat(Icon): add `Unlock` icon & use it in `DatasetHeader`

### DIFF
--- a/src/chrome/Icon.tsx
+++ b/src/chrome/Icon.tsx
@@ -1,3 +1,16 @@
+/*
+To add a new icon (from the Figma design board):
+
+- right click the 24 x 24 version of the icon from Figma, choose Copy > copy as SVG
+- duplicate an existing icon and name it to match the new icon
+- paste the SVG you copied in between the <CustomIcon> tags
+- Remove the opening and closing <svg> tags, leaving only the internal svg elements (<path>, etc)
+- Rename the component variables to match the icon's name
+- convert attributes to camelcase `stroke-linejoin` becomes `strokeLinejoin` to satisfy react/linting
+- In this file, add an import for the new icon, and add it to the `customIcons` object.  Keep things in alphabetical order.
+- You're ready to use the icon!  <Icon icon='mynewicon' />
+*/
+
 import React from 'react'
 
 import ActivityFeed from './icon/ActivityFeed'
@@ -56,6 +69,7 @@ import String from './icon/String'
 import Structure from './icon/Structure'
 import Tags from './icon/Tags'
 import Twitter from './icon/Twitter'
+import Unlock from './icon/Unlock'
 import Youtube from './icon/Youtube'
 
 interface IconProps {
@@ -132,6 +146,7 @@ const Icon: React.FunctionComponent<IconProps> = (props) => {
     structure: <Structure {...props} />,
     tags: <Tags {...props} />,
     twitter: <Twitter {...props} />,
+    unlock: <Unlock {...props} />,
     youtube: <Youtube {...props} />
   }
 

--- a/src/chrome/icon/Unlock.tsx
+++ b/src/chrome/icon/Unlock.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import CustomIcon, { CustomIconProps } from '../CustomIcon'
+
+const Unlock: React.FC<CustomIconProps> = (props) => (
+  <CustomIcon {...props}>
+<path d="M19 11H5C3.89543 11 3 11.8954 3 13V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V13C21 11.8954 20.1046 11 19 11Z" stroke="#1B3356" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+<path d="M7 11V7C6.99876 5.76005 7.45828 4.56387 8.28938 3.64367C9.12047 2.72347 10.2638 2.1449 11.4975 2.02029C12.7312 1.89568 13.9671 2.2339 14.9655 2.96931C15.9638 3.70472 16.6533 4.78485 16.9 6" stroke="#1B3356" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </CustomIcon>
+)
+
+export default Unlock
+

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -72,7 +72,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
               <DatasetInfoItem icon='disk' label={fileSize(header.bodySize || 0)} />
               <DatasetInfoItem icon='download' label={getLabel(header.downloadCount, 'download')} />
               <DatasetInfoItem icon='follower' label={getLabel(header.followerCount, 'follower')} />
-              <DatasetInfoItem icon='globe' label='public' />
+              <DatasetInfoItem icon='unlock' label='public' />
             </div>
           )}
         </div>


### PR DESCRIPTION
Also added instructions on how to import icons from the Figma board
to the `src/chrome/Icon.tsx` file