### PR TITLE
refactor(collection): update collection based on incoming events

### DIFF
--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -17,6 +17,7 @@ import RunStatusBadge from '../run/RunStatusBadge'
 import { VersionInfo } from '../../qri/versionInfo'
 import ManualTriggerButton from '../workflow/ManualTriggerButton'
 import DatasetInfoItem from '../dataset/DatasetInfoItem'
+import { runEndTime } from '../../utils/runEndTime'
 
 interface CollectionTableProps {
   filteredWorkflows: VersionInfo[]
@@ -177,9 +178,14 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         // out this section that mocks durations & timestamps for us
         const {
           runStatus,
-          commitTime
+          runStart,
+          runDuration,
+          runCount
         } = row
-
+        let runEndLabel = <span>-</span> 
+        if (runStatus !== 'running' && runStart && runDuration) {
+          runEndLabel = <RelativeTimestamp timestamp={runEndTime(runStart, runDuration)} />
+        }
         // if status is not defined, show nothing in this column
         if (runStatus === undefined) {
           return <>&nbsp;</>
@@ -188,8 +194,8 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         return (
           <div className='flex flex-col'>
             <div className='flex items-center'>
-              <div className='text-sm mr-2'>#23</div>
-              <DatasetInfoItem icon='clock' label={<RelativeTimestamp timestamp={new Date(commitTime || '')}/>} />
+              <div className='text-sm mr-2'>{runStatus === 'running' ? '-' : `#${runCount}`}</div>
+              <DatasetInfoItem icon='clock' label={runEndLabel}/>
             </div>
             <div className='text-gray-500 text-xs'>
               <RunStatusBadge status={runStatus}/>

--- a/src/features/collection/state/collectionActions.ts
+++ b/src/features/collection/state/collectionActions.ts
@@ -1,11 +1,10 @@
 import { ApiAction, CALL_API, ApiActionThunk } from "../../../store/api"
 import { newVersionInfo, VersionInfo } from "../../../qri/versionInfo"
-import { NewWorkflow, workflowInfoFromWorkflow } from "../../../qrimatic/workflow"
-import { WORKFLOW_COMPLETED, WORKFLOW_STARTED } from "./collectionState"
-import { AnyAction } from "redux"
+import { LOGBOOK_WRITE_COMMIT, LOGBOOK_WRITE_RUN, TRANSFORM_START } from "./collectionState"
 import { RootState } from "../../../store/store";
 import { ThunkDispatch } from 'redux-thunk'
 import { QriRef } from '../../../qri/ref'
+import { TransformLifecycle } from "../../../qri/events"
 
 
 function mapVersionInfo (data: object | []): VersionInfo[] {
@@ -79,22 +78,32 @@ function fetchRunNow (qriRef: QriRef, initID: string): ApiAction {
   }
 }
 
-// workflowStarted is dispatched by the websocket and users should not need to
-// dispatch it anywhere else
-export function workflowStarted(workflow: Record<string, any>): AnyAction {
-  const wf = NewWorkflow(workflow)
+export interface LogbookWriteAction {
+  type: string
+  vi: VersionInfo
+}
+
+export function logbookWriteCommitEvent(vi: VersionInfo): LogbookWriteAction {
   return {
-    type: WORKFLOW_STARTED,
-    data: workflowInfoFromWorkflow(wf)
+    type: LOGBOOK_WRITE_COMMIT,
+    vi
   }
 }
 
-// workflowCompleted is dispatched by the websocket and users should not need to
-// dispatch it anywhere else
-export function workflowCompleted(workflow: Record<string, any>): AnyAction {
-  const wf = NewWorkflow(workflow)
+export function logbookWriteRunEvent(vi: VersionInfo): LogbookWriteAction {
   return {
-    type: WORKFLOW_COMPLETED,
-    data: workflowInfoFromWorkflow(wf)
+    type: LOGBOOK_WRITE_RUN,
+    vi
+  }
+}
+
+export interface TransformStartAction {
+  type: string
+  lc: TransformLifecycle
+}
+export function transformStartEvent(lc: TransformLifecycle): TransformStartAction {
+  return {
+    type: TRANSFORM_START,
+    lc
   }
 }

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -3,9 +3,11 @@ import { createReducer } from '@reduxjs/toolkit'
 import { newVersionInfo, VersionInfo } from '../../../qri/versionInfo';
 import { CALL_API } from "../../../store/api";
 import { runEndTime } from '../../../utils/runEndTime';
+import { LogbookWriteAction, TransformStartAction } from './collectionActions';
 
-export const WORKFLOW_STARTED = 'WORKFLOW_STARTED'
-export const WORKFLOW_COMPLETED = 'WORKFLOW_COMPLETED'
+export const LOGBOOK_WRITE_COMMIT = 'LOGBOOK_WRITE_COMMIT'
+export const LOGBOOK_WRITE_RUN = 'LOGBOOK_WRITE_RUN'
+export const TRANSFORM_START = 'TRANSFORM_START'
 
 export const selectCollection = (state: RootState): VersionInfo[] => {
   const { collection } = state.collection
@@ -82,15 +84,66 @@ export const collectionReducer = createReducer(initialState, {
     state.pendingIDs = state.pendingIDs.filter(id => id !== versionInfo.initID)
     state.collection[versionInfo.initID] = newVersionInfo(versionInfo)
   },
-  WORKFLOW_STARTED: (state, action) => {
-    const id = action.data.id
-    state.collection[id] = action.data
-  },
-  WORKFLOW_COMPLETED: (state, action) => {
-    state.collection[action.data.id] = action.data
-  },
-  'API_RUNNOW_COLLECTION_SUCCESS': (state, action) => {
-    const initID = action.payload.requestID
-    state.collection[initID].runID = action.payload.data
-  }
+  TRANSFORM_START: transformStart,
+  LOGBOOK_WRITE_RUN: logbookWriteRun,
+  LOGBOOK_WRITE_COMMIT: logbookWriteCommit,
 })
+
+function transformStart(state: CollectionState, action: TransformStartAction) {
+  const { collection } = state
+  const { mode, initID, runID } = action.lc
+
+  if (mode === "apply" || !collection[initID]) return
+
+  collection[initID].runStatus = "running"
+  collection[initID].runID = runID
+  collection[initID].runCount++
+}
+
+function logbookWriteRun(state: CollectionState, action: LogbookWriteAction) {
+  const { collection } = state
+  const { initID, runID, runStatus, runDuration, runStart } = action.vi
+
+  if (!collection[initID]) return
+
+  collection[initID].runID = runID
+  collection[initID].runStatus = runStatus
+  collection[initID].runDuration = runDuration
+  collection[initID].runStart = runStart
+}
+
+function logbookWriteCommit(state: CollectionState, action: LogbookWriteAction) {
+  const { collection } = state
+  const { vi } = action
+
+  if (!collection[vi.initID]) return
+
+  const { 
+    workflowID,
+    downloadCount, 
+    runCount, 
+    followerCount, 
+    openIssueCount, 
+    runID, 
+    runStatus, 
+    runDuration, 
+    runStart 
+  } = collection[vi.initID]
+  
+  // preserve fields that are not tracked in logbookWriteCommit
+  vi.workflowID = workflowID
+  vi.downloadCount = downloadCount
+  vi.runCount = runCount
+  vi.followerCount = followerCount
+  vi.openIssueCount = openIssueCount
+
+  // preserve "last run" information
+  if (vi.runID === "") {
+    vi.runID = runID
+    vi.runStatus = runStatus
+    vi.runDuration = runDuration
+    vi.runStart = runStart
+  }
+
+  collection[vi.initID] = vi
+}

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -1,34 +1,37 @@
 import { RootState } from '../../../store/store';
 import { createReducer } from '@reduxjs/toolkit'
-import { datasetAliasFromVersionInfo, newVersionInfo, VersionInfo } from '../../../qri/versionInfo';
+import { newVersionInfo, VersionInfo } from '../../../qri/versionInfo';
 import { CALL_API } from "../../../store/api";
+import { runEndTime } from '../../../utils/runEndTime';
 
 export const WORKFLOW_STARTED = 'WORKFLOW_STARTED'
 export const WORKFLOW_COMPLETED = 'WORKFLOW_COMPLETED'
 
 export const selectCollection = (state: RootState): VersionInfo[] => {
-  const { collection, running } = state.collection
+  const { collection } = state.collection
 
-  var ordered: VersionInfo[] = []
-  running.forEach((id: string) => {
-    // websocket may notify us about a running workflow that we haven't
-    // loaded locally yet. Return early if id is not in collection
-    if (!collection[id]) {
-      return
-    }
-    ordered.push(collection[id])
-  })
-
-  state.collection.listedIDs.forEach( (id: string) => {
-    if (running.includes(id)) {
-      return
-    }
-    ordered.push(collection[id])
-  })
+  var ordered: VersionInfo[] = Object.keys(collection).map((id: string) => collection[id])
 
   return ordered.sort((a,b) => {
-    if (a.commitTime === b.commitTime) { return 0 }
-    else if (a.commitTime > b.commitTime) { return -1 }
+    let aTime: Date
+    let bTime: Date
+    if (a.runStart && a.runDuration) {
+      aTime = runEndTime(a.runStart, a.runDuration)
+    } else if (!a.commitTime) {
+     return 0 
+    } else {
+      aTime = new Date(a.commitTime)
+    }
+
+    if (b.runStart && b.runDuration) {
+      bTime = runEndTime(b.runStart, b.runDuration)
+    } else if (!b.commitTime) {
+      return 0
+    } else {
+      bTime = new Date(b.commitTime)
+    }
+    if (aTime === bTime) { return 0 }
+    else if (aTime > bTime) { return -1 }
     return 1
   })
 }
@@ -36,30 +39,23 @@ export const selectCollection = (state: RootState): VersionInfo[] => {
 export const selectVersionInfo = ( initId: string): (state: RootState) => VersionInfo =>
   (state) => state.collection.collection[initId]
 
-export const selectIsCollectionLoading = (state: RootState): boolean => state.collection.collectionLoading && state.collection.runningLoading
+export const selectIsCollectionLoading = (state: RootState): boolean => state.collection.collectionLoading
 
 export interface CollectionState {
   // collection is a record of all the workflow infos
   collection: Record<string, VersionInfo>
-  // running contains the ids of the currently running workflows in reverse chronological
-  // order based on latestRunTime
-  running: string[]
   // ids of datasets in the current user's collection
   listedIDs: Set<string>
   // ids of run events in middle of loading
   pendingIDs: string[]
   collectionLoading: boolean
-  runningLoading: boolean
-
 }
 
 const initialState: CollectionState = {
   collection: {},
-  running: [],
   listedIDs: new Set<string>(),
   pendingIDs: [],
   collectionLoading: true,
-  runningLoading: true
 }
 
 export const collectionReducer = createReducer(initialState, {
@@ -76,27 +72,7 @@ export const collectionReducer = createReducer(initialState, {
     state.collectionLoading = false
   },
   'API_COLLECTION_FAILURE': (state, action) => {
-    state.runningLoading = false
-  },
-  'API_RUNNING_REQUEST': (state, action) => {
-    state.running = []
-    state.runningLoading = true
-  },
-  'API_RUNNING_SUCCESS': (state, action) => {
-    var running: string[] = []
-    action.payload.data.forEach( (workflow: VersionInfo) => {
-      var alias = workflow.initID
-      if (alias === '') {
-        alias = datasetAliasFromVersionInfo(workflow)
-      }
-      state.collection[alias] = workflow
-      running.push(alias)
-    })
-    state.running = running
-    state.runningLoading = false
-  },
-  'API_RUNNING_FAILURE': (state, action) => {
-    state.runningLoading = false
+    state.collectionLoading = false
   },
   'API_VERSIONINFO_REQUEST' : (state, action) => {
     state.pendingIDs.push(action[CALL_API].body.initID)
@@ -108,11 +84,6 @@ export const collectionReducer = createReducer(initialState, {
   },
   WORKFLOW_STARTED: (state, action) => {
     const id = action.data.id
-    const i = state.running.findIndex((runningID: string) => runningID === id)
-    if (i !== -1) {
-      state.running.splice(i, 1)
-    }
-    state.running.unshift(id)
     state.collection[id] = action.data
   },
   WORKFLOW_COMPLETED: (state, action) => {

--- a/src/features/workflow/ManualTriggerButton.tsx
+++ b/src/features/workflow/ManualTriggerButton.tsx
@@ -1,9 +1,9 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import ReactTooltip from 'react-tooltip'
 
 import Icon from '../../chrome/Icon'
-import { runNow, loadCollection } from '../collection/state/collectionActions'
+import { runNow } from '../collection/state/collectionActions'
 import { refStringFromQriRef } from '../../qri/ref'
 import { VersionInfo } from '../../qri/versionInfo'
 import { selectRun } from '../events/state/eventsState'
@@ -23,17 +23,6 @@ const ManualTriggerButton: React.FC<ManualTriggerButtonProps> = ({ row }) => {
   const handleClick = () => {
     dispatch(runNow({ username, name }, initID))
   }
-
-  const statusRef = useRef(status);
-
-  // when status changes from 'running' to 'succeeded', refresh the collection state
-  useEffect(() => {
-    if ((statusRef.current === 'running') && (status === 'succeeded')) {
-      dispatch(loadCollection())
-    }
-
-    statusRef.current = status
-  }, [dispatch, status])
 
   return (
     <div

--- a/src/qri/events.ts
+++ b/src/qri/events.ts
@@ -43,6 +43,20 @@ export const ETWorkflowStarted = "wf:Started"
 // payload is a Workflow
 export const ETWorkflowCompleted = "wf:Completed"
 
+// ETTransformStart signals the start of a transform execution
+// payload is a TransformLifecycle
+export const ETTransformStart = "tf:Start"
+
+// ETLogbookWriteRun occurs when the logbook writes an op of model
+// `RunModel`, indicating that a new run of a dataset has occured
+// payload is a dsref.VersionInfo
+export const ETLogbookWriteRun = "logbook:WriteRun"
+// ETLogbookWriteCommit occurs when the logbook writes an op of model
+// `CommitModel`, indicating that a new dataset version has been saved
+// payload is a dsref.VersionInfo
+export const ETLogbookWriteCommit = "logbook:WriteCommit"
+
+
 export const ETAutomationDeployStart = "automation:DeployStart"
 export const ETAutomationDeployEnd = "automation:DeployEnd"
 
@@ -58,3 +72,21 @@ export const WSSubscribeRequest = "subscribe:request"
 export const WSSubscribeSuccess = "subscribe:success"
 export const WSSubscribeFailure = "subscribe:failure"
 export const WSUnsubscribeRequest = "unsubscribe:request"
+
+export interface TransformLifecycle {
+  runID: string
+  stepCount: number
+  status: string
+  mode: string
+  initID: string
+}
+
+export function NewTransformLifecycle(data: Record<string,any>): TransformLifecycle {
+  return {
+    runID: data.runID,
+    stepCount: data.stepCount,
+    status: data.status,
+    mode: data.mode,
+    initID: data.initID
+  }
+}

--- a/src/qri/versionInfo.ts
+++ b/src/qri/versionInfo.ts
@@ -35,7 +35,8 @@ export interface VersionInfo {
 
   runID?: string
   runStatus?: RunStatus
-  runDuration?: number
+  runDuration?: number // duration of the run in nanoseconds
+  runStart?: string
 
   // TODO (boandriy): These fields are only temporarily living on `VersionInfo`.
   // When we get more user feedback and settle what info
@@ -79,6 +80,7 @@ export function newVersionInfo(data: Record<string,any>): VersionInfo {
     runID: data.runID,
     runStatus: data.runStatus,
     runDuration: data.runDuration,
+    runStart: data.runStart,
 
     // TODO(boandriy): the following fields are likely to be removed from the VersionInfo
     // type in the future

--- a/src/utils/runEndTime.ts
+++ b/src/utils/runEndTime.ts
@@ -1,0 +1,4 @@
+export function runEndTime(runStart: string, runDuration: number): Date {
+  const runStartTime = new Date(runStart)
+  return new Date(runStartTime.getTime() + (runDuration / 1000000))
+}


### PR DESCRIPTION
This PR allows the collection view to respond to incoming events that have to do with transform runs, so that we can display to the user that the particular.

This essentially "copies" the behavior of the backend collection. Normally I would not be up for duplicating code like this, but the way we have framed the collection on the backend actually folds in rather nicely to the redux reducer pattern. It prevents unnecessary fetching, and is scoped to only three events: `ETTransformStart`, `ETLogbookWriteRun`, & `ETLogbookWriteCommit`. It would be simple to expand these cases *if we need to* at some point in the future, if we add more functionality to the collection view and would like to prevent fetching of data that already comes across over the websocket connection.

This PR also adds the `runStart` field to `VersionInfo` that we can use along with the `runDuration` to calculate the `runEnd` time.

closes #285 

depends on qri-io/qri#1945