### PR TITLE
fix: disabling dry run button for users that are not logged in

### DIFF
--- a/src/chrome/Button.tsx
+++ b/src/chrome/Button.tsx
@@ -23,7 +23,14 @@ export type ButtonType = 'primary' // light blue button with white text
       'text-white bg-dangerred hover:bg-dangerred-600': (type === 'danger'),
       'text-qrigray-400 hover:text-qrigray-600 border border-qrigray-400 hover:border-qrigray-600': (type === 'light'),
       'text-qrigray-900 hover:text-qripink border border-qrigray-900 hover:border-qripink': (type === 'dark'),
-      'cursor-default bg-opacity-40 hover:bg-opacity-40': disabled
+      'cursor-default text-white bg-qrigray-400 hover:bg-qrigray-400': (type === 'primary' && disabled),
+      'text-qrigray-400 border border-qrigray-400 box-border hover:text-qrigray-400 hover:border-qrigray-400': (type === 'primary-outline' && disabled),
+      'text-white bg-qrigray-400 hover:bg-qrigray-400': ((type === 'secondary' || type === 'danger') && disabled),
+      'text-qrigray-400 hover:text-qrigray-400 border border-qrigray-400 hover:border-qrigray-400 box-border': (type === 'secondary-outline' && disabled),
+      'text-qrigray-400 bg-qrigray-400 hover:bg-qrigray-400': (type === 'warning' && disabled),
+      'text-qrigray-400 hover:text-qrigray-400 border border-qrigray-400 hover:border-qrigray-400': (type === 'light' && disabled),
+      'text-qrigray-400 hover:text-qripink border border-qrigray-400 hover:border-qrigray-400': (type === 'dark' && disabled),
+      'cursor-default': disabled
     }
   }
 

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -86,7 +86,7 @@ const RunBar: React.FC<RunBarProps> = ({
               )
             : (
                 <div data-tip data-for='dry-run'>
-                  <Button type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
+                  <Button disabled={!canEdit} type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
                 </div>
               )
           }
@@ -97,7 +97,10 @@ const RunBar: React.FC<RunBarProps> = ({
         id='dry-run'
         effect='solid'
       >
-        Try this script and preview the results without saving ({isMac ? '⌘' : 'Ctrl'}+↵)
+        {canEdit ?
+          `Try this script and preview the results without saving (${isMac ? '⌘' : 'Ctrl'}+↵)` :
+          'Only the dataset owner can run this script'
+        }
       </ReactTooltip>
     </div>
   )


### PR DESCRIPTION
disabling dry run button for users that are not logged in

fixes #441 

@chriswhong , the button has no disabled styles, I have changed the tooltip for the button to 'Please log in before running script', Let me know if I should add the styles to disabled button.

![image](https://user-images.githubusercontent.com/22635911/138676580-9f7738bc-d36e-41b3-8a43-4f36468eb136.png)
