### PR TITLE
Cw/next version preview info

### DIFF
--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -11,76 +11,64 @@ interface DatasetCommitInfoProps {
   dataset: Dataset
   // small yields the same info with smaller text, used in collection, history list and run log
   small?: boolean
-  // isRow indicates whether this is being displayed inline in a row in a list (versus in a card)
-  // and is used to tweak styles
+  // inRow will set the commit title to normal (instead of semibold) so it's less noisy when displayed in a row of other info
   inRow?: boolean
   // custom styles are applied if the commit info is for preview page
   preview?: boolean
+  // sets the maxWidth, used for dynamic display in dataset preview page
   flex?: boolean
 }
 
 const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
   dataset,
   small=false,
-  inRow=false,
-  preview=false,
-  flex=false
+  inRow=false
 }) => {
-  let maxWidht = ''
-  if (preview && !flex) {
-    maxWidht = '220px'
-  } else if (preview && flex) {
-    maxWidht = '550px'
-  }
-
   return (
   <div className={classNames('truncate', {
     'text-base': !small,
     'text-sm': small
   })}>
-    {dataset.path && preview && !flex &&  (
-      <div className='flex items-center leading-tight text-sm mb' title={dataset.path}>
-        <Icon icon='commit' size={'xs'} className='-ml-1' />
-        <div className='font-semibold'>{commitishFromPath(dataset.path)}</div>
-      </div>
-    )}
+    {/* first row (commit title) */}
     <div className={classNames('text-black flex justify-between items-center mb-2', {
       'font-semibold': !inRow
     })}>
-      {dataset.path && preview && flex &&  (
-        <div className='flex items-center leading-tight text-sm mb border-r pr-2 mr-2' title={dataset.path}>
-          <Icon icon='commit' size={'xs'} className='-ml-1' />
-          <div className='font-semibold'>{commitishFromPath(dataset.path)}</div>
-        </div>
-      )}
-      <div className={`dataset_commit_info_text ${preview && 'text-xs'} truncate flex-grow`} style={{maxWidth: maxWidht}} title={dataset.commit?.title}>{dataset.commit?.title}</div>
+      <div className={classNames(`dataset_commit_info_text truncate flex-grow`, {
+
+      })} title={dataset.commit?.title}>{dataset.commit?.title}</div>
     </div>
+    {/* end first row */}
+
+    {/* second row (icons) */}
     <div className={classNames('flex items-center text-qrigray-400', {
       'text-xs': small
     })}>
+      {/* automation icon */}
       {dataset.runID && (
-        <div className='flex-grow-0 text-qrigreen mr-2' title='version created by this dataset&apos;s transform script'>
-          <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
+        <div className='flex-grow-0 mr-2' title='version created by this dataset&apos;s transform script'>
+          <Icon icon='automationFilled' size={small ? '2xs' : 'xs'}/>
         </div>
       )}
-      {preview ?
-        <>
-          <RelativeTimestampWithIcon className='mr-3 text-xs' timestamp={new Date(dataset.commit?.timestamp)} />
-          <UsernameWithIcon username={dataset.username} tooltip className='mr-2 text-xs' iconWidth={small ? 14 : 18} iconOnly={small} />
-        </>:
-        <>
-          <UsernameWithIcon username={dataset.username} tooltip className='mr-2' iconWidth={small ? 14 : 18} iconOnly={small} />
-          <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
-        </>
-      }
+      {/* end automation icon */}
 
-      {dataset.path && !preview &&  (
+      {/* username icon */}
+      <UsernameWithIcon username={dataset.username} tooltip className='mr-2' iconWidth={small ? 12 : 18} iconOnly={small} />
+      {/* end username icon */}
+
+      {/* relative timestamp icon */}
+      <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit?.timestamp)} />
+      {/* end relative timestamp icon */}
+
+      {/* commit icon */}
+      {dataset.path &&  (
         <div className='flex items-center leading-tight' title={dataset.path}>
           <Icon icon='commit' size={small ? 'xs' : 'sm'} className='-ml-2' />
           <div>{commitishFromPath(dataset.path)}</div>
         </div>
       )}
+      {/* end commit icon */}
     </div>
+    {/* end second row */}
   </div>
 )}
 

--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -54,15 +54,15 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
         </div>
       )}
       <div className={`dataset_commit_info_text ${preview && 'text-xs'} truncate flex-grow`} style={{maxWidth: maxWidht}} title={dataset.commit?.title}>{dataset.commit?.title}</div>
-      {dataset.runID && (
-        <div className='flex-grow-0 text-qrigreen' title='version created by this dataset&apos;s transform script'>
-          <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
-        </div>
-      )}
     </div>
     <div className={classNames('flex items-center text-qrigray-400', {
       'text-xs': small
     })}>
+      {dataset.runID && (
+        <div className='flex-grow-0 text-qrigreen mr-2' title='version created by this dataset&apos;s transform script'>
+          <Icon icon='automationFilled' size={small ? 'xs' : 'sm'}/>
+        </div>
+      )}
       {preview ?
         <>
           <RelativeTimestampWithIcon className='mr-3 text-xs' timestamp={new Date(dataset.commit?.timestamp)} />

--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -17,12 +17,16 @@ interface DatasetCommitInfoProps {
   preview?: boolean
   // sets the maxWidth, used for dynamic display in dataset preview page
   flex?: boolean
+  // determines whether or not to show the automated icon.  This should be included in dataset, but our responses
+  // are inconsistent, so this prop allows us to turn it on manually wherever we know it should appear
+  automated?: boolean
 }
 
 const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
   dataset,
   small=false,
-  inRow=false
+  inRow=false,
+  automated=false
 }) => {
   return (
   <div className={classNames('truncate', {
@@ -44,7 +48,7 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
       'text-xs': small
     })}>
       {/* automation icon */}
-      {dataset.runID && (
+      {automated && (
         <div className='flex-grow-0 mr-2' title='version created by this dataset&apos;s transform script'>
           <Icon icon='automationFilled' size={small ? '2xs' : 'xs'}/>
         </div>

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -81,7 +81,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
           const versionLink = `/${row.username}/${row.name}/at${row.path}/history/body`
           return (
             <Link to={versionLink} className='min-w-0 flex-grow'>
-              <DatasetCommitInfo dataset={dataset} small inRow />
+              <DatasetCommitInfo dataset={dataset} small inRow automated/>
             </Link>
           )
         } else {

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -170,7 +170,7 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
         const versionLink = `/${row.username}/${row.name}/at${row.path}/history`
         return (
           <Link to={versionLink} className='min-w-0 flex-grow'>
-            <DatasetCommitInfo dataset={dataset} small inRow />
+            <DatasetCommitInfo dataset={dataset} small inRow automated={!!runID}/>
           </Link>
         )
       }

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -117,19 +117,20 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       grow: 1,
       cell: (row: VersionInfo) => (
         <div className='flex items-center truncate'>
-          <div className='w-8 mr-2 flex-shrink-0'  title={row.workflowID && 'This dataset has an automation script'}>
-            <Icon icon='automationFilled' size='sm' className={classNames('text-qrigreen', {
-              'visible': row.runID,
-              'invisible': !row.runID
-            })}/>
-          </div>
+
           <div className='truncate'>
             <div className='mb-1'>
               <Link to={pathToDatasetHeadPreview(row, { ignorePath: true })}>
                 <UsernameWithIcon username={`${row.username}/${row.name}`}  className='text-sm font-bold text-black ' />
               </Link>
             </div>
-            <div className='flex text-xs overflow-y-hidden'>
+            <div className='flex text-xs items-center overflow-y-hidden'>
+              <div className='mr-2 flex-shrink-0'  title={row.workflowID && 'This dataset has an automation script'}>
+                <Icon icon='automationFilled' size='2xs' className={classNames('text-qrigray-400', {
+                  'visible': row.runID,
+                  'invisible': !row.runID
+                })}/>
+              </div>
               <DatasetInfoItem icon='disk' label={numeral(row.bodySize).format('0.0 b')} size='sm' />
               <DatasetInfoItem icon='rows' label={numeral(row.bodyRows).format('0,0a')} size='sm' />
               <DatasetInfoItem icon={'commit'} label={row.commitCount.toString()} size='sm' />

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -31,7 +31,7 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
   }
 
   const content = (
-    <DatasetCommitInfo dataset={dataset} small />
+    <DatasetCommitInfo dataset={dataset} small automated={!!dataset.runID} />
   )
 
   const containerClassNames = classNames('block rounded-md px-3 py-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-qrigray-400 border border-qrigray-300')

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -69,11 +69,11 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                     <div className='flex items-center'>
                       <div className='flex-grow truncate'>
                         <div className='flex items-center justify-between'>
-                          <div>
+                          <div className='flex-grow min-w-0 pr-6'>
                             <ContentBoxTitle title='Latest Version' />
-                            <DatasetCommitInfo preview={true} flex={!dataset.readme} inRow={true} dataset={dataset} />
+                            <DatasetCommitInfo dataset={dataset} small />
                           </div>
-                          <div className='flex'>
+                          <div className='flex flex-shrink-0'>
                             <DownloadDatasetButton hideIcon={true} type='primary' qriRef={qriRef} />
                           </div>
                         </div>

--- a/src/features/workflow/RunBar.tsx
+++ b/src/features/workflow/RunBar.tsx
@@ -89,7 +89,7 @@ const RunBar: React.FC<RunBarProps> = ({
               )
             : (
                 <div data-tip data-for='dry-run'>
-                  <Button disabled={!canEdit} type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
+                  <Button disabled={(!canEdit && !isNew)} type='secondary-outline' icon='playCircle' className='run_bar_run_button justify-items-start mr-2' onClick={() => { handleRun() }}>Dry Run</Button>
                 </div>
               )
           }

--- a/src/features/workflow/WorkflowEditor.tsx
+++ b/src/features/workflow/WorkflowEditor.tsx
@@ -45,6 +45,9 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const [activeCell, setActiveCell] = useState<number>(-1)
   const [addedCell, setAddedCell] = useState<number>(-1)
   const [collapseStates, setCollapseStates] = useState({} as Record<string, "all" | "collapsed" | "only-editor" | "only-output">)
+
+  const isNew = !qriRef.username && !qriRef.name
+
   const collapseState = (stepName: string, run?: RunStep): "all" | "collapsed" | "only-editor" | "only-output" => {
     if (collapseStates[stepName]) {
       return collapseStates[stepName]
@@ -147,7 +150,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                 return (
                   <WorkflowCell
                     active={activeCell === i}
-                    disabled={run?.status === 'running' || !canEdit}
+                    disabled={run?.status === 'running' || (!canEdit && !isNew)}
                     key={step.category}
                     index={i}
                     step={step}

--- a/src/features/workflow/WorkflowOutline.tsx
+++ b/src/features/workflow/WorkflowOutline.tsx
@@ -55,6 +55,7 @@ const WorkflowOutline: React.FC<WorkflowOutlineProps> = ({
             </ScrollTrigger>
           </div>
           <WorkflowCellsStatus run={run} dataset={dataset} />
+          <div className='text-sm font-semibold mt-3 mb-1'>Next Version Preview</div>
           <WorkflowScriptStatus run={run} />
 
           <ScrollTrigger target='on-completion'>

--- a/src/features/workflow/WorkflowScriptStatus.tsx
+++ b/src/features/workflow/WorkflowScriptStatus.tsx
@@ -1,50 +1,27 @@
 import React from 'react'
 
-import { Run, RunStatus } from '../../qri/run'
+import { Run } from '../../qri/run'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 
 interface WorkflowScriptStatusProps {
   run?: Run
 }
 
-interface StatusMapping {
-  classes: string
-}
-
-type StatusMappings = {
-  [key in RunStatus]: StatusMapping
-}
-
-const statusMappings: StatusMappings = {
-  waiting: {
-    classes: 'border-solid border-qrigray-200 border text-qrigray-400'
-  },
-  running: {
-    classes: 'border-solid border-qrigray-200 border text-qrigray-400'
-  },
-  succeeded: {
-    classes: 'text-black bg-white'
-  },
-  failed: {
-    classes: 'border-solid bg-white border-dangerred border text-black'
-  },
-  unchanged: {
-    classes: 'bg-blue'
-  },
-  skipped: {
-    classes: 'border-solid border-qrigray-200 border text-qrigray-400'
-  },
-  '': {
-    classes: 'border-solid border-qrigray-200 border text-qrigray-400'
-  }
-}
-
 const WorkflowScriptStatus: React.FC<WorkflowScriptStatusProps> = ({
   run
 }) => {
-  const { classes } = statusMappings[run?.status || '']
+  const { dsPreview } = run
+
+  let classes = 'border-solid border-qrigray-200 border text-qrigray-400'
+  if (run?.status === 'succeeded') {
+    classes = 'text-black bg-white'
+  }
+
   return (
-    <div className={`${classes} px-2 pt-2 pb-2 rounded-lg mb-5`}>
-      <div className='mb-2 text-sm tracking-wide'>New Preview Version</div>
+    <div className={`${classes} px-2 pt-2 pb-2 rounded-lg mb-5`} style={{
+      minHeight: 54
+    }}>
+      {dsPreview && <DatasetCommitInfo dataset={dsPreview} small automated />}
     </div>
   )
 }


### PR DESCRIPTION
Builds on work in #481, merge that one first.

- Uses `DatasetCommitInfo` in Workflow Outline to indicate the Next Version Preview is available
- Adds `automated` prop to `DatasetCommitInfo` since `runID` is used inconsistently.  This can be set to true for all workflow dry runs.
- Audits usage of `DatasetCommitInfo` to ensure we are always properly showing `automated` status where we can.  (there are two places where we can't see #430)

![image](https://user-images.githubusercontent.com/1833820/139312709-6d6358c1-4ee3-435e-ba3e-249437db141e.png)


Closes #393 