### PR TITLE
refactor: dataset route refactor, use hash for selected component

### DIFF
--- a/e2e-tests/golden_path.spec.ts
+++ b/e2e-tests/golden_path.spec.ts
@@ -82,7 +82,7 @@ test.describe.serial('Golden path', () => {
   });
 
   test('History update check', async () => {
-    await page.goto(APP_URL + `/ds/${USERNAME}/${workflowRandomName}/body`);
+    await page.goto(APP_URL + `/${USERNAME}/${workflowRandomName}/body`);
     const versionInfoText = await page.locator('.commit_summary_header_container .dataset_commit_info_text');
     await expect(versionInfoText).toHaveText('created dataset')
     const versionSelector = await page.locator('#dataset_commit_list_versions_text');
@@ -90,7 +90,7 @@ test.describe.serial('Golden path', () => {
   });
 
   test('Checking if trigger is fine on workflow', async () => {
-    await page.goto(APP_URL + `/ds/${USERNAME}/${workflowRandomName}/workflow`);
+    await page.goto(APP_URL + `/${USERNAME}/${workflowRandomName}/workflow`);
     const selector = await page.locator('#cron_trigger_interval_text');
     await expect(selector).toContainText('Every day');
   });
@@ -112,11 +112,10 @@ test.describe.serial('Golden path', () => {
   });
 
   test('History second version update check', async () => {
-    await page.goto(APP_URL + `/ds/${USERNAME}/${workflowRandomName}/body`);
+    await page.goto(APP_URL + `/${USERNAME}/${workflowRandomName}/body`);
     const versionSelector = await page.locator('#dataset_commit_list_versions_text');
     const versionInfoText = await page.locator('.commit_summary_header_container .dataset_commit_info_text');
     await expect(versionSelector).toHaveText('2 versions');
     await expect(versionInfoText).toContainText('updated transform and body')
   });
 });
-

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -58,7 +58,7 @@ test('happy path', async () => {
   await page.waitForSelector("#new-dataset-button")
 
   await page.click('#new-dataset-button')
-  expect(page.url()).toContain('/ds/new')
+  expect(page.url()).toContain('/new')
 
   await page.click('#CSVDownload')
   await page.waitForSelector('#workflow')
@@ -95,7 +95,7 @@ test('happy path', async () => {
   await page.keyboard.type('\nbadcode',{delay: 20})
   await page.click('#dry-run')
   await page.waitForSelector('#failed')
-  
+
   const downloadOutput = await page.$('#download-cell .output')
     .then(async el => {
       return await page.evaluate((el: HTMLElement) => {
@@ -112,7 +112,7 @@ test('happy path', async () => {
   await page.click('#dry-run')
   await page.waitForSelector('#succeeded')
   await page.waitForSelector('#dataset-preview')
-  
+
   // TODO (ramfox): when we get this functionality up and running, we can comment
   // these tests back in
   // await page.click('#select-schedule')
@@ -151,7 +151,7 @@ test('happy path', async () => {
   // await workflowItemEl.click()
   // await page.waitForSelector('#setup-cell')
   // await page.click('#setup-cell .monaco-editor')
-  // await page.keyboard.type('badcode',{delay: 20}) 
+  // await page.keyboard.type('badcode',{delay: 20})
   // await page.click('#run-and-save')
   // await page.click('#menu')
   // await page.click('#back-to-collection')

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -40,7 +40,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
         const { username, name } = row
         return (
           <div className='hover:text-qrilightblue hover:underline'>
-            <Link to={`/ds/${username}/${name}`}>{username}/{name}</Link>
+            <Link to={`/${username}/${name}`}>{username}/{name}</Link>
           </div>
         )
       }

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -11,7 +11,7 @@ import Icon from '../../chrome/Icon'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
 import DropdownMenu from '../../chrome/DropdownMenu'
-import { pathToDatasetPreview } from '../dataset/state/datasetPaths'
+import { pathToDatasetHeadPreview } from '../dataset/state/datasetPaths'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { VersionInfo } from '../../qri/versionInfo'
 import ManualTriggerButton from '../workflow/ManualTriggerButton'
@@ -116,7 +116,7 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
           </div>
           <div className='truncate'>
             <div className='mb-1'>
-              <Link to={pathToDatasetPreview(row)}>
+              <Link to={pathToDatasetHeadPreview(row, { ignorePath: true })}>
                 <UsernameWithIcon username={`${row.username}/${row.name}`}  className='text-sm font-medium text-black ' />
               </Link>
             </div>

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import classNames from 'classnames'
 
 import { LogItem } from '../../qri/log'
-import { newQriRef } from '../../qri/ref'
+import { newQriRef, refParamsFromLocation } from '../../qri/ref'
 import { NewDataset } from '../../qri/dataset'
-import { pathToDatasetViewer } from '../dataset/state/datasetPaths'
+import { pathToDatasetHistory } from '../dataset/state/datasetPaths'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 
 export interface DatasetCommitProps {
@@ -19,6 +19,7 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
   active = false,
   isLink = true
 }) => {
+  const location = useLocation()
   // create a Dataset to pass into DatasetCommitInfo
   const dataset = NewDataset({
     username: logItem.username,
@@ -39,7 +40,7 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
     return (
       <Link
         className={containerClassNames}
-        to={pathToDatasetViewer(newQriRef(logItem))}
+        to={pathToDatasetHistory(newQriRef(refParamsFromLocation(logItem, location)))}
         style={{ fontSize: 11 }}
       >
         {content}

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -30,7 +30,7 @@ const Dashboard: React.FC<any> = () => {
         <header className='mb-8 flex'>
           <h1 className='text-2xl font-extrabold w-1/2'>Dashboard</h1>
           <div className='w-1/2 text-right'>
-          <Link to='/ds/new'>
+          <Link to='/new'>
             <Button>
               <Icon icon='plusCircle' className='mr-2' size='md'/> New Dataset
             </Button>

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -10,10 +10,10 @@ import NewDatasetButton from '../../chrome/NewDatasetButton'
 import Icon from '../../chrome/Icon'
 import {
   pathToWorkflowEditor,
-  pathToDatasetViewer,
+  pathToDatasetHistory,
   pathToDatasetIssues,
   pathToDatasetPreview,
-  pathToActivityFeed,
+  pathToDatasetRuns,
 } from './state/datasetPaths'
 
 import { selectNavExpanded } from '../app/state/appState'
@@ -91,7 +91,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
           id='components'
           icon='history'
           label='History'
-          to={pathToDatasetViewer(qriRef)}
+          to={pathToDatasetHistory(qriRef)}
           expanded={expanded}
           number={versionCount}
           tooltip={
@@ -119,7 +119,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
           id='activity-feed'
           icon='clock'
           label='Run Log'
-          to={pathToActivityFeed(qriRef.username, qriRef.name)}
+          to={pathToDatasetRuns(qriRef.username, qriRef.name)}
           expanded={expanded}
           number={logCount}
           tooltip={

--- a/src/features/dataset/DatasetRoutes.tsx
+++ b/src/features/dataset/DatasetRoutes.tsx
@@ -6,7 +6,7 @@
 // DatasetPreviewPage fetches the other necessary parts of the preview (body + readme)
 
 import React, {useEffect} from 'react'
-import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router'
+import { Route, Switch, useParams } from 'react-router'
 import { useDispatch } from "react-redux";
 
 import WorkflowPage from '../workflow/WorkflowPage'
@@ -20,7 +20,6 @@ import DatasetWrapper from '../dsComponents/DatasetWrapper'
 import { loadHeader } from "./state/datasetActions";
 
 const DatasetRoutes: React.FC<{}> = () => {
-  const { url } = useRouteMatch()
   // TODO(b5): this qriRef is missing all params after /:username/:name b/c
   // params are dictated by the route that loaded this component.
   // This ref can only be used to load HEAD because DatasetRoutes defines
@@ -37,49 +36,46 @@ const DatasetRoutes: React.FC<{}> = () => {
   return (
     <DatasetWrapper>
       <Switch>
-        <Route path='/ds/:username/:name' exact>
-          <Redirect to={`${url}/preview`} />
-        </Route>
-
-        <Route path='/ds/:username/:name/workflow'>
-          <WorkflowPage qriRef={qriRef} />
-        </Route>
-
-        <Route path='/ds/:username/:name/history'>
-          <DatasetActivityFeed qriRef={qriRef} />
-        </Route>
-
-        <Route path='/ds/:username/:name/preview' exact>
+        {/* dataset preview */}
+        <Route path='/:username/:name' exact>
           <DatasetPreviewPage qriRef={qriRef} />
         </Route>
 
+        <Route path='/:username/:name/at/:fs/:hash' exact>
+          <DatasetPreviewPage qriRef={qriRef} />
+        </Route>
+
+        {/* dataset history */}
+        <Route path='/:username/:name/history'>
+          <DatasetComponents />
+        </Route>
+
+        <Route path='/:username/:name/at/:fs/:hash/history'>
+          <DatasetComponents />
+        </Route>
+
+        {/* dataset workflow */}
+        <Route path='/:username/:name/workflow'>
+          <WorkflowPage qriRef={qriRef} />
+        </Route>
+
+        {/* dataset runs */}
+        <Route path='/:username/:name/runs'>
+          <DatasetActivityFeed qriRef={qriRef} />
+        </Route>
+
         {process.env.REACT_APP_FEATURE_WIREFRAMES &&
-          <Route path='/ds/:username/:name/issues'>
+          <Route path='/:username/:name/issues'>
             <DatasetIssues qriRef={qriRef} />
           </Route>
         }
 
         {process.env.REACT_APP_FEATURE_WIREFRAMES &&
-          <Route path='/ds/:username/:name/edit'>
+          <Route path='/:username/:name/edit'>
             <DatasetEditor />
           </Route>
         }
 
-        <Route path='/ds/:username/:name/at/:fs/:hash/components'>
-          <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/at/${qriRef.path}/body`} />
-        </Route>
-
-        <Route path='/ds/:username/:name/at/:fs/:hash/:component'>
-          <DatasetComponents />
-        </Route>
-
-        <Route path='/ds/:username/:name/components'>
-          <Redirect to={`/ds/${qriRef.username}/${qriRef.name}/body`} />
-        </Route>
-
-        <Route path='/ds/:username/:name/:component'>
-          <DatasetComponents />
-        </Route>
       </Switch>
     </DatasetWrapper>
   )

--- a/src/features/dataset/state/datasetPaths.ts
+++ b/src/features/dataset/state/datasetPaths.ts
@@ -1,31 +1,41 @@
 import { QriRef } from "../../../qri/ref";
 
 export function pathToDatasetIssues(ref: QriRef): string {
-  return `/ds/${ref.username}/${ref.name}/issues`
+  return `/${ref.username}/${ref.name}/issues`
+}
+
+export function pathToDatasetHeadPreview(ref: QriRef): string {
+  return `/${ref.username}/${ref.name}`
 }
 
 export function pathToDatasetPreview(ref: QriRef): string {
-  return `/ds/${ref.username}/${ref.name}/preview`
-}
-
-export function pathToDatasetViewer(ref: QriRef): string {
-  let urlPath = `/ds/${ref.username}/${ref.name}`
+  let urlPath = `/${ref.username}/${ref.name}`
   if (ref.path) {
     urlPath += `/at${ref.path}`
   }
-  urlPath += ref.component ? `/${ref.component}`  : "/body"
+
+  return urlPath
+}
+
+export function pathToDatasetHistory(ref: QriRef): string {
+  let urlPath = `/${ref.username}/${ref.name}`
+  if (ref.path) {
+    urlPath += `/at${ref.path}`
+  }
+  urlPath += '/history'
+  urlPath += ref.component ? `#${ref.component}`  : "#body"
 
   return urlPath
 }
 
 export function pathToDatasetEditor(ref: QriRef): string {
-  return `/ds/${ref.username}/${ref.name}/edit`
+  return `/${ref.username}/${ref.name}/edit`
 }
 
 export function pathToWorkflowEditor(username: string, name: string): string {
-  return `/ds/${username}/${name}/workflow`
+  return `/${username}/${name}/workflow`
 }
 
-export function pathToActivityFeed(username: string, name:string): string {
-  return `/ds/${username}/${name}/history`
+export function pathToDatasetRuns(username: string, name:string): string {
+  return `/${username}/${name}/runs`
 }

--- a/src/features/dsComponents/ComponentItem.tsx
+++ b/src/features/dsComponents/ComponentItem.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import classNames from 'classnames'
-import { Action } from 'redux'
 
 import { ComponentStatus, ComponentName } from '../../qri/dataset'
 import Icon from '../../chrome/Icon'
 import StatusDot from '../../chrome/StatusDot'
+import Link from '../../chrome/Link'
 
 export interface ComponentItemProps {
   displayName: string
@@ -18,7 +18,6 @@ export interface ComponentItemProps {
   tooltip?: string
   // for showing a gray border around the selected tab to contrast with white background
   border?: boolean
-  onClick?: (component: ComponentName) => Action | void
 }
 
 export const ComponentItem: React.FC<ComponentItemProps> = ({
@@ -27,40 +26,56 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
   name,
   displayName,
   selected,
-  onClick,
   icon,
   filename,
   color = 'dark',
   border = false
 }) => {
-
-  return (
-    <div
-      id={`${displayName.toLowerCase()}-status`}
-      className={classNames('flex flex-grow items-center mw-40 mr-2 last:mr-0 py-1.5 rounded-tr-lg rounded-tl-lg group justify-center relative', {
-        'selected': selected,
-        'bg-white': selected,
-        'text-qripink': selected,
-        'bg-qrigray-200': !selected,
-        'text-qrigray-400': disabled,
-        'text-black': !disabled,
-        'hover:cursor-pointer': !disabled,
-        'w-1/4': displayName === 'Data',
-        'border-grigray-200 border-t-2 border-r-2 border-l-2 -bottom-0.5': border
-      })}
-      onClick={() => {
-        if (onClick && displayName) {
-          onClick(name)
-        }
-      }}
-    >
+  const tabContent = (
+    <>
       {icon && <Icon icon={icon} size='2xs' className='mr-2' color={disabled ? 'medium' : color} />}
       <div>
         <div className='font-bold' style={{ fontSize: 12 }}>{displayName}</div>
         <div>{filename}</div>
       </div>
       <StatusDot status={status} />
-    </div>
+    </>
+  )
+
+  const tabClasses = 'flex flex-grow items-center mw-40 mr-2 last:mr-0 py-1.5 rounded-tr-lg rounded-tl-lg group justify-center relative'
+
+  const enabledClasses = {
+    'selected': selected,
+    'bg-white': selected,
+    'bg-qrigray-200': !selected,
+    'w-1/4': displayName === 'Data',
+    'border-grigray-200 border-t-2 border-r-2 border-l-2 -bottom-0.5': border
+  }
+
+  const enabledColorClasses = {
+    'text-qripink': selected,
+    'text-black': !selected,
+  }
+
+  const disabledClasses = 'text-qrigray-400 bg-qrigray-200'
+
+  if (disabled) {
+    return (
+      <div className={classNames(tabClasses, disabledClasses)}>
+        {tabContent}
+      </div>
+    )
+  }
+
+  return (
+    <Link
+      id={`${displayName.toLowerCase()}-status`}
+      className={classNames(tabClasses, enabledClasses)}
+      colorClassName={classNames('flex items-center', enabledColorClasses)}
+      to={`#${name}`}
+    >
+      {tabContent}
+    </Link>
   )
 }
 

--- a/src/features/dsComponents/ComponentList.tsx
+++ b/src/features/dsComponents/ComponentList.tsx
@@ -53,7 +53,6 @@ export const componentsInfo:ComponentInfo[] = [
 export interface ComponentListProps {
   // qriRef: QriRef
   dataset: Dataset
-  onClick?: (component: ComponentName) => void
   // components?: SelectedComponent[]
   // status: Status
   selectedComponent?: ComponentName
@@ -65,7 +64,6 @@ export interface ComponentListProps {
 
 const ComponentList: React.FC<ComponentListProps> = ({
   dataset,
-  onClick,
   // qriRef,
   // status,
   // components = [],
@@ -79,7 +77,7 @@ const ComponentList: React.FC<ComponentListProps> = ({
     return (
     <div className={classNames('flex w-full', { 'border-b-2': border })}>
       {componentsInfo.map(({ name, displayName, tooltip, icon }) => {
-          if (allowClickMissing || componentNames.includes(name)) {
+          if (allowClickMissing || componentNames.includes(name) || ( name==='body' && dataset.bodyPath )) {
             var fileStatus: ComponentStatus = 'unmodified'
             // if (status[name]) {
             //   fileStatus = status[name].status
@@ -94,7 +92,6 @@ const ComponentList: React.FC<ComponentListProps> = ({
                 status={fileStatus}
                 selected={selectedComponent === name}
                 tooltip={tooltip}
-                onClick={onClick}
                 border={border}
               />
             )

--- a/src/features/dsComponents/DatasetComponents.tsx
+++ b/src/features/dsComponents/DatasetComponents.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react'
-import { push } from 'connected-react-router'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router'
+import { useLocation } from 'react-router-dom'
 
 import { ComponentName } from '../../qri/dataset'
-import { newQriRef } from '../../qri/ref'
-import { pathToDatasetViewer } from '../dataset/state/datasetPaths'
+import { newQriRef, refParamsFromLocation } from '../../qri/ref'
 import { selectDataset, selectIsDatasetLoading } from '../dataset/state/datasetState'
 import DatasetCommitList from '../commits/DatasetCommitList'
 import CommitSummaryHeader from '../commits/CommitSummaryHeader'
@@ -15,15 +14,10 @@ import { loadDataset } from '../dataset/state/datasetActions'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
 
 const DatasetComponents: React.FC<{}> = () => {
-  const qriRef = newQriRef(useParams())
+  const qriRef = newQriRef(refParamsFromLocation(useParams(), useLocation()))
   const dispatch = useDispatch()
   const dataset = useSelector(selectDataset)
   const loading = useSelector(selectIsDatasetLoading)
-
-  const setSelectedComponent = (component: ComponentName) => {
-    const dest = newQriRef(Object.assign({}, qriRef, { component }))
-    dispatch(push(pathToDatasetViewer(dest)))
-  }
 
   useEffect(() => {
     const ref = newQriRef({username: qriRef.username, name: qriRef.name, path: qriRef.path})
@@ -43,7 +37,6 @@ const DatasetComponents: React.FC<{}> = () => {
             dataset={dataset}
             loading={loading}
             selectedComponent={qriRef.component as ComponentName || 'body'}
-            setSelectedComponent={setSelectedComponent}
           />
         </div>
       </div>

--- a/src/features/dsComponents/DatasetWrapper.tsx
+++ b/src/features/dsComponents/DatasetWrapper.tsx
@@ -15,7 +15,7 @@ import NavBar from '../navbar/NavBar'
 import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 
 interface DatasetWrapperProps {
-  fetchData: boolean
+  fetchData?: boolean
 }
 
 const DatasetWrapper: React.FC<DatasetWrapperProps> = ({

--- a/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -9,7 +9,6 @@ import Spinner from '../../chrome/Spinner'
 export interface TabbedComponentViewerProps {
   dataset: Dataset
   selectedComponent?: ComponentName
-  setSelectedComponent?: (name: ComponentName) => void
   loading?: boolean
   // border is used to display TabbedComponentViewer over a white background e.g. on the workflow editor
   border?: boolean
@@ -21,7 +20,6 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
   dataset: ds,
   loading,
   selectedComponent,
-  setSelectedComponent,
   border = false,
   preview = false,
   children
@@ -44,7 +42,6 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
     <div className={'flex flex-col w-full mt-1 pt-4 h-full min-h-0'}>
       <ComponentList
         dataset={dataset}
-        onClick={setSelectedComponent}
         selectedComponent={selectedComponent}
         border={border}
       />

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -41,8 +41,8 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset, loading=fa
 
       itemContent = (
         <>
-          <Link to={`/ds/${humanRef}`}><div className='text-sm text-gray-400 relative flex items-baseline group hover:text mb-2 font-mono hover:underline'>{humanRef}</div></Link>
-          <Link to={`/ds/${humanRef}`}><div className='text-xl text-black-500 font-medium hover:text hover:underline mb-1'>{title}</div></Link>
+          <Link to={`/${humanRef}`}><div className='text-sm text-gray-400 relative flex items-baseline group hover:text mb-2 font-mono hover:underline'>{humanRef}</div></Link>
+          <Link to={`/${humanRef}`}><div className='text-xl text-black-500 font-medium hover:text hover:underline mb-1'>{title}</div></Link>
           <div className='text-sm text-qrigray hover:text line-clamp-3 mb-2'>{meta?.description || 'No Description'}</div>
           <div className='flex items-center flex-wrap'>
             <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={timestamp} />} />

--- a/src/features/splash/Splash.tsx
+++ b/src/features/splash/Splash.tsx
@@ -18,7 +18,7 @@ const Splash: React.FC<{}> = () => (
             Qrimatic binds code to data, so you can keep your data fresh.  Just write a script to move and munge your data, set a schedule, and we'll take care of the rest.
           </p>
           <div className="max-w-xs mx-auto sm:max-w-none sm:flex sm:justify-center">
-            <Link to="/ds/new">
+            <Link to="/new">
               <Button size='lg'>
                 Try Qri now <Icon className='ml-3' icon='caretRight' />
               </Button>

--- a/src/features/toast/Toast.tsx
+++ b/src/features/toast/Toast.tsx
@@ -28,7 +28,7 @@ const Toast: React.FC<ToastProps> = ({ message, initID, type }) => {
           'text-qrigreen': type === 'succeeded',
           'text-dangerred': type === 'failed',
         })}>{message}</div>
-        <Link to={'/ds/'+ref}
+        <Link to={`/${ref}`}
               className='text-qrinavy w-56 whitespace-nowrap overflow-hidden block text-sm overflow-ellipsis'>
           {ref}
         </Link>

--- a/src/features/workflow/Workflow.tsx
+++ b/src/features/workflow/Workflow.tsx
@@ -57,7 +57,7 @@ const Workflow: React.FC<WorkflowProps> = ({ qriRef }) => {
       dispatch(showModal(ModalType.workflowSplash))
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location])
+  }, [])
 
   const handleBlockedNavigation = (nextLocation: Location) => {
     if (redirectTo) { return true }

--- a/src/features/workflow/WorkflowDatasetPreview.tsx
+++ b/src/features/workflow/WorkflowDatasetPreview.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
+import { useLocation } from 'react-router-dom'
 
-import { Dataset, ComponentName, NewDataset } from  '../../qri/dataset'
+import { Dataset, NewDataset } from  '../../qri/dataset'
+import { selectorFromLocationHash } from '../../qri/ref'
 import TabbedComponentViewer from '../dsComponents/TabbedComponentViewer'
 
 export interface WorkflowDatasetPreviewProps {
@@ -11,7 +13,7 @@ const WorkflowDatasetPreview: React.FC<WorkflowDatasetPreviewProps> = ({
   dataset
 }) => {
 
-  const [ selectedComponent, setSelectedComponent ] = useState<ComponentName>('body')
+  const selectedComponent = selectorFromLocationHash(useLocation())
 
   return (
     <div style={{ height: '65vh' }}>
@@ -20,7 +22,6 @@ const WorkflowDatasetPreview: React.FC<WorkflowDatasetPreviewProps> = ({
           dataset={dataset}
           loading={false}
           selectedComponent={selectedComponent}
-          setSelectedComponent={(component: ComponentName) => { setSelectedComponent(component) }}
           preview
         />
       ) : (

--- a/src/features/workflow/modal/DeployModal.tsx
+++ b/src/features/workflow/modal/DeployModal.tsx
@@ -71,7 +71,7 @@ const DeployModal: React.FC = () => {
       dispatch(setModalLocked(false))
       // navigate to the new dataset's workflow!
       history.push({
-        pathname: `/ds/${qriRef.username}/${qriRef.name}/workflow`,
+        pathname: `/${qriRef.username}/${qriRef.name}/workflow`,
       })
     }
 

--- a/src/qri/ref.ts
+++ b/src/qri/ref.ts
@@ -73,6 +73,28 @@ export function newQriRef(d: Record<string,any>): QriRef {
   }
 }
 
+// TODO(b5): this function should be applied to the selector field of QriRef
+export function selectorFromLocationHash(location: Record<string,any>): string {
+  if (location?.hash) {
+    const hashValue = location.hash.split('#')[1]
+    // only set component if it's a valid qri component name
+    if (['body', 'meta', 'structure', 'readme', 'transform'].includes(hashValue)) {
+      return hashValue
+    }
+  }
+  return 'body'
+}
+
+// parses the selected component from the location hash and appends it to params
+// params can be any object that would normally be passed to newQriRef
+// location is the result of useLocation
+export function refParamsFromLocation(params: Record<string,any>, location: Record<string,any>): Record<string,any> {
+  return {
+    ...params,
+    component: selectorFromLocationHash(location)
+  }
+}
+
 // // qriRefFromRoute parses route props into a Ref
 // export function qriRefFromRoute (p: RouteComponentProps): QriRef {
 //   const selectedComponent = selectedComponentFromLocation(p.location.pathname)

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -52,8 +52,7 @@ export default function Routes () {
           </DatasetWrapper>
         </Route>
 
-        <Route path='/ds/new'><TemplateList /></Route>
-        <Route path='/ds/:username/:name'><DatasetRoutes /></Route>
+        <Route path='/new'><TemplateList /></Route>
 
         <Route path='/run'><Run /></Route>
         <Route path='/changes'><ChangeReport /></Route>
@@ -66,6 +65,7 @@ export default function Routes () {
         <Route path='/:username' exact><UserProfile /></Route>
         <Route path='/:username/following'><UserProfile path='/following' /></Route>
 
+        <Route path='/:username/:name'><DatasetRoutes /></Route>
 
         <Route path='/'>
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,7 +3106,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/deep-equal@^1.0.1":
+"@types/deep-equal@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"
   integrity sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==


### PR DESCRIPTION
- Refactors dataset routes, eliminating `/ds`
  - `preview` no longer appears in the route, and will show at `/:username/:name/`
  -  history is now explicit at `/:username/:name/history#component` or `/:username/:name/at/ipfs/history#component`. This still feels weird as it implies we are looking at the history of a version, not the history of the dataset.  Can revisit later.
  -  Workflow is at `/:username/:name/workflow`
  -  Run log is at `/:username/:name/runs`
- Refactors `ComponentList` to use `Link` for navigation instead of click handlers.  This allows for updating the hash in the URL when selecting a component tab in the history view, and also means the current tab will stay selected when navigating through the commit history!

Closes #297 and #400