### PR TITLE
feat: add tooltips where we use the automation icon

### DIFF
--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -24,7 +24,7 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
     })}>
       <div className={classNames('text-black font-semibold flex justify-between items-center mb-2')}>
         <div className='dataset_commit_info_text'>{dataset.commit?.title}</div>
-        <div className='flex-grow-0 text-qrigreen'>
+        <div className='flex-grow-0 text-qrigreen' title='version created by this dataset&apos;s transform script'>
           <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
         </div>
       </div>

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -108,7 +108,7 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       grow: 1,
       cell: (row: VersionInfo) => (
         <div className='flex items-center truncate'>
-          <div className='w-8 mr-2'>
+          <div className='w-8 mr-2' title={row.workflowID && 'This dataset has an automation script'}>
             <Icon icon='automationFilled' className={classNames('text-qrigreen', {
               'visible': row.workflowID,
               'invisible': !row.workflowID

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -68,7 +68,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
           </div>
           {showInfo && (
             <div className='flex mt-3 text-sm'>
-              {header.workflowID && <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' />}
+              {header.runID && <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' />}
               <DatasetInfoItem icon='disk' label={fileSize(header.bodySize || 0)} />
               <DatasetInfoItem icon='download' label={getLabel(header.downloadCount, 'download')} />
               <DatasetInfoItem icon='follower' label={getLabel(header.followerCount, 'follower')} />


### PR DESCRIPTION
- Adds browser-built-in tooltips wherever we use the small "automated" icon (in commit list, collection, and run log).
- Adds browser-built-in tooltip to the large automation icon that appears in the left-most column of collection view.