### PR TITLE
fix: workflow output text wraps without breaking the UI

### DIFF
--- a/src/features/workflow/WorkflowCellsStatus.tsx
+++ b/src/features/workflow/WorkflowCellsStatus.tsx
@@ -27,7 +27,7 @@ const WorkflowCellsStatus: React.FC<WorkflowCellsStatusProps> = ({
             <div className='bg-white rounded-md px-2 w-20 h-6 flex items-center'>
               <Icon size='2xs' icon='code'/>
             </div>
-            {r && <RunStatusIcon status={r.status} />}
+            {r && r.status && <RunStatusIcon status={r.status} />}
           </div>
         )
       })}

--- a/src/features/workflow/output/LogLinePrint.tsx
+++ b/src/features/workflow/output/LogLinePrint.tsx
@@ -9,11 +9,11 @@ const LogLinePrint: React.FC<LogLineProps> = ({ line }) => {
   switch (line.type) {
     case EventLogLineType.ETPrint:
       // TODO (b5) - utilize line.data.lvl to set output colour
-     return <p className='log_line_print_text text-sm whitespace-pre text-gray-500'>{line.data.msg}</p>
+     return <p className='log_line_print_text text-sm whitespace-pre-wrap text-gray-500'>{line.data.msg}</p>
     case EventLogLineType.ETError:
-     return <p className='text-sm whitespace-pre text-dangerred'>{line.data.msg}</p>
+     return <p className='text-sm whitespace-pre-wrap text-dangerred'>{line.data.msg}</p>
     default:
-      return <p className='whitespace-pre'>{line.data.msg}</p>
+      return <p className='whitespace-pre-wrap'>{line.data.msg}</p>
   }
 }
 


### PR DESCRIPTION
workflow output text wraps without breaking the UI
fixed issue where workflow crashed due to run.status being undefined.

fixes #359 