### PR TITLE
fix: added logic to hide the output and status of each cell/outline on edit while remaining the events list intact

### DIFF
--- a/src/features/workflow/CodeEditor.tsx
+++ b/src/features/workflow/CodeEditor.tsx
@@ -10,7 +10,7 @@ export interface CodeEditorProps {
   // determines whether the Component should render with rounded corners on the bottom
   standalone?: boolean
   onChange: (newValue: string) => void
-  hasOutput: boolean;
+  isEdited: boolean
   onRun?: () => void
   status?: RunStatus
 }
@@ -42,8 +42,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   onChange,
   onRun = () => {},
   disabled,
-  hasOutput,
-  status
+  status,
+  isEdited
 }) => {
   const ref = useRef<MonacoEditor>(null)
 
@@ -106,16 +106,21 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     window.addEventListener('resize', handleResize);
   });
 
-  let borderStyles = '';
-  if(status === 'succeeded') {
-    borderStyles = `border-qrigreen border-2 border-solid ${hasOutput && 'border-b-0'}`
-  }else if(status === 'running'){
-    borderStyles = 'border-qrinavy-700 border-2 border-solid border-b-0 -mb-1'
-  }else if(status === 'failed'){
-    borderStyles = `border-dangerred border-2 border-solid ${hasOutput && 'border-b-0'}`
-  }else{
-    borderStyles = 'border-transparent hover:border-qritile border-2 border-solid'
+  let borderStyles
+  if (!isEdited) {
+    if (status === 'succeeded') {
+      borderStyles = `border-qrigreen border-2 border-solid ${!standalone && 'border-b-0'}`
+    } else if (status === 'running') {
+      borderStyles = 'border-qrinavy-700 border-2 border-solid border-b-0 -mb-1'
+    } else if (status === 'failed') {
+      borderStyles = `border-dangerred border-2 border-solid ${!standalone && 'border-b-0'}`
+    } else {
+      borderStyles = 'border-transparent hover:border-qritile border-2 border-solid'
+    }
+  } else {
+    borderStyles = `border-transparent group-hover:border-qritile border-2 border-solid ${!standalone && isEdited && 'border-b-0'}`
   }
+
 
   return (
     <div className={classNames(`rounded-t-lg overflow-hidden flex-grow transition-all ${borderStyles}`, {

--- a/src/features/workflow/CodeEditor.tsx
+++ b/src/features/workflow/CodeEditor.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react'
 import MonacoEditor, { EditorConstructionOptions } from 'react-monaco-editor'
 import { KeyMod, KeyCode } from "monaco-editor/esm/vs/editor/editor.api";
-import classNames from 'classnames'
 import { RunStatus } from "../../qri/run";
 
 export interface CodeEditorProps {
+  active: boolean
   script: string
   disabled?: boolean
   // determines whether the Component should render with rounded corners on the bottom
@@ -15,7 +15,7 @@ export interface CodeEditorProps {
   status?: RunStatus
 }
 
-const LINE_HEIGHT = 19
+const LINE_HEIGHT = 21
 const MIN_LINE_COUNT = 4
 const PADDING = 15
 
@@ -38,12 +38,9 @@ export const MONACO_EDITOR_OPTIONS: EditorConstructionOptions = {
 
 const CodeEditor: React.FC<CodeEditorProps> = ({
   script,
-  standalone = true,
   onChange,
   onRun = () => {},
   disabled,
-  status,
-  isEdited
 }) => {
   const ref = useRef<MonacoEditor>(null)
 
@@ -106,44 +103,24 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
     window.addEventListener('resize', handleResize);
   });
 
-  let borderStyles
-  if (!isEdited) {
-    if (status === 'succeeded') {
-      borderStyles = `border-qrigreen border-2 border-solid ${!standalone && 'border-b-0'}`
-    } else if (status === 'running') {
-      borderStyles = 'border-qrinavy-700 border-2 border-solid border-b-0 -mb-1'
-    } else if (status === 'failed') {
-      borderStyles = `border-dangerred border-2 border-solid ${!standalone && 'border-b-0'}`
-    } else {
-      borderStyles = 'border-transparent hover:border-qritile border-2 border-solid'
-    }
-  } else {
-    borderStyles = `border-transparent group-hover:border-qritile border-2 border-solid ${!standalone && isEdited && 'border-b-0'}`
-  }
-
-
   return (
-    <div className={classNames(`rounded-t-lg overflow-hidden flex-grow transition-all ${borderStyles}`, {
-      'rounded-b-lg': standalone
-    })}>
-      <MonacoEditor
-        ref={ref}
-        height={(lineCount * LINE_HEIGHT) + PADDING}
-        value={script as any as string}
-        onChange={(script: string) => {
-          onChange(script)
+    <MonacoEditor
+      ref={ref}
+      height={(lineCount * LINE_HEIGHT) + PADDING}
+      value={script as any as string}
+      onChange={(script: string) => {
+        onChange(script)
 
-          if (ref) {
-            handleSetLineCount(ref.current?.editor?.getModel()?.getLineCount() || 4)
-          }
-        }}
-        language='python'
-        theme='qri-theme'
-        options={{...MONACO_EDITOR_OPTIONS, readOnly: disabled}}
-        editorDidMount={handleEditorDidMount}
-        editorWillMount={handleEditorWillMount}
-      />
-    </div>
+        if (ref) {
+          handleSetLineCount(ref.current?.editor?.getModel()?.getLineCount() || 4)
+        }
+      }}
+      language='python'
+      theme='qri-theme'
+      options={{...MONACO_EDITOR_OPTIONS, readOnly: disabled}}
+      editorDidMount={handleEditorDidMount}
+      editorWillMount={handleEditorWillMount}
+    />
   )
 }
 

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -14,7 +14,8 @@ import {
   selectApplyStatus,
   selectWorkflowIsDirty,
   selectLatestDryRunId,
-  selectLatestRunId
+  selectLatestRunId,
+  selectEditedCells
 } from './state/workflowState'
 import { platform } from '../../utils/platform'
 import Icon from "../../chrome/Icon";
@@ -41,6 +42,7 @@ const RunBar: React.FC<RunBarProps> = ({
   const latestDryRunId = useSelector(selectLatestDryRunId)
   const latestRunId = useSelector(selectLatestRunId)
   const qriRef = newQriRef(useParams())
+  const areCellsEdited = useSelector(selectEditedCells)
 
   const removeRunEvents = () => {
     if (latestDryRunId)
@@ -78,7 +80,7 @@ const RunBar: React.FC<RunBarProps> = ({
       <div className='flex w-64 items-center'>
         <div className='mr-4'>
           <div className='inline-block align-middle'>
-            <RunStatusIcon status={displayStatus} size='md' className='ml-2' />
+            <RunStatusIcon status={areCellsEdited.includes(true) ? 'waiting' : displayStatus} size='md' className='ml-2' />
           </div>
         </div>
         <div className='w-36'>

--- a/src/features/workflow/WorkflowCell.tsx
+++ b/src/features/workflow/WorkflowCell.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import classNames from 'classnames'
 import { RunStep } from '../../qri/run'
 import { TransformStep } from '../../qri/dataset'
 import CodeEditor from './CodeEditor'
@@ -10,6 +11,7 @@ import { useSelector } from "react-redux";
 import { selectClearedCells, selectEditedCells } from "./state/workflowState";
 
 export interface WorkflowCellProps {
+  active: boolean
   index: number
   step: TransformStep
   run?: RunStep
@@ -21,9 +23,11 @@ export interface WorkflowCellProps {
   setAnimatedCell: (i: number) => void
   isCellAdded: boolean
   onRowAdd: (index: number, syntax: string) => void
+  onClick: () => void
 }
 
 const WorkflowCell: React.FC<WorkflowCellProps> = ({
+  active = false,
   index,
   step,
   run,
@@ -33,16 +37,21 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
   onRowAdd,
   onRun,
   isCellAdded,
-  setAnimatedCell
+  setAnimatedCell,
+  onClick
 }) => {
   const { syntax, name, script } = step
   const editedCells = useSelector(selectEditedCells)
   const clearedCells = useSelector(selectClearedCells)
 
+  const status = run?.status
+  const isEdited = editedCells[index]
+
   let editor: React.ReactElement
   switch (syntax) {
     case 'starlark':
       editor = <CodeEditor
+        active={active}
         isEdited={editedCells[index]}
         status={run?.status}
         script={script}
@@ -61,16 +70,49 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
       editor = <p>unknown editor for '{syntax}' workflow step</p>
   }
 
+  const noColorStatus = !['succeeded', 'running', 'failed'].includes(status)
+
+  let borderStyles
+  if (!isEdited) {
+    if (status === 'succeeded') {
+      borderStyles = 'border-qrigreen'
+    } else if (status === 'running') {
+      borderStyles = 'border-qrinavy-700 -mb-1'
+    } else if (status === 'failed') {
+      borderStyles = 'border-dangerred'
+    } else if (active) {
+      borderStyles = 'border-qritile'
+    } else {
+      borderStyles = 'border-transparent'
+    }
+  } else {
+    borderStyles = 'border-qritile'
+  }
+
   return (
-    <div id={`${name}-cell`} className={`w-full workflow-cell flex ${isCellAdded && 'animate-appear'}`}>
+    <div id={`${name}-cell`} className={`w-full workflow-cell flex ${isCellAdded && 'animate-appear'}`} onClick={onClick}>
       <div className='flex-grow min-w-0'>
         <ScrollAnchor id={name} />
-        <div className='group'>
-          {(collapseState === 'all' || collapseState === 'only-editor') && editor}
-          {(collapseState === 'all' || collapseState === 'only-output') && (run?.output || run?.status === 'running') &&
-          !clearedCells[index] &&
-          <Output data={run?.output} status={run?.status} wasEdited={editedCells[index]} />}
-        </div>
+          <div
+            className={classNames(`border rounded-lg ${active && borderStyles}`, {
+              'border-transparent': !active
+            })}
+            style={{
+              borderRadius: '0.58rem'
+            }}
+          >
+            {/* ^^ this wrapping div allows us to use two different borders.  Active cell shows both, allowing for a thicker border without causing content to shift*/}
+            <div
+              className={classNames(`rounded-lg overflow-hidden flex-grow border box-content ${borderStyles}`, {
+                'border-transparent hover:border-qrigray-200': !active && (noColorStatus)
+              })}
+            >
+              {(collapseState === 'all' || collapseState === 'only-editor') && editor}
+              {(collapseState === 'all' || collapseState === 'only-output') && (run?.output || run?.status === 'running') &&
+              !clearedCells[index] &&
+              <Output data={run?.output} status={run?.status} wasEdited={editedCells[index]} />}
+            </div>
+          </div>
         <div
           onClick={() => onRowAdd(index, 'starlark')}
           className='mt-2 mb-2 cursor-pointer opacity-0 hover:opacity-100 transition-opacity flex items-center'
@@ -79,7 +121,12 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
           <button className='text-xs border-none flex-shrink-0 bg-white rounded py-1 pr-2 pl-1 font-semibold '>+ Code</button>
         </div>
       </div>
-      <WorkflowCellControls index={index} sessionId={run ? run.id : ''} setAnimatedCell={setAnimatedCell} />
+      <WorkflowCellControls
+        index={index}
+        sessionId={run ? run.id : ''}
+        setAnimatedCell={setAnimatedCell}
+        hide={!active}
+      />
     </div>
   )
 }

--- a/src/features/workflow/WorkflowCell.tsx
+++ b/src/features/workflow/WorkflowCell.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useSelector } from "react-redux";
+
 import classNames from 'classnames'
 import { RunStep } from '../../qri/run'
 import { TransformStep } from '../../qri/dataset'
@@ -7,7 +9,6 @@ import Output from './output/Output'
 import ScrollAnchor from '../scroller/ScrollAnchor'
 import WorkflowHeader from './WorkflowHeader'
 import WorkflowCellControls from './WorkflowCellControls'
-import { useSelector } from "react-redux";
 import { selectClearedCells, selectEditedCells } from "./state/workflowState";
 
 export interface WorkflowCellProps {

--- a/src/features/workflow/WorkflowCellControls.tsx
+++ b/src/features/workflow/WorkflowCellControls.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { useDispatch } from "react-redux";
 
 import {
+  clearWorkflowTransformStepOutput,
   duplicateWorkflowTransformStep,
   moveWorkflowTransformStepDown,
   moveWorkflowTransformStepUp,
   removeWorkflowTransformStep
 } from './state/workflowActions';
 import WorkflowCellControlButton from "./WorkflowCellControlButton";
-import { removeEvent } from "../events/state/eventsActions";
 
 
 interface WorkflowCellControlsProps {
@@ -33,18 +33,13 @@ const WorkflowCellControls: React.FC<WorkflowCellControlsProps> = ({
     setAnimatedCell(index+1)
     dispatch(duplicateWorkflowTransformStep(index))
   }
-
-  const onOutputClear = () => {
-    if (sessionId)
-      dispatch(removeEvent(sessionId))
-  }
-
+  
   return (
-    <div className={'group-hover:opacity-100 flex-grow-0 flex-shrink-0 w-48 ml-8 opacity-0 transition-opacity relative'}>
-      <div className={'flex flex-col bg-white w-48 rounded-md absolute p-5 pt-2.5'}>
+    <div className='workflow-cell-hover:opacity-100 flex-grow-0 flex-shrink-0 w-48 ml-8 opacity-0 transition-opacity relative'>
+      <div className='flex flex-col bg-white w-48 rounded-md absolute p-5 pt-2.5'>
         <WorkflowCellControlButton onClick={onDelete} label='Delete' icon='trashBin'/>
         <WorkflowCellControlButton onClick={onDuplicate} label='Duplicate block' icon='duplicate'/>
-        <WorkflowCellControlButton onClick={onOutputClear} label='Clean output' icon='circleX'/>
+        <WorkflowCellControlButton onClick={() => { dispatch(clearWorkflowTransformStepOutput(index)) }} label='Clean output' icon='circleX'/>
         <WorkflowCellControlButton onClick={() => { dispatch(moveWorkflowTransformStepUp(index)) }} label='Move block up' icon='upArrow'/>
         <WorkflowCellControlButton onClick={() => { dispatch(moveWorkflowTransformStepDown(index)) }} flipIcon label='Move block down' icon='upArrow' />
       </div>

--- a/src/features/workflow/WorkflowCellControls.tsx
+++ b/src/features/workflow/WorkflowCellControls.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { useDispatch } from "react-redux";
+import React from "react"
+import classNames from 'classnames'
+import { useDispatch } from "react-redux"
 
 import {
   clearWorkflowTransformStepOutput,
@@ -15,12 +16,14 @@ interface WorkflowCellControlsProps {
   index: number
   setAnimatedCell: (i:number) => void
   sessionId: string
+  hide: boolean
 }
 
 const WorkflowCellControls: React.FC<WorkflowCellControlsProps> = ({
   index,
   setAnimatedCell,
-  sessionId
+  sessionId,
+  hide=false
 }) => {
   const dispatch = useDispatch()
 
@@ -33,10 +36,12 @@ const WorkflowCellControls: React.FC<WorkflowCellControlsProps> = ({
     setAnimatedCell(index+1)
     dispatch(duplicateWorkflowTransformStep(index))
   }
-  
+
   return (
-    <div className='workflow-cell-hover:opacity-100 flex-grow-0 flex-shrink-0 w-48 ml-8 opacity-0 transition-opacity relative'>
-      <div className='flex flex-col bg-white w-48 rounded-md absolute p-5 pt-2.5'>
+    <div className={classNames('flex-grow-0 w-48 ml-8 relative pb-11', {
+      'opacity-0': hide
+    })}>
+      <div className='flex flex-col bg-white w-48 rounded-md absolute p-5 pt-2.5 sticky top-20'>
         <WorkflowCellControlButton onClick={onDelete} label='Delete' icon='trashBin'/>
         <WorkflowCellControlButton onClick={onDuplicate} label='Duplicate block' icon='duplicate'/>
         <WorkflowCellControlButton onClick={() => { dispatch(clearWorkflowTransformStepOutput(index)) }} label='Clean output' icon='circleX'/>

--- a/src/features/workflow/WorkflowCellsStatus.tsx
+++ b/src/features/workflow/WorkflowCellsStatus.tsx
@@ -4,6 +4,8 @@ import { NewRunStep, Run } from "../../qri/run";
 import Dataset, { TransformStep } from "../../qri/dataset";
 import Icon from "../../chrome/Icon";
 import RunStatusIcon from "../run/RunStatusIcon";
+import { useSelector } from "react-redux";
+import { selectEditedCells } from "./state/workflowState";
 
 interface WorkflowCellsStatusProps {
   run?: Run
@@ -14,6 +16,7 @@ const WorkflowCellsStatus: React.FC<WorkflowCellsStatusProps> = ({
  run,
  dataset
 }) => {
+  const editedCells = useSelector(selectEditedCells)
 
   return (
     <div className='mb-1'>
@@ -27,7 +30,7 @@ const WorkflowCellsStatus: React.FC<WorkflowCellsStatusProps> = ({
             <div className='bg-white rounded-md px-2 w-20 h-6 flex items-center'>
               <Icon size='2xs' icon='code'/>
             </div>
-            {r && r.status && <RunStatusIcon status={r.status} />}
+            {r && r.status && <RunStatusIcon status={!editedCells[i] ? r.status : 'waiting'} />}
           </div>
         )
       })}

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -39,6 +39,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const latestDryRunId = useSelector(selectLatestDryRunId)
   const latestRunId = useSelector(selectLatestRunId)
 
+  const [activeCell, setActiveCell] = useState<number>(-1)
   const [addedCell, setAddedCell] = useState<number>(-1)
   const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
   const collapseState = (stepName: string, run?: RunStep): "all" | "collapsed" | "only-editor" | "only-output" => {
@@ -138,6 +139,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                 }
                 return (
                   <WorkflowCell
+                    active={activeCell === i}
                     disabled={run?.status === 'running'}
                     key={step.category}
                     index={i}
@@ -158,6 +160,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                         dispatch(changeWorkflowTransformStep(i, script))
                       }
                     }}
+                    onClick={() => { setActiveCell(i) }}
                   />
                 )
               })}

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -9,6 +9,8 @@ import RunStatusIcon from '../run/RunStatusIcon'
 import DeployStatusIndicator from '../deploy/DeployStatusIndicator'
 import WorkflowScriptStatus from './WorkflowScriptStatus'
 import WorkflowCellsStatus from "./WorkflowCellsStatus";
+import { useSelector } from "react-redux";
+import { selectEditedCells } from "./state/workflowState";
 
 export interface WorkflowOutlineProps {
   workflow?: Workflow
@@ -21,6 +23,8 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
   run,
   dataset
 }) => {
+  const areCellsEdited = useSelector(selectEditedCells)
+
   const [showing, setShowing] = useState(true)
   if (!showing) {
     return (
@@ -44,7 +48,9 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
           <div className='mb-2'>
             <ScrollTrigger target='script'>
               <div className='font-bold text-black mb-2' style={{ fontSize: 13 }}>
-                Script {run && <div className='float-right'><RunStatusIcon status={run.status} /></div>}
+                Script {run && <div className='float-right'>
+                <RunStatusIcon status={areCellsEdited.includes(true) ? 'waiting' : run.status} />
+                </div>}
               </div>
             </ScrollTrigger>
           </div>

--- a/src/features/workflow/output/Output.tsx
+++ b/src/features/workflow/output/Output.tsx
@@ -35,7 +35,7 @@ const Output: React.FC<OutputProps> = ({ data, status, wasEdited }) => {
       }}>
         <RunStatusIcon status={status} size='2xs' />
       </div>}
-      <div className={classNames('max-h-96 overflow-auto output font-mono px-5 py-4 rounded-sm overflow-x-hidden border-2 rounded-b-md bg-white', borderColorClass)}>
+      <div className={classNames('max-h-96 overflow-auto output font-mono px-5 py-4 rounded-sm overflow-x-hidden border-t rounded-b-md bg-white', borderColorClass)}>
         {data && data.map((line, i) => {
           switch (line.type) {
             case EventLogLineType.ETPrint:

--- a/src/features/workflow/output/Output.tsx
+++ b/src/features/workflow/output/Output.tsx
@@ -11,12 +11,15 @@ import { RunStatus } from '../../../qri/run'
 export interface OutputProps {
   data?: EventLogLine[]
   status?: RunStatus
+  wasEdited: boolean
 }
 
-const Output: React.FC<OutputProps> = ({ data, status }) => {
+const Output: React.FC<OutputProps> = ({ data, status, wasEdited }) => {
   let borderColorClass = 'border-qrigreen'
 
-  if (status === 'failed') {
+  if (wasEdited) {
+    borderColorClass = 'group-hover:border-qritile'
+  } else if (status === 'failed') {
     borderColorClass = 'border-dangerred'
   } else if(status === 'running') {
     borderColorClass = 'border-qrinavy-700'
@@ -24,14 +27,14 @@ const Output: React.FC<OutputProps> = ({ data, status }) => {
 
   return (
     <div className='relative'>
-      <div className='rounded-xl absolute bg-white inline-block flex items-center justify-center' style={{
+      {!wasEdited && <div className='rounded-xl absolute bg-white inline-block flex items-center justify-center' style={{
         top: -8,
         left: 10,
         height: 18,
         width: 18
       }}>
         <RunStatusIcon status={status} size='2xs' />
-      </div>
+      </div>}
       <div className={classNames('max-h-96 overflow-auto output font-mono px-5 py-4 rounded-sm overflow-x-hidden border-2 rounded-b-md bg-white', borderColorClass)}>
         {data && data.map((line, i) => {
           switch (line.type) {

--- a/src/features/workflow/state/workflowActions.ts
+++ b/src/features/workflow/state/workflowActions.ts
@@ -17,7 +17,8 @@ import {
   WORKFLOW_DUPLICATE_TRANSFORM_STEP,
   WORKFLOW_MOVE_TRANSFORM_STEP_UP,
   WORKFLOW_MOVE_TRANSFORM_STEP_DOWN,
-  WORKFLOW_UNDO_CHANGES
+  WORKFLOW_UNDO_CHANGES,
+  WORKFLOW_CLEAR_TRANSFORM_STEP_OUTPUT
 } from './workflowState'
 import { AnyAction } from 'redux'
 import { Dataset, qriRefFromDataset } from '../../../qri/dataset'
@@ -94,6 +95,13 @@ export function changeWorkflowTransformStep (index: number, script: string): Set
     type: WORKFLOW_CHANGE_TRANSFORM_STEP,
     index,
     script
+  }
+}
+
+export function clearWorkflowTransformStepOutput (index: number): WorkflowStepAction {
+  return {
+    type: WORKFLOW_CLEAR_TRANSFORM_STEP_OUTPUT,
+    index: index
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1138,6 +1138,10 @@ code {
   @apply rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 opacity-100 p-4 !important;
 }
 
+.workflow-cell:hover .workflow-cell-hover\:opacity-100 {
+  opacity: 1;
+}
+
 /* override react-responsive-carousel control dot styles */
 .carousel .control-dots .dot {
   @apply bg-qrigray-400 shadow-none !important;


### PR DESCRIPTION
added logic to hide the output and status of each cell/outline on edit while remaining the events list intact
fixed the output clear action to hide the output of single cell

fixes #313 