### PR TITLE
feat(workflow): cancel dry runs and runs

### DIFF
--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -7,7 +7,7 @@ import ActivityList from './ActivityList'
 import { loadDatasetLogs } from './state/activityFeedActions'
 import { newDatasetLogsSelector } from './state/activityFeedState'
 import DatasetFixedLayout from '../dataset/DatasetFixedLayout'
-import { runNow } from '../workflow/state/workflowActions'
+import { cancelRun, runNow } from '../workflow/state/workflowActions'
 import { selectLatestRunId } from '../workflow/state/workflowState'
 import RunNowButton from './RunNowButton'
 import { LogItem, NewLogItem } from "../../qri/log"
@@ -43,6 +43,10 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
     dispatch(runNow(qriRef))
   }
 
+  const handleCancelRun = () => {
+    dispatch(cancelRun(latestRun.id))
+  }
+
   useEffect(() => {
     if (latestRun.status === 'running') {
       const runningLog:LogItem = NewLogItem({
@@ -71,7 +75,7 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
   }, [ logs, latestRun ])
 
   return (
-    <DatasetFixedLayout headerChildren={<RunNowButton status={latestRun?.status} onClick={handleRunNowClick} />}>
+    <DatasetFixedLayout headerChildren={<RunNowButton status={latestRun?.status} onClick={handleRunNowClick} onCancel={handleCancelRun} />}>
       <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white'>
         <div className='rounded-none h-full'>
           <ActivityList

--- a/src/features/activityFeed/RunNowButton.tsx
+++ b/src/features/activityFeed/RunNowButton.tsx
@@ -6,18 +6,21 @@ import { RunStatus } from '../../qri/run'
 export interface RunNowButtonProps {
   status: RunStatus
   onClick: () => void
+  onCancel: () => void
 }
 
 const RunNowButton: React.FC<RunNowButtonProps> = ({
   status,
-  onClick
+  onClick,
+  onCancel
 }) => {
   let text = 'Run Now'
   if (status === 'running') {
-    text = 'Running'
+    text = 'Cancel'
   }
+
   return (
-    <Button type='primary' icon={ status === 'running' ? 'loader' : 'play'} disabled={status === 'running'} onClick={onClick}>
+    <Button type='primary' icon={ status === 'running' ? 'loader' : 'play'} disabled={status === 'running'} onClick={status === 'running' ? onCancel : onClick}>
       {text}
     </Button>
   )

--- a/src/features/collection/state/collectionActions.ts
+++ b/src/features/collection/state/collectionActions.ts
@@ -5,6 +5,7 @@ import {
   LOGBOOK_WRITE_RUN,
   REMOVE_COLLECTION_ITEM,
   RESET_COLLECTION_STATE,
+  TRANSFORM_CANCELED,
   TRANSFORM_START
 } from "./collectionState"
 import { RootState } from "../../../store/store";
@@ -117,7 +118,7 @@ export function removeCollectionItem(username: string, name: string): RemoveColl
   }
 }
 
-export interface TransformStartAction {
+export interface TransformAction {
   type: string
   lc: TransformLifecycle
 }
@@ -126,9 +127,16 @@ export interface ResetCollectionStateAction {
   type: string
 }
 
-export function transformStartEvent(lc: TransformLifecycle): TransformStartAction {
+export function transformStartEvent(lc: TransformLifecycle): TransformAction {
   return {
     type: TRANSFORM_START,
+    lc
+  }
+}
+
+export function transformCanceledEvent(lc: TransformLifecycle): TransformAction {
+  return {
+    type: TRANSFORM_CANCELED,
     lc
   }
 }

--- a/src/features/collection/state/collectionState.ts
+++ b/src/features/collection/state/collectionState.ts
@@ -7,12 +7,13 @@ import {
   LogbookWriteAction,
   RemoveCollectionItemAction,
   ResetCollectionStateAction,
-  TransformStartAction
+  TransformAction
 } from './collectionActions';
 
 export const LOGBOOK_WRITE_COMMIT = 'LOGBOOK_WRITE_COMMIT'
 export const LOGBOOK_WRITE_RUN = 'LOGBOOK_WRITE_RUN'
 export const TRANSFORM_START = 'TRANSFORM_START'
+export const TRANSFORM_CANCELED = 'TRANSFORM_CANCELED'
 export const REMOVE_COLLECTION_ITEM = 'REMOVE_COLLECTION_ITEM'
 export const RESET_COLLECTION_STATE = 'RESET_COLLECTION_STATE'
 
@@ -92,6 +93,7 @@ export const collectionReducer = createReducer(initialState, {
     state.collection[versionInfo.initID] = newVersionInfo(versionInfo)
   },
   TRANSFORM_START: transformStart,
+  TRANSFORM_CANCELED: transformCanceled,
   LOGBOOK_WRITE_RUN: logbookWriteRun,
   LOGBOOK_WRITE_COMMIT: logbookWriteCommit,
   REMOVE_COLLECTION_ITEM:removeCollectionItem,
@@ -100,7 +102,7 @@ export const collectionReducer = createReducer(initialState, {
   },
 })
 
-function transformStart(state: CollectionState, action: TransformStartAction) {
+function transformStart(state: CollectionState, action: TransformAction) {
   const { collection } = state
   const { mode, initID, runID } = action.lc
 
@@ -109,6 +111,15 @@ function transformStart(state: CollectionState, action: TransformStartAction) {
   collection[initID].runStatus = "running"
   collection[initID].runID = runID
   collection[initID].runCount++
+}
+
+function transformCanceled(state: CollectionState, action: TransformAction) {
+  const { collection } = state
+  const { mode, initID } = action.lc
+
+  if (mode === 'apply' || !collection[initID]) return
+  
+  collection[initID].runStatus = "failed"
 }
 
 function logbookWriteRun(state: CollectionState, action: LogbookWriteAction) {

--- a/src/features/session/state/sessionState.ts
+++ b/src/features/session/state/sessionState.ts
@@ -14,6 +14,7 @@ export const selectSessionTokens = (state: RootState): SessionTokens => {
   }
 }
 export const selectIsSessionLoading = (state: RootState): boolean => state.session.loading
+export const selectIsLoggedIn = (state: RootState): boolean => state.session.user.username !== 'new'
 
 export interface User {
   name?: string

--- a/src/features/websocket/middleware/websocket.ts
+++ b/src/features/websocket/middleware/websocket.ts
@@ -5,7 +5,7 @@ import { NewEventLogLine } from '../../../qri/eventLog'
 import { RootState } from '../../../store/store'
 import { trackVersionTransfer, completeVersionTransfer, removeVersionTransfer } from '../../transfer/state/transferActions'
 import { runEventLog } from '../../events/state/eventsActions'
-import { logbookWriteCommitEvent, logbookWriteRunEvent, transformStartEvent } from '../../collection/state/collectionActions'
+import { logbookWriteCommitEvent, logbookWriteRunEvent, transformStartEvent, transformCanceledEvent } from '../../collection/state/collectionActions'
 import {
   deployStarted,
   deployEnded,
@@ -37,6 +37,7 @@ import {
   ETLogbookWriteRun,
   ETLogbookWriteCommit,
   NewTransformLifecycle,
+  ETTransformCancel,
 } from '../../../qri/events'
 import { wsConnectionChange } from '../state/websocketActions'
 import { WS_CONNECT, WS_DISCONNECT } from '../state/websocketState'
@@ -113,6 +114,7 @@ const middleware = () => {
 
       if (event.type.startsWith("tf:")) {
         if (event.type === ETTransformStart) dispatch(transformStartEvent(NewTransformLifecycle(event.data)))
+        if (event.type === ETTransformCancel) dispatch(transformCanceledEvent(NewTransformLifecycle(event.data)))
         dispatch(runEventLog(NewEventLogLine(event)))
         return
       }
@@ -283,3 +285,4 @@ const middleware = () => {
 }
 
 export const websocketMiddleware = middleware()
+

--- a/src/features/workflow/ManualTriggerButton.tsx
+++ b/src/features/workflow/ManualTriggerButton.tsx
@@ -8,6 +8,7 @@ import { refStringFromQriRef } from '../../qri/ref'
 import { VersionInfo } from '../../qri/versionInfo'
 import { selectRun } from '../events/state/eventsState'
 import { trackGoal } from '../../features/analytics/analytics'
+import { cancelRun } from './state/workflowActions'
 
 export interface ManualTriggerButtonProps  {
   row: VersionInfo
@@ -18,7 +19,7 @@ const ManualTriggerButton: React.FC<ManualTriggerButtonProps> = ({ row }) => {
   const dispatch = useDispatch()
 
   const id = refStringFromQriRef({ username, name })
-  const { status } = useSelector(selectRun(runID))
+  const { status } = useSelector(selectRun(runID || ''))
 
   const handleClick = () => {
     //collection-run-now event
@@ -26,14 +27,18 @@ const ManualTriggerButton: React.FC<ManualTriggerButtonProps> = ({ row }) => {
     dispatch(runNow({ username, name }, initID))
   }
 
+  const handleCancel = () => {
+    dispatch(cancelRun(runID || ''))
+  }
+
   return (
     <div
       className='mx-auto'
       data-for={id}
       data-tip
-      onClick={handleClick}
+      onClick={status === 'running'? handleCancel : handleClick}
     >
-      <Icon icon={ status === 'running' ? 'loader' : 'playCircle'} size='lg' className='text-qritile'/>
+      <Icon icon={ status === 'running' ? 'circleX' : 'playCircle'} size='lg' className='text-qritile'/>
       <ReactTooltip
         id={id}
         place='bottom'

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -5,7 +5,7 @@ import ReactTooltip from 'react-tooltip'
 import Button from '../../chrome/Button'
 import { RunStatus } from '../../qri/run'
 import RunStatusIcon from '../run/RunStatusIcon'
-import { applyWorkflowTransform } from './state/workflowActions'
+import { applyWorkflowTransform, cancelRun } from './state/workflowActions'
 import { deployResetRunId } from '../deploy/state/deployActions'
 import {
   selectWorkflow,
@@ -63,7 +63,7 @@ const RunBar: React.FC<RunBarProps> = ({
     dispatch(applyWorkflowTransform(workflow, workflowDataset))
   }
 
-  const handleCancel = () => { alert('cannot cancel runs yet') }
+  const handleCancel = () => { dispatch(cancelRun(latestDryRunId)) }
 
   const isMac = (platform() === 'mac')
 
@@ -91,7 +91,7 @@ const RunBar: React.FC<RunBarProps> = ({
               )
             : (
                 <div data-tip data-for='dry-run'>
-                  <Button disabled={(!canEdit && !isNew)} type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
+                  <Button disabled={!((isNew && isLoggedIn) || canEdit)} type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
                 </div>
               )
           }

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -24,6 +24,7 @@ import { removeEvent } from "../events/state/eventsActions";
 import { selectDeployRunId } from "../deploy/state/deployState";
 import { selectSessionUserCanEditDataset } from '../dataset/state/datasetState'
 import { trackGoal } from '../../features/analytics/analytics'
+import { selectIsLoggedIn } from '../session/state/sessionState'
 
 export interface RunBarProps {
  status: RunStatus
@@ -43,6 +44,7 @@ const RunBar: React.FC<RunBarProps> = ({
   const latestDeployRunId = useSelector(selectDeployRunId)
   const qriRef = newQriRef(useParams())
   const areCellsEdited = useSelector(selectEditedCells)
+  const isLoggedIn = useSelector(selectIsLoggedIn)
 
   const removeRunEvents = () => {
     if (latestDryRunId)
@@ -100,7 +102,7 @@ const RunBar: React.FC<RunBarProps> = ({
         id='dry-run'
         effect='solid'
       >
-        {canEdit ?
+        {canEdit || (isNew && isLoggedIn) ?
           `Try this script and preview the results without saving (${isMac ? '⌘' : 'Ctrl'}+↵)` :
           'Only the dataset owner can run this script'
         }

--- a/src/features/workflow/state/workflowActions.ts
+++ b/src/features/workflow/state/workflowActions.ts
@@ -195,7 +195,20 @@ export function applyWorkflowTransform (w: Workflow, d: Dataset): ApiActionThunk
   }
 }
 
-
+export function cancelRun(runID: string): ApiActionThunk {
+  return async (dispatch) => {
+    return dispatch({
+      type: 'cancel',
+      [CALL_API]: {
+        endpoint: 'auto/cancel',
+        method: 'POST',
+        body: {
+          runID
+        }
+      }
+    })
+  }
+}
 
 export interface SetWorkflowAction {
   type: string

--- a/src/qri/events.ts
+++ b/src/qri/events.ts
@@ -46,6 +46,10 @@ export const ETWorkflowCompleted = "wf:Completed"
 // ETTransformStart signals the start of a transform execution
 // payload is a TransformLifecycle
 export const ETTransformStart = "tf:Start"
+// ETTransformCanceled signals that the transform was canceled before it
+// could fully execute
+// payload is a TransformLifecycle
+export const ETTransformCancel = "tf:Canceled"
 
 // ETLogbookWriteRun occurs when the logbook writes an op of model
 // `RunModel`, indicating that a new run of a dataset has occured


### PR DESCRIPTION
closes #68 
depends on qri-io/qri#1949

Clicking "Cancel" during a "dry run" will cancel the run.

Also fixes bug where user could not "dry run" a new workflow, even when logged in.

Also adjusts `/activity` pagination to use `limit` rather than `pageSize`