### PR TITLE
feat: added css rule to respect new lines in workflow cell outputs

### DIFF
--- a/src/features/workflow/output/LogLinePrint.tsx
+++ b/src/features/workflow/output/LogLinePrint.tsx
@@ -9,11 +9,11 @@ const LogLinePrint: React.FC<LogLineProps> = ({ line }) => {
   switch (line.type) {
     case EventLogLineType.ETPrint:
       // TODO (b5) - utilize line.data.lvl to set output colour
-     return <p className='log_line_print_text text-sm text-gray-500'>{line.data.msg}</p>
+     return <p className='log_line_print_text text-sm whitespace-pre text-gray-500'>{line.data.msg}</p>
     case EventLogLineType.ETError:
-     return <p className='text-sm text-dangerred'>{line.data.msg}</p>
+     return <p className='text-sm whitespace-pre text-dangerred'>{line.data.msg}</p>
     default:
-      return <p>{line.data.msg}</p>
+      return <p className='whitespace-pre'>{line.data.msg}</p>
   }
 }
 


### PR DESCRIPTION
added css rule to respect new lines in workflow cell outputs.

![image](https://user-images.githubusercontent.com/22635911/135293777-26581a50-1fe5-402e-9f38-756e0178da0c.png)

fixes #79 