### PR TITLE
refactor: moved events to its own state tree section from workflow state tree

### DIFF
--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -8,8 +8,9 @@ import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 import { runNow } from '../workflow/state/workflowActions'
-import { selectLatestRun } from '../workflow/state/workflowState'
+import { selectLatestRunId } from '../workflow/state/workflowState'
 import RunNowButton from './RunNowButton'
+import { selectRun } from "../events/state/eventsState";
 
 
 export interface DatasetActivityFeedProps {
@@ -21,7 +22,8 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
 }) => {
 
   const logs = useSelector(newDatasetLogsSelector(qriRef))
-  const latestRun = useSelector(selectLatestRun)
+  const latestRunId = useSelector(selectLatestRunId)
+  const latestRun = useSelector(selectRun(latestRunId))
   const dispatch = useDispatch()
 
   const [tableContainer, { height: tableContainerHeight }] = useDimensions()

--- a/src/features/events/state/eventsActions.ts
+++ b/src/features/events/state/eventsActions.ts
@@ -1,0 +1,31 @@
+import { EventLogLine } from "../../../qri/eventLog";
+
+import {
+  REMOVE_EVENT,
+  RUN_EVENT_LOG
+} from "./eventsState";
+
+export interface EventLogAction {
+  type: string
+  data: EventLogLine
+}
+
+export interface RemoveEventAction {
+  type: string
+  sessionID: string
+}
+
+export function runEventLog (event: EventLogLine): EventLogAction {
+  return {
+    type: RUN_EVENT_LOG,
+    data: event
+  }
+}
+
+export function removeEvent(sessionID: string): RemoveEventAction {
+  return {
+    type: REMOVE_EVENT,
+    sessionID: sessionID
+  }
+}
+

--- a/src/features/events/state/eventsState.ts
+++ b/src/features/events/state/eventsState.ts
@@ -1,0 +1,44 @@
+import { createReducer } from '@reduxjs/toolkit'
+
+import { EventLogLine } from "../../../qri/eventLog";
+import { NewRunFromEventLog, Run } from "../../../qri/run";
+import { RootState } from "../../../store/store";
+import { EventLogAction, RemoveEventAction } from "./eventsActions";
+
+export const RUN_EVENT_LOG = 'RUN_EVENT_LOG'
+export const REMOVE_EVENT = 'REMOVE_EVENT'
+
+export const selectRuns = (state: RootState): Run[] => {
+  const { events } = state.events
+  const unique = Array.from(new Set(events.map(d => d.sessionID)))
+  return unique.map((d) => {
+    return NewRunFromEventLog(d, events.filter(e => e.data.mode !== 'apply'))
+  })
+}
+
+export const selectRun = (sessionId: string): (state: RootState) =>  Run =>
+  (state:RootState) => NewRunFromEventLog(sessionId, state.events.events)
+
+export interface EventsState {
+  events: EventLogLine[]
+}
+
+const initialState: EventsState = {
+  events: [],
+}
+
+export const eventsReducer = createReducer(initialState, {
+  RUN_EVENT_LOG: addRunEvent,
+  REMOVE_EVENT: removeEvent,
+})
+
+
+function addRunEvent(state: EventsState, action: EventLogAction) {
+  state.events.push(action.data)
+  state.events.sort((a,b) => a.ts - b.ts)
+}
+
+function removeEvent(state: EventsState, action: RemoveEventAction) {
+  state.events = state.events.filter(e => e.sessionID !== action.sessionID)
+}
+

--- a/src/features/toast/ToastRenderer.tsx
+++ b/src/features/toast/ToastRenderer.tsx
@@ -4,14 +4,15 @@ import { ToastContainer, toast } from 'react-toastify'
 
 import { Run, RunStatus } from '../../qri/run'
 import Toast from './Toast'
-import { selectRunsFromEventLog } from '../workflow/state/workflowState'
+import { selectRuns } from '../events/state/eventsState'
 import { loadVersionInfo } from "../collection/state/collectionActions";
 
 import 'react-toastify/dist/ReactToastify.css'
+import {removeEvent} from "../events/state/eventsActions";
 
 const ToastRenderer: React.FC<{}> = () => {
 
-  const runs = useSelector(selectRunsFromEventLog)
+  const runs = useSelector(selectRuns)
   const dispatch = useDispatch()
   // use a ref to store the workflow status so we can
   // determine when it changes and update an already visible toast
@@ -46,6 +47,7 @@ const ToastRenderer: React.FC<{}> = () => {
           toast(<Toast message={'Running Workflow...'} initID={initID as string} type='running' />, {
             toastId: id,
             autoClose: false,
+            onClose: () => dispatch(removeEvent(id))
           })
         }
       break
@@ -61,7 +63,10 @@ const ToastRenderer: React.FC<{}> = () => {
                 <Toast message={'Success!'} initID={initID as string} type='succeeded' />
               ),
               autoClose: SUCCESS_CLOSE_DELAY,
-              onClose: () => {delete runsRef.current[id]}
+              onClose: () => {
+                delete runsRef.current[id]
+                dispatch(removeEvent(id))
+              }
             })
           }, SUCCESS_START_DELAY)
         }

--- a/src/features/websocket/middleware/websocket.ts
+++ b/src/features/websocket/middleware/websocket.ts
@@ -4,7 +4,7 @@ import { QriRef } from '../../../qri/ref'
 import { NewEventLogLine } from '../../../qri/eventLog'
 import { RootState } from '../../../store/store'
 import { trackVersionTransfer, completeVersionTransfer, removeVersionTransfer } from '../../transfer/state/transferActions'
-import { runEventLog } from '../../workflow/state/workflowActions'
+import { runEventLog } from '../../events/state/eventsActions'
 import { workflowCompleted, workflowStarted } from '../../collection/state/collectionActions'
 import {
   deployStarted,
@@ -198,7 +198,7 @@ const middleware = () => {
 
   const subscribe = (token: string) => {
     if (token === "") {
-      return 
+      return
     }
     if (socket === undefined) {
       return

--- a/src/features/workflow/CodeEditor.tsx
+++ b/src/features/workflow/CodeEditor.tsx
@@ -81,8 +81,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     }
   }, [theEditor])
 
-  const handleEditorDidMount = (editor: MonacoEditor['editor']) => {
-    editor?.addAction({
+  useEffect(() => {
+    theEditor?.addAction({
       id: "executeCurrentAndAdvance",
       label: "Execute Block and Advance",
       keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
@@ -90,9 +90,11 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       precondition: "editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible",
       run: () => {
         onRun()
-      },
-    });
+      }
+    })
+  }, [theEditor, onRun])
 
+  const handleEditorDidMount = (editor: MonacoEditor['editor']) => {
     setTheEditor(editor)
   }
 

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -12,13 +12,16 @@ import {
   selectWorkflow,
   selectWorkflowDataset,
   selectApplyStatus,
-  selectWorkflowIsDirty
+  selectWorkflowIsDirty,
+  selectLatestDryRunId,
+  selectLatestRunId
 } from './state/workflowState'
 import { platform } from '../../utils/platform'
 import Icon from "../../chrome/Icon";
 import DeployButton from "../deploy/DeployButton";
 import { newQriRef } from "../../qri/ref";
 import { useParams } from "react-router";
+import { removeEvent } from "../events/state/eventsActions";
 
 export interface RunBarProps {
  status: RunStatus
@@ -35,9 +38,19 @@ const RunBar: React.FC<RunBarProps> = ({
   const workflowDataset = useSelector(selectWorkflowDataset)
   const applyStatus = useSelector(selectApplyStatus)
   const isDirty = useSelector(selectWorkflowIsDirty)
+  const latestDryRunId = useSelector(selectLatestDryRunId)
+  const latestRunId = useSelector(selectLatestRunId)
   const qriRef = newQriRef(useParams())
 
+  const removeRunEvents = () => {
+    if (latestDryRunId)
+      dispatch(removeEvent(latestDryRunId))
+    if (latestRunId)
+      dispatch(removeEvent(latestRunId))
+  }
+
   const handleRun = () => {
+    removeRunEvents()
     if (onRun) { onRun() }
     if (runMode === 'apply') {
       dispatch(applyWorkflowTransform(workflow, workflowDataset))

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -6,7 +6,7 @@ import { Location } from 'history'
 
 import WorkflowOutline from './WorkflowOutline'
 import {
-  selectLatestDryRun,
+  selectLatestDryRunId,
   selectRunMode,
   selectWorkflow,
   selectWorkflowIsDirty,
@@ -19,6 +19,7 @@ import { QriRef } from '../../qri/ref'
 import WorkflowEditor from './WorkflowEditor'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
+import { selectRun } from "../events/state/eventsState";
 
 interface WorkflowLocationState {
   template: string
@@ -34,7 +35,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
   const location = useLocation<WorkflowLocationState>()
   const workflow = useSelector(selectWorkflow)
   const workflowDataset = useSelector(selectWorkflowDataset)
-  const latestRun = useSelector(selectLatestDryRun)
+  const latestRun = useSelector(selectRun(useSelector(selectLatestDryRunId)))
   const runMode = useSelector(selectRunMode)
   const isDirty = useSelector(selectWorkflowIsDirty)
 

--- a/src/features/workflow/WorkflowCell.tsx
+++ b/src/features/workflow/WorkflowCell.tsx
@@ -65,7 +65,7 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
           <button className='text-xs border-none flex-shrink-0 bg-white rounded py-1 pr-2 pl-1 font-semibold '>+ Code</button>
         </div>
       </div>
-      <WorkflowCellControls index={index} setAnimatedCell={setAnimatedCell} />
+      <WorkflowCellControls index={index} sessionId={run ? run.id : ''} setAnimatedCell={setAnimatedCell} />
     </div>
   )
 }

--- a/src/features/workflow/WorkflowCellControls.tsx
+++ b/src/features/workflow/WorkflowCellControls.tsx
@@ -2,23 +2,25 @@ import React from "react";
 import { useDispatch } from "react-redux";
 
 import {
-  clearOutputWorkflowTransformStep,
   duplicateWorkflowTransformStep,
   moveWorkflowTransformStepDown,
   moveWorkflowTransformStepUp,
   removeWorkflowTransformStep
 } from './state/workflowActions';
 import WorkflowCellControlButton from "./WorkflowCellControlButton";
+import { removeEvent } from "../events/state/eventsActions";
 
 
 interface WorkflowCellControlsProps {
   index: number
   setAnimatedCell: (i:number) => void
+  sessionId: string
 }
 
 const WorkflowCellControls: React.FC<WorkflowCellControlsProps> = ({
   index,
-  setAnimatedCell
+  setAnimatedCell,
+  sessionId
 }) => {
   const dispatch = useDispatch()
 
@@ -32,12 +34,17 @@ const WorkflowCellControls: React.FC<WorkflowCellControlsProps> = ({
     dispatch(duplicateWorkflowTransformStep(index))
   }
 
+  const onOutputClear = () => {
+    if (sessionId)
+      dispatch(removeEvent(sessionId))
+  }
+
   return (
     <div className={'group-hover:opacity-100 flex-grow-0 w-48 ml-8 opacity-0 transition-opacity relative'}>
       <div className={'flex flex-col bg-white w-48 rounded-md absolute p-5 pt-2.5'}>
         <WorkflowCellControlButton onClick={onDelete} label='Delete' icon='trashBin'/>
         <WorkflowCellControlButton onClick={onDuplicate} label='Duplicate block' icon='duplicate'/>
-        <WorkflowCellControlButton onClick={() => { dispatch(clearOutputWorkflowTransformStep(index)) }} label='Clean output' icon='circleX'/>
+        <WorkflowCellControlButton onClick={onOutputClear} label='Clean output' icon='circleX'/>
         <WorkflowCellControlButton onClick={() => { dispatch(moveWorkflowTransformStepUp(index)) }} label='Move block up' icon='upArrow'/>
         <WorkflowCellControlButton onClick={() => { dispatch(moveWorkflowTransformStepDown(index)) }} flipIcon label='Move block down' icon='upArrow' />
       </div>

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -5,12 +5,13 @@ import { useSelector, useDispatch } from 'react-redux'
 import Spinner from '../../chrome/Spinner'
 import { selectWorkflowDataset } from '../workflow/state/workflowState'
 import { setWorkflowRef } from './state/workflowActions'
-import { selectLatestDryRun } from './state/workflowState'
+import { selectLatestDryRunId } from './state/workflowState'
 import { QriRef } from '../../qri/ref'
 import { NewDataset } from '../../qri/dataset'
 import Workflow from './Workflow'
 import RunBar from './RunBar'
 import DatasetScrollLayout from '../dataset/DatasetScrollLayout'
+import { selectRun } from "../events/state/eventsState";
 
 interface WorkflowPageProps {
   qriRef: QriRef
@@ -19,7 +20,8 @@ interface WorkflowPageProps {
 const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
   const dispatch = useDispatch()
   let dataset = useSelector(selectWorkflowDataset)
-  const latestRun = useSelector(selectLatestDryRun)
+  const latestDryRunId = useSelector(selectLatestDryRunId)
+  const latestRun = useSelector(selectRun(latestDryRunId))
   let { username, name } = useParams()
 
   // if qriRef is empty, this is a new workflow

--- a/src/features/workflow/modal/DeployModal.tsx
+++ b/src/features/workflow/modal/DeployModal.tsx
@@ -12,18 +12,27 @@ import TextInput from '../../../chrome/forms/TextInput'
 import Checkbox from '../../../chrome/forms/Checkbox'
 import { deployWorkflow } from '../../deploy/state/deployActions'
 import { setWorkflowRef } from '../state/workflowActions'
-import { selectWorkflow, selectWorkflowQriRef, selectWorkflowDataset } from '../state/workflowState'
+import {
+  selectWorkflow,
+  selectWorkflowQriRef,
+  selectWorkflowDataset,
+  selectLatestDryRunId,
+  selectLatestRunId
+} from '../state/workflowState'
 import { validateDatasetName } from '../../session/state/formValidation'
 import RunStatusIcon from '../../run/RunStatusIcon'
 import { selectDeployStatus } from '../../deploy/state/deployState'
 import { selectSessionUser } from '../../session/state/sessionState'
 import WarningDialog from '../WarningDialog'
+import { removeEvent } from "../../events/state/eventsActions";
 
 
 
 
 const DeployModal: React.FC = () => {
   const dispatch = useDispatch()
+  const latestDryRunId = useSelector(selectLatestDryRunId)
+  const latestRunId = useSelector(selectLatestRunId)
   const history = useHistory()
 
   const qriRef = useSelector(selectWorkflowQriRef)
@@ -84,6 +93,12 @@ const DeployModal: React.FC = () => {
 
   const handleDeployClick = () => {
     setDeploying(true)
+    if (latestDryRunId) {
+      dispatch(removeEvent(latestDryRunId))
+    }
+    if (latestRunId) {
+      dispatch(removeEvent(latestRunId))
+    }
     dispatch(setModalLocked(true))
     dispatch(deployWorkflow(qriRef, workflow, dataset, runNow))
   }

--- a/src/features/workflow/state/workflowActions.ts
+++ b/src/features/workflow/state/workflowActions.ts
@@ -6,7 +6,6 @@ import {
   WORKFLOW_CHANGE_TRIGGER,
   WORKFLOW_DELETE_TRIGGER,
   WORKFLOW_CHANGE_TRANSFORM_STEP,
-  RUN_EVENT_LOG,
   TEMP_SET_WORKFLOW_EVENTS,
   SET_TEMPLATE,
   SET_WORKFLOW,
@@ -16,7 +15,6 @@ import {
   WORKFLOW_ADD_TRANSFORM_STEP,
   WORKFLOW_REMOVE_TRANSFORM_STEP,
   WORKFLOW_DUPLICATE_TRANSFORM_STEP,
-  WORKFLOW_CLEAR_OUTPUT_TRANSFORM_STEP,
   WORKFLOW_MOVE_TRANSFORM_STEP_UP,
   WORKFLOW_MOVE_TRANSFORM_STEP_DOWN,
   WORKFLOW_UNDO_CHANGES
@@ -121,13 +119,6 @@ export function duplicateWorkflowTransformStep (index: number): WorkflowStepActi
   }
 }
 
-export function clearOutputWorkflowTransformStep (index: number): WorkflowStepAction {
-  return {
-    type: WORKFLOW_CLEAR_OUTPUT_TRANSFORM_STEP,
-    index
-  }
-}
-
 export function moveWorkflowTransformStepUp (index: number): WorkflowStepAction {
   return {
     type: WORKFLOW_MOVE_TRANSFORM_STEP_UP,
@@ -196,17 +187,7 @@ export function applyWorkflowTransform (w: Workflow, d: Dataset): ApiActionThunk
   }
 }
 
-export interface EventLogAction {
-  type: string
-  data: EventLogLine
-}
 
-export function runEventLog (event: EventLogLine): EventLogAction {
-  return {
-    type: RUN_EVENT_LOG,
-    data: event
-  }
-}
 
 export interface SetWorkflowAction {
   type: string

--- a/src/qri/run.ts
+++ b/src/qri/run.ts
@@ -34,6 +34,7 @@ export function NewRunFromEventLog(runID: string, log: EventLogLine[]): Run {
 }
 
 export interface RunStep {
+  id: string
   name: string
   category: string
   status: RunStatus
@@ -45,6 +46,7 @@ export interface RunStep {
 
 export function NewRunStep(data: Record<string, any>): RunStep {
   return {
+    id: data.sessionID,
     name: data.name,
     category: data.category,
     status: data.status,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,6 +21,7 @@ import { commitsReducer, CommitsState } from '../features/commits/state/commitSt
 import { datasetEditsReducer, DatasetEditsState } from '../features/dataset/state/editDatasetState';
 import { WebsocketState, websocketReducer } from '../features/websocket/state/websocketState';
 import { UserProfileState, userProfileReducer } from '../features/userProfile/state/userProfileState'
+import { eventsReducer, EventsState } from "../features/events/state/eventsState";
 
 export const history = createBrowserHistory()
 
@@ -40,6 +41,7 @@ export interface RootState {
   userProfile: UserProfileState
   workflow: WorkflowState
   edits: DatasetEditsState
+  events: EventsState
   websocket: WebsocketState
 }
 
@@ -62,6 +64,7 @@ const rootReducer = (h: History) => combineReducers({
   userProfile: userProfileReducer,
   workflow: workflowReducer,
   edits: datasetEditsReducer,
+  events: eventsReducer,
   websocket: websocketReducer
 })
 


### PR DESCRIPTION
moved events to its own state tree section from workflow as not all events are tied to the workflow. 

closes #350 