### PR TITLE
fix: added scroll to expended body preview

### DIFF
--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -107,7 +107,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
               <ComponentHeader>
                 {componentHeader}
               </ComponentHeader>
-              <div className='overflow-auto flex-grow'>
+              <div style={{maxHeight: 'calc(100% - 92px)'}} className='overflow-auto flex-grow'>
                 {component}
               </div>
             </ContentBox>


### PR DESCRIPTION
added scroll to expended body preview

![image](https://user-images.githubusercontent.com/22635911/136944631-a123efc3-a32d-46fc-baa9-a13f2e63766d.png)

fixes #355 