### PR TITLE
fix: run log commit message replaced with title

### DIFF
--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -73,7 +73,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
           runID: row.runID,
           path: row.path,
           commit: {
-            title: row.message,
+            title: row.title,
             timestamp:row.timestamp
           }
         }


### PR DESCRIPTION
run log commit message replaced with title to match commit message on history page

fixes #437 