### PR TITLE
fix: fixed logic to display the username on expanded body preview

### DIFF
--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -94,7 +94,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
               <div className='flex'>
                 <div className='flex-grow'>
                   <div className='text-sm text-gray-400 font-mono'>
-                    {dataset.peername}/{dataset.name}
+                    {dataset.username}/{dataset.name}
                   </div>
                   <div className='text-xl text-black font-semibold'>
                     {dataset.meta?.title || dataset.name}


### PR DESCRIPTION
fixed logic to display the username on expanded body preview

![image](https://user-images.githubusercontent.com/22635911/137483127-2cfab1f6-a4c6-430a-a2f8-9f3d810f84d0.png)


fixes #412 