### PR TITLE
refactor: split up history and runs api calls

### DIFF
--- a/src/features/activityFeed/state/activityFeedActions.ts
+++ b/src/features/activityFeed/state/activityFeedActions.ts
@@ -14,14 +14,15 @@ export function loadDatasetLogs(qriRef: QriRef): ApiActionThunk {
 
 function fetchDatasetLogs(qriRef: QriRef): ApiAction {
   return {
-    type: 'dataset_activity',
+    type: 'dataset_activity_runs',
     qriRef,
     [CALL_API]: {
       endpoint: `ds/activity`,
       method: 'POST',
       body: {
         ref: `${qriRef.username}/${qriRef.name}`,
-        pageSize: 100
+        limit: 500,
+        term: 'run'
       },
       map: mapLogs
     }

--- a/src/features/activityFeed/state/activityFeedState.ts
+++ b/src/features/activityFeed/state/activityFeedState.ts
@@ -3,6 +3,8 @@ import { createReducer } from '@reduxjs/toolkit'
 import { RootState } from '../../../store/store';
 import { QriRef, humanRef, refStringFromQriRef } from '../../../qri/ref';
 import { LogItem } from '../../../qri/log';
+import { ApiErr, NewApiErr } from '../../../store/api'
+
 
 export function newDatasetLogsSelector(qriRef: QriRef): (state: RootState) => LogItem[] {
   return (state: RootState) => {
@@ -19,15 +21,28 @@ export function selectLogCount(qriRef: QriRef): (state: RootState) => number {
 
 export interface ActivityFeedState {
   datasetLogs: Record<string,LogItem[]>
+  loading: boolean
+  error: ApiErr
 }
 
 const initialState: ActivityFeedState = {
-  datasetLogs: {}
+  datasetLogs: {},
+  loading: false,
+  error: NewApiErr()
 }
 
 export const activityFeedReducer = createReducer(initialState, {
-  'API_DATASET_ACTIVITY_SUCCESS': (state, action) => {
-    const ls = action.payload.data.filter((d: LogItem)  => d.runStatus) as LogItem[]
-    state.datasetLogs[refStringFromQriRef(action.qriRef)] = ls
+  'API_DATASET_ACTIVITY_RUNS_REQUEST': (state, action) => {
+    state.loading = true
+  },
+
+  'API_DATASET_ACTIVITY_RUNS_SUCCESS': (state, action) => {
+    state.loading = false
+    state.datasetLogs[refStringFromQriRef(action.qriRef)] = action.payload.data
+  },
+
+  'API_DATASET_ACTIVITY_RUNS_FAILURE': (state, action) => {
+    state.loading = false
+    state.error = action.payload.err
   },
 })

--- a/src/features/commits/state/commitActions.ts
+++ b/src/features/commits/state/commitActions.ts
@@ -14,13 +14,15 @@ export function loadDatasetCommits(qriRef: QriRef): ApiActionThunk {
 
 function fetchDatasetCommits(qriRef: QriRef): ApiAction {
   return {
-    type: 'dataset_activity',
+    type: 'dataset_activity_history',
     qriRef,
     [CALL_API]: {
       endpoint: `ds/activity`,
       method: 'POST',
       body: {
-        ref: `${qriRef.username}/${qriRef.name}`
+        ref: `${qriRef.username}/${qriRef.name}`,
+        limit: 100,
+        term: 'history'
       },
       map: mapCommits
     }

--- a/src/features/commits/state/commitState.ts
+++ b/src/features/commits/state/commitState.ts
@@ -3,6 +3,7 @@ import { createReducer } from '@reduxjs/toolkit'
 import { RootState } from '../../../store/store'
 import { humanRef, QriRef, refStringFromQriRef } from '../../../qri/ref'
 import { LogItem } from '../../../qri/log'
+import { ApiErr, NewApiErr } from '../../../store/api'
 
 export function newDatasetCommitsSelector(qriRef: QriRef): (state: RootState) => LogItem[] {
   qriRef = humanRef(qriRef)
@@ -25,27 +26,25 @@ export function selectDatasetCommitsLoading(state: RootState): boolean {
 export interface CommitsState {
   commits: Record<string,LogItem[]>
   loading: boolean
-  loadError: string
+  error: ApiErr
 }
 
 const initialState: CommitsState = {
   commits: {},
   loading: false,
-  loadError: ''
+  error: NewApiErr()
 }
 
 export const commitsReducer = createReducer(initialState, {
-  'API_DATASET_ACTIVITY_REQUEST': (state, action) => {
+  'API_DATASET_ACTIVITY_HISTORY_REQUEST': (state, action) => {
     state.loading = true
   },
-  'API_DATASET_ACTIVITY_FAILURE': (state, action) => {
+  'API_DATASET_ACTIVITY_HISTORY_FAILURE': (state, action) => {
     state.loading = false
-    // TODO (b5): capture error from API response
-    state.loadError = 'failed to load commits'
+    state.error = action.payload.err
   },
-  'API_DATASET_ACTIVITY_SUCCESS': (state, action) => {
-    const ls = action.payload.data as LogItem[]
-    state.commits[refStringFromQriRef(action.qriRef)] = ls.filter(d => d.path)
+  'API_DATASET_ACTIVITY_HISTORY_SUCCESS': (state, action) => {
+    state.commits[refStringFromQriRef(action.qriRef)] = action.payload.data
     state.loading = false
   },
 })


### PR DESCRIPTION
Splits up the api calls for history and run log.  Before they were sharing calls to `/activity`, now they each do their own and store the results in their own respective state.

Also adds `loading` and `error` state to both for consistency, but these aren't yet used in the UI.