### PR TITLE
feat: persis output on new runs

### DIFF
--- a/src/features/workflow/WorkflowCell.tsx
+++ b/src/features/workflow/WorkflowCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSelector } from "react-redux";
 
 import classNames from 'classnames'
@@ -10,6 +10,7 @@ import ScrollAnchor from '../scroller/ScrollAnchor'
 import WorkflowHeader from './WorkflowHeader'
 import WorkflowCellControls from './WorkflowCellControls'
 import { selectClearedCells, selectEditedCells } from "./state/workflowState";
+import { EventLogLine } from "../../qri/eventLog";
 
 export interface WorkflowCellProps {
   active: boolean
@@ -44,6 +45,15 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
   const { syntax, name, script } = step
   const editedCells = useSelector(selectEditedCells)
   const clearedCells = useSelector(selectClearedCells)
+  const [output, setOutput] = useState<EventLogLine[]>(run?.output || [])
+
+  useEffect(() => {
+    if ((run?.status === "succeeded" || run?.status === "failed") && run.output) {
+      setOutput(run.output)
+    } else if ((run?.status === "succeeded" || run?.status === "failed") && !run.output?.length){
+      setOutput([])
+    }
+  }, [ run, output ])
 
   const status = run?.status
   const isEdited = editedCells[index]
@@ -113,9 +123,9 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
             )}
           >
             {(collapseState === 'all' || collapseState === 'only-editor') && editor}
-            {(collapseState === 'all' || collapseState === 'only-output') && (run?.output || run?.status === 'running') &&
+            {(collapseState === 'all' || collapseState === 'only-output') && (output.length > 0 || run?.status === 'running') &&
             !clearedCells[index] &&
-            <Output data={run?.output} status={run?.status} wasEdited={editedCells[index]} />}
+            <Output data={output} status={run?.status} wasEdited={editedCells[index]} />}
           </div>
         </div>
         <WorkflowCellControls

--- a/src/features/workflow/output/Output.tsx
+++ b/src/features/workflow/output/Output.tsx
@@ -9,7 +9,7 @@ import RunStatusIcon from '../../run/RunStatusIcon'
 import { RunStatus } from '../../../qri/run'
 
 export interface OutputProps {
-  data?: EventLogLine[]
+  data: EventLogLine[]
   status?: RunStatus
   wasEdited: boolean
 }
@@ -33,10 +33,10 @@ const Output: React.FC<OutputProps> = ({ data, status, wasEdited }) => {
         height: 18,
         width: 18
       }}>
-        <RunStatusIcon status={status} size='2xs' />
+        {status && <RunStatusIcon status={status} size='2xs' />}
       </div>}
       <div className={classNames('max-h-96 overflow-auto output font-mono px-5 py-4 rounded-sm overflow-x-hidden border-t rounded-b-md bg-white', borderColorClass)}>
-        {data && data.map((line, i) => {
+        {data.map((line, i) => {
           switch (line.type) {
             case EventLogLineType.ETPrint:
             case EventLogLineType.ETError:
@@ -47,7 +47,7 @@ const Output: React.FC<OutputProps> = ({ data, status, wasEdited }) => {
               return <p key={i}>{JSON.stringify(line, undefined, 2)}</p>
           }
         })}
-        {status === 'running' && <p className='text-qrinavy-700 text-sm'>Running...</p>}
+        {status === 'running' && !data.length && <p className='text-qrinavy-700 text-sm'>Running...</p>}
         &nbsp;
       </div>
     </div>


### PR DESCRIPTION
When you do consecutive dry-runs, the output of the cells will persist until the new output is calculated. 

closes #394 