### PR TITLE
feat: only show collection loading state on first load

### DIFF
--- a/src/features/collection/Collection.tsx
+++ b/src/features/collection/Collection.tsx
@@ -9,6 +9,7 @@ import CollectionTable from './CollectionTable'
 import Spinner from '../../chrome/Spinner'
 import Link from '../../chrome/Link'
 import NewDatasetButton from '../../chrome/NewDatasetButton'
+import Icon from '../../chrome/Icon'
 import SearchBox from '../search/SearchBox'
 import { filterVersionInfos } from '../../qri/versionInfo'
 
@@ -45,8 +46,8 @@ const Collection: React.FC<{}> = () => {
     </div>
   )
 
-  // if loading, show a spinner
-  if (loading) {
+  // if loading and there is no collection, show a spinner
+  if (loading && (collection.length === 0)) {
     resultsContent = (
       <div className='h-full w-full flex justify-center items-center'>
         <Spinner color='#43B3B2' />
@@ -87,6 +88,11 @@ const Collection: React.FC<{}> = () => {
                   {collection.length}
                 </div>
               </div>
+              { loading && collection.length && (
+                <div>
+                  <Icon icon='loader' className='ml-2 text-qrigray-400'/>
+                </div>
+              )}
             </div>
 
             <div className='w-1/2 flex items-center justify-end'>

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -25,6 +25,7 @@ export const selectCollection = (state: RootState): VersionInfo[] => {
     }
     ordered.push(collection[id])
   })
+
   return ordered.sort((a,b) => {
     if (a.username === b.username && a.name === b.name) { return 0 }
     else if (a.username < b.username ||  a.name < b.name) { return -1 }
@@ -63,7 +64,6 @@ const initialState: CollectionState = {
 
 export const collectionReducer = createReducer(initialState, {
   'API_COLLECTION_REQUEST': (state, action) => {
-    state.listedIDs = new Set<string>()
     state.collectionLoading = true
   },
   'API_COLLECTION_SUCCESS': (state, action) => {


### PR DESCRIPTION
- Shows a loading spinner in place of the list in Collection view *only* if there is no collection state (only on first load)
- If there is already a collection state, show a smaller 'loader' icon next to the page title (this will show when a dataset is removed and the app is refreshing the collection)

When the user removes a dataset from Collection view, the collection list will update in place (the dataset will disappear).  In the future we can make this interaction better by animating the removal.