### PR TITLE
feat: Indicate that the user is viewing a body preview

### DIFF
--- a/src/features/dsComponents/body/BodyHeader.tsx
+++ b/src/features/dsComponents/body/BodyHeader.tsx
@@ -34,6 +34,13 @@ const BodyHeader: React.FC<BodyHeaderProps> = ({
         <div className='body_header_columns_text mr-4 flex items-center'>
           <Icon icon='columns' size='2xs' className='mr-1'/> {numeral(headers.length).format('0,0')} columns
         </div>
+        {/*
+          TODO (boandriy): Once the preview row count is filtered by fetch pagination -
+          use global filtering variable instead of hardcoded 100
+        */}
+        <div className={'mr-4'}>
+          Previewing 100 of {numeral(structure?.entries).format('0,0')} rows
+        </div>
       </div>
       {showDownload && <DownloadDatasetButton qriRef={qriRefFromDataset(dataset)} asIconLink body />}
       {showExpand && <IconLink icon='fullScreen' onClick={onToggleExpanded} />}


### PR DESCRIPTION
Added text to Body header to indicate that the user is viewing a body preview: 
![image](https://user-images.githubusercontent.com/22635911/133754996-624f2faf-f23e-464b-974e-d30a3dd56c36.png)


Fixes #282 