### PR TITLE
fix: reset 404 error state on new request

### DIFF
--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -29,14 +29,6 @@ const initialState: DsPreviewState = {
 }
 
 export const dsPreviewReducer = createReducer(initialState, {
-
-
-
-  'API_PREVIEW_REQUEST': (state) => {
-    state.preview = NewDataset({})
-    state.loading = true
-  },
-
   'DS_PREVIEW_REQUEST': (state) => {
     state.loading = true
   },
@@ -47,7 +39,11 @@ export const dsPreviewReducer = createReducer(initialState, {
     state.loading = false
   },
 
-
+  'API_PREVIEW_REQUEST': (state) => {
+    state.preview = NewDataset({})
+    state.loading = true
+    state.error = NewApiErr()
+  },
   'API_PREVIEW_FAILURE': (state, action) => {
     state.loading = false
     state.error = action.payload.err

--- a/src/features/userProfile/state/userProfileState.ts
+++ b/src/features/userProfile/state/userProfileState.ts
@@ -59,6 +59,7 @@ const initialState: UserProfileState = {
 export const userProfileReducer = createReducer(initialState, {
   'API_USERPROFILE_REQUEST': (state: UserProfileState, action) => {
     state.loading = true
+    state.error = NewApiErr()
   },
   'API_USERPROFILE_SUCCESS': (state: UserProfileState, action) => {
     state.profile = action.payload.data


### PR DESCRIPTION
Fixes bug where once a 404 is encountered, all userprofile or dataset routes will also 404 because the state is never reset.