### PR TITLE
fix: moved the preview ds body label to existing row count label

### DIFF
--- a/src/features/dsComponents/body/BodyHeader.tsx
+++ b/src/features/dsComponents/body/BodyHeader.tsx
@@ -30,18 +30,16 @@ const BodyHeader: React.FC<BodyHeaderProps> = ({
     <div className='flex'>
       <div className='flex flex-grow text-qrigray-400' style={{ fontSize: 12 }}>
         <div className='mr-4 flex items-center'>
-          <Icon icon='rows' size='2xs' className='mr-1'/> {entries} rows
+          <Icon icon='rows' size='2xs' className='mr-1'/>
+          {/*
+            TODO (boandriy): Once the preview row count is filtered by fetch pagination -
+            use global filtering variable instead of hardcoded 100
+          */}
+          {numeral(structure?.entries).value() > 100 ? 'Previewing 100 of' : 'Showing all'} {entries} rows
         </div>
         <div className='body_header_columns_text mr-4 flex items-center'>
           <Icon icon='columns' size='2xs' className='mr-1'/> {numeral(headers.length).format('0,0')} columns
         </div>
-        {/*
-          TODO (boandriy): Once the preview row count is filtered by fetch pagination -
-          use global filtering variable instead of hardcoded 100
-        */}
-        {numeral(structure?.entries).value() > 100 && <div className={'mr-4'}>
-          Previewing 100 of {entries} rows
-        </div>}
       </div>
       {showDownload && <DownloadDatasetButton qriRef={qriRefFromDataset(dataset)} asIconLink body />}
       {showExpand && <IconLink icon='fullScreen' onClick={onToggleExpanded} />}


### PR DESCRIPTION
moved the preview ds body label to existing row count label

Preview:
![image](https://user-images.githubusercontent.com/22635911/137478124-5008f23b-1ec2-4e8e-8f08-dd02327ef5d0.png)
All dataset: 
![image](https://user-images.githubusercontent.com/22635911/137478167-18e4e319-f9d2-4733-86d9-74e2df8a9ff9.png)

fixes #413 