### PR TITLE
Cw/run now from collection

### DIFF
--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -76,7 +76,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
           }
         })
         if (!['failed', 'unchanged'].includes(row.runStatus)) {
-          const versionLink = `/ds/${row.username}/${row.name}/at${row.path}/body`
+          const versionLink = `/${row.username}/${row.name}/at${row.path}/history/body`
           return (
             <Link to={versionLink}>
               <DatasetCommitInfo dataset={dataset} small />

--- a/src/features/collection/Collection.tsx
+++ b/src/features/collection/Collection.tsx
@@ -9,6 +9,7 @@ import CollectionTable from './CollectionTable'
 import Spinner from '../../chrome/Spinner'
 import Link from '../../chrome/Link'
 import NewDatasetButton from '../../chrome/NewDatasetButton'
+import Icon from '../../chrome/Icon'
 import SearchBox from '../search/SearchBox'
 import { filterVersionInfos } from '../../qri/versionInfo'
 
@@ -45,8 +46,8 @@ const Collection: React.FC<{}> = () => {
     </div>
   )
 
-  // if loading, show a spinner
-  if (loading) {
+  // if loading and there is no collection, show a spinner
+  if (loading && (collection.length === 0)) {
     resultsContent = (
       <div className='h-full w-full flex justify-center items-center'>
         <Spinner color='#43B3B2' />
@@ -87,6 +88,11 @@ const Collection: React.FC<{}> = () => {
                   {collection.length}
                 </div>
               </div>
+              { loading && collection.length && (
+                <div>
+                  <Icon icon='loader' className='ml-2 text-qrigray-400'/>
+                </div>
+              )}
             </div>
 
             <div className='w-1/2 flex items-center justify-end'>

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -110,8 +110,8 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         <div className='flex items-center truncate'>
           <div className='w-8 mr-2'>
             <Icon icon='automationFilled' className={classNames('text-qrigreen', {
-              'visible': row.workflowID,
-              'invisible': !row.workflowID
+              'visible': row.runID,
+              'invisible': !row.runID
             })}/>
           </div>
           <div className='truncate'>
@@ -185,10 +185,13 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         flexShrink: 0
       },
       omit: simplified,
-      width: '90px',
-      cell: (row: VersionInfo) => (row.workflowID
-          ? <ManualTriggerButton qriRef={{ username: row.username, name: row.name }} />
-          : '—'
+      width: '100px',
+      cell: (row: VersionInfo) => (
+        <div className='mx-auto text-qrigray-400'>
+          {row.runID
+            ? <ManualTriggerButton row={row}/>
+            : '—'}
+        </div>
       )
     },
     {

--- a/src/features/collection/state/collectionActions.ts
+++ b/src/features/collection/state/collectionActions.ts
@@ -1,10 +1,12 @@
-import { ApiAction, CALL_API } from "../../../store/api"
+import { ApiAction, CALL_API, ApiActionThunk } from "../../../store/api"
 import { newVersionInfo, VersionInfo } from "../../../qri/versionInfo"
 import { NewWorkflow, workflowInfoFromWorkflow } from "../../../qrimatic/workflow"
 import { WORKFLOW_COMPLETED, WORKFLOW_STARTED } from "./collectionState"
 import { AnyAction } from "redux"
 import { RootState } from "../../../store/store";
 import { ThunkDispatch } from 'redux-thunk'
+import { QriRef } from '../../../qri/ref'
+
 
 function mapVersionInfo (data: object | []): VersionInfo[] {
   if (!data) { return [] }
@@ -53,6 +55,26 @@ function fetchVersionInfo (initID: string): ApiAction {
       body: {
         initID: initID
       },
+    }
+  }
+}
+
+// runnow will trigger a manual run.  On success, it will refresh the collection
+export function runNow (qriRef: QriRef, initID: string): ApiActionThunk {
+  return async (dispatch, getState) => {
+    return dispatch(fetchRunNow(qriRef, initID))
+  }
+}
+
+function fetchRunNow (qriRef: QriRef, initID: string): ApiAction {
+  return {
+    type: 'runnow_collection',
+    qriRef,
+    [CALL_API]: {
+      endpoint: 'auto/run',
+      method: 'POST',
+      body: { ref: `${qriRef.username}/${qriRef.name}` },
+      requestID: initID
     }
   }
 }

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -117,5 +117,9 @@ export const collectionReducer = createReducer(initialState, {
   },
   WORKFLOW_COMPLETED: (state, action) => {
     state.collection[action.data.id] = action.data
+  },
+  'API_RUNNOW_COLLECTION_SUCCESS': (state, action) => {
+    const initID = action.payload.requestID
+    state.collection[initID].runID = action.payload.data
   }
 })

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -25,6 +25,7 @@ export const selectCollection = (state: RootState): VersionInfo[] => {
     }
     ordered.push(collection[id])
   })
+
   return ordered.sort((a,b) => {
     if (a.username === b.username && a.name === b.name) { return 0 }
     else if (a.username < b.username ||  a.name < b.name) { return -1 }
@@ -63,7 +64,6 @@ const initialState: CollectionState = {
 
 export const collectionReducer = createReducer(initialState, {
   'API_COLLECTION_REQUEST': (state, action) => {
-    state.listedIDs = new Set<string>()
     state.collectionLoading = true
   },
   'API_COLLECTION_SUCCESS': (state, action) => {

--- a/src/features/toast/Toast.tsx
+++ b/src/features/toast/Toast.tsx
@@ -28,7 +28,7 @@ const Toast: React.FC<ToastProps> = ({ message, initID, type }) => {
           'text-qrigreen': type === 'succeeded',
           'text-dangerred': type === 'failed',
         })}>{message}</div>
-        <Link to={`/${ref}`}
+        <Link to={`/${ref}/runs`}
               className='text-qrinavy w-56 whitespace-nowrap overflow-hidden block text-sm overflow-ellipsis'>
           {ref}
         </Link>

--- a/src/features/workflow/ManualTriggerButton.tsx
+++ b/src/features/workflow/ManualTriggerButton.tsx
@@ -1,28 +1,48 @@
-import React from 'react'
-import { useDispatch } from 'react-redux'
+import React, { useRef, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import ReactTooltip from 'react-tooltip'
 
 import Icon from '../../chrome/Icon'
-import { runNow } from './state/workflowActions'
-import { refStringFromQriRef, QriRef } from '../../qri/ref'
+import { runNow, loadCollection } from '../collection/state/collectionActions'
+import { refStringFromQriRef } from '../../qri/ref'
+import { VersionInfo } from '../../qri/versionInfo'
+import { selectRun } from '../events/state/eventsState'
+
 
 export interface ManualTriggerButtonProps  {
-  qriRef: QriRef
+  row: VersionInfo
 }
 
-const ManualTriggerButton: React.FC<ManualTriggerButtonProps> = ({ qriRef }) => {
+const ManualTriggerButton: React.FC<ManualTriggerButtonProps> = ({ row }) => {
+  const { username, name, runID, initID } = row
   const dispatch = useDispatch()
 
-  const id = refStringFromQriRef(qriRef)
+  const id = refStringFromQriRef({ username, name })
+  const { status } = useSelector(selectRun(runID))
+
+  const handleClick = () => {
+    dispatch(runNow({ username, name }, initID))
+  }
+
+  const statusRef = useRef(status);
+
+  // when status changes from 'running' to 'succeeded', refresh the collection state
+  useEffect(() => {
+    if ((statusRef.current === 'running') && (status === 'succeeded')) {
+      dispatch(loadCollection())
+    }
+
+    statusRef.current = status
+  }, [dispatch, status])
 
   return (
     <div
       className='mx-auto'
       data-for={id}
       data-tip
-      onClick={() => { dispatch(runNow(qriRef)) }}
+      onClick={handleClick}
     >
-      <Icon icon='playCircle' size='lg' className='text-qritile'/>
+      <Icon icon={ status === 'running' ? 'loader' : 'playCircle'} size='lg' className='text-qritile'/>
       <ReactTooltip
         id={id}
         place='bottom'

--- a/src/qri/run.ts
+++ b/src/qri/run.ts
@@ -3,6 +3,7 @@ import { Dataset } from './dataset'
 
 export type RunStatus =
   | 'waiting'
+  | 'queued'
   | 'running'
   | 'succeeded'
   | 'failed'


### PR DESCRIPTION
Review/Merge #420 first

Adds run now action from collection view.

This introduces a different "Run Now" process from the one we are using in the Run Log.  (Run now from the run log makes use of `workflow` actions and state, which feels wrong, but it's working and I didn't want to break it). 

This approach takes the `runID` returned from the API call to `/auto/run` and mutates the value stored for that dataset in `collection` state.  That `runID` is then used by `ManualTriggerButton` to show a loading spinner in the correct row in collection view.

- Adds some logic to `ManualTriggerButton` to refresh the collection state when the run is successful.
- Restores the "automation" icon in collection view based on the existence of `runID`
- Some tweaks/fixes to various internal dataset links