### PR TITLE
Cw/collection last update

### DIFF
--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -9,37 +9,44 @@ import { Dataset } from '../qri/dataset'
 
 interface DatasetCommitInfoProps {
   dataset: Dataset
-  // small yields the same info with smaller text, used in history list and run log
+  // small yields the same info with smaller text, used in collection, history list and run log
   small?: boolean
+  // isRow indicates whether this is being displayed inline in a row in a list (versus in a card)
+  // and is used to tweak styles
+  inRow?: boolean
 }
 
 const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
   dataset,
-  small=false
-}) => {
-  return (
-    <div className={classNames({
-      'text-sm': !small,
-      'text-xs': small
+  small=false,
+  inRow=false
+}) => (
+  <div className={classNames('truncate', {
+    'text-sm': !small,
+    'text-xs': small
+  })}>
+    <div className={classNames('text-black flex justify-between items-center mb-2', {
+      'font-semibold': !inRow
     })}>
-      <div className={classNames('text-black font-semibold flex justify-between items-center mb-2')}>
-        <div className='dataset_commit_info_text'>{dataset.commit?.title}</div>
+      <div className='dataset_commit_info_text truncate flex-grow' title={dataset.commit?.title}>{dataset.commit?.title}</div>
+      {dataset.runID && (
         <div className='flex-grow-0 text-qrigreen' title='version created by this dataset&apos;s transform script'>
           <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
         </div>
-      </div>
-      <div className='flex items-center text-gray-400'>
-        <UsernameWithIcon username={dataset.username} tooltip className='mr-2' iconWidth={small ? 14 : 18} iconOnly={small} />
-        <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
-        {dataset.path && (
-          <div className='flex items-center leading-tight'>
-            <Icon icon='commit' size={small ? 'xs' : 'sm'} className='-ml-2' />
-            <div>{commitishFromPath(dataset.path)}</div>
-          </div>
-        )}
-      </div>
+      )}
     </div>
-  )
-}
+    <div className='flex items-center text-gray-400'>
+      <UsernameWithIcon username={dataset.username} tooltip className='mr-2' iconWidth={small ? 14 : 18} iconOnly={small} />
+      <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
+      {dataset.path && (
+        <div className='flex items-center leading-tight' title={dataset.path}>
+          <Icon icon='commit' size={small ? 'xs' : 'sm'} className='-ml-2' />
+          <div>{commitishFromPath(dataset.path)}</div>
+        </div>
+      )}
+    </div>
+  </div>
+)
+
 
 export default DatasetCommitInfo

--- a/src/chrome/RelativeTimestamp.tsx
+++ b/src/chrome/RelativeTimestamp.tsx
@@ -23,6 +23,7 @@ const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({
     .replace(/ months? ago/, 'mo')
     .replace(/ years? ago/, 'y')
     .replace('a', '1')
+    .replace('over', '>')
 
   return (
     <div

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -8,7 +8,6 @@ import Icon from '../../chrome/Icon'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { LogItem } from '../../qri/log'
-import { NewDataset } from '../../qri/dataset'
 import { customStyles, customSortIcon } from '../../features/collection/CollectionTable'
 
 
@@ -48,6 +47,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
     {
       name: 'Time',
       selector: (row: LogItem) => row.timestamp,
+      width: '180px',
       cell: (row: LogItem) => {
         return (
           <div className='text-qrigray-400 flex flex-col text-xs'>
@@ -66,20 +66,22 @@ const ActivityList: React.FC<ActivityListProps> = ({
     {
       name: 'Commit',
       selector: (row: LogItem) => row.message,
+      width: '180px',
       cell: (row: LogItem) => {
-        const dataset = NewDataset({
+        const dataset = {
           username: row.username,
+          runID: row.runID,
           path: row.path,
           commit: {
             title: row.message,
             timestamp:row.timestamp
           }
-        })
+        }
         if (!['failed', 'unchanged'].includes(row.runStatus)) {
           const versionLink = `/ds/${row.username}/${row.name}/at${row.path}/body`
           return (
-            <Link to={versionLink}>
-              <DatasetCommitInfo dataset={dataset} small />
+            <Link to={versionLink} className='min-w-0 flex-grow'>
+              <DatasetCommitInfo dataset={dataset} small inRow />
             </Link>
           )
         } else {

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames'
 import { showModal } from '../app/state/appActions'
 import { ModalType } from '../app/state/appState'
 import Icon from '../../chrome/Icon'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import RelativeTimestamp from '../../chrome/RelativeTimestamp'
 import UsernameWithIcon from '../../chrome/UsernameWithIcon'
 import DropdownMenu from '../../chrome/DropdownMenu'
@@ -108,7 +109,7 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       grow: 1,
       cell: (row: VersionInfo) => (
         <div className='flex items-center truncate'>
-          <div className='w-8 mr-2' title={row.workflowID && 'This dataset has an automation script'}>
+          <div className='w-8 mr-2 flex-shrink-0'  title={row.workflowID && 'This dataset has an automation script'}>
             <Icon icon='automationFilled' className={classNames('text-qrigreen', {
               'visible': row.workflowID,
               'invisible': !row.workflowID
@@ -123,15 +124,47 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
             <div className='flex text-xs overflow-y-hidden'>
               <DatasetInfoItem icon='disk' label={numeral(row.bodySize).format('0.0 b')} small />
               <DatasetInfoItem icon='rows' label={numeral(row.bodyRows).format('0,0a')} small />
-              <DatasetInfoItem icon='page' label={row.bodyFormat} small />
-              {row.commitTime && (
-                <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={new Date(row.commitTime)}/>} small />
-              )}
               <DatasetInfoItem icon={'commit'} label={row.commitCount.toString()} small/>
             </div>
           </div>
         </div>
       )
+    },
+    {
+      name: 'Last Update',
+      selector: (row: VersionInfo) => row.commitTime,
+      sortable: true,
+      omit: simplified,
+      width: '180px',
+      cell: (row: VersionInfo) => {
+        // TODO (ramfox): the activity feed expects more content than currently exists
+        // in the VersionInfo. Once the backend supplies these values, we can rip
+        // out this section that mocks durations & timestamps for us
+        const {
+          username,
+          commitTime,
+          commitTitle,
+          path,
+          runID
+        } = row
+
+        const dataset = {
+          username,
+          commit: {
+            title: commitTitle,
+            timestamp: commitTime
+          },
+          path: path,
+          runID
+        }
+
+        const versionLink = `/${row.username}/${row.name}/at${row.path}/history`
+        return (
+          <Link to={versionLink} className='min-w-0 flex-grow'>
+            <DatasetCommitInfo dataset={dataset} small inRow />
+          </Link>
+        )
+      }
     },
     {
       name: 'Last Run',

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -26,8 +26,8 @@ export const selectCollection = (state: RootState): VersionInfo[] => {
     ordered.push(collection[id])
   })
   return ordered.sort((a,b) => {
-    if (a.username === b.username && a.name === b.name) { return 0 }
-    else if (a.username < b.username ||  a.name < b.name) { return -1 }
+    if (a.commitTime === b.commitTime) { return 0 }
+    else if (a.commitTime > b.commitTime) { return -1 }
     return 1
   })
 }

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames'
 
 import { LogItem } from '../../qri/log'
 import { newQriRef, refParamsFromLocation } from '../../qri/ref'
-import { NewDataset } from '../../qri/dataset'
 import { pathToDatasetHistory } from '../dataset/state/datasetPaths'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 
@@ -21,14 +20,15 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
 }) => {
   const location = useLocation()
   // create a Dataset to pass into DatasetCommitInfo
-  const dataset = NewDataset({
+  const dataset = {
     username: logItem.username,
     path: logItem.path,
     commit: {
       title: logItem.title,
       timestamp: logItem.timestamp
-    }
-  })
+    },
+    runID: logItem.runID
+  }
 
   const content = (
     <DatasetCommitInfo dataset={dataset} small />


### PR DESCRIPTION
<img width="1049" alt="Home___Qri_Cloud" src="https://user-images.githubusercontent.com/1833820/137514037-83221349-1df2-43fc-afd7-535bb3bc40dc.png">

- Sort's collection by last update (newest on top) Closes #403
- Adds a "Last Update" column, showing a small `DatasetCommitInfo` (same as used in history list and activity list) Closes #404
- Truncates the word `over` in relative timestamps so `over 1y` becomes `> 1y`
- Removes commitTime and bodyFormat icons from the collection view Name column
- Some style tweaks Closes #416 #415