### PR TITLE
fix workflow preview loading state

### DIFF
--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -20,12 +20,14 @@ export interface DatasetComponentProps {
   componentName: ComponentName
   // preview will cause the body component to render only what is in dataset and not fetch more data
   preview?: boolean
+  showLoadingState?: boolean
 }
 
 const DatasetComponent: React.FC<DatasetComponentProps> = ({
   dataset,
   componentName,
   preview = false,
+  showLoadingState = true
 }) => {
   const [ expanded, setExpanded ] = useState(false)
   const loading = useSelector(selectIsDatasetLoading)
@@ -39,10 +41,12 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   let componentHeader: JSX.Element | null = null
   switch (componentName) {
     case 'body':
-      component = <Body loading={loading || bodyLoading} data={dataset} preview={preview} />
+      component = (
+        <Body loading={showLoadingState ? (loading || bodyLoading) : false} data={dataset} preview={preview} />
+      )
       componentHeader = (
         <BodyHeader
-          loading={ loading || bodyLoading }
+          loading={ showLoadingState ? (loading || bodyLoading) : false }
           dataset={dataset}
           onToggleExpanded={handleToggleExpanded}
           showDownload={!preview}

--- a/src/features/dsComponents/TabbedComponentViewer.tsx
+++ b/src/features/dsComponents/TabbedComponentViewer.tsx
@@ -12,6 +12,8 @@ export interface TabbedComponentViewerProps {
   border?: boolean
   // preview will cause the body component to render only what is in dataset and not fetch more data
   preview?: boolean
+  // used to disable loading state when rendering the component viewer in the workflow
+  showLoadingState?: boolean
 }
 
 export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
@@ -19,6 +21,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
   selectedComponent,
   border = false,
   preview = false,
+  showLoadingState = true,
   children
 }) => {
 
@@ -46,6 +49,7 @@ export const TabbedComponentViewer: React.FC<TabbedComponentViewerProps> = ({
               dataset={dataset}
               componentName={selectedComponent}
               preview={preview}
+              showLoadingState={showLoadingState}
             />
           )
         }

--- a/src/features/workflow/WorkflowCell.tsx
+++ b/src/features/workflow/WorkflowCell.tsx
@@ -53,7 +53,7 @@ const WorkflowCell: React.FC<WorkflowCellProps> = ({
     } else if ((run?.status === "succeeded" || run?.status === "failed") && !run.output?.length){
       setOutput([])
     }
-  }, [ run, output ])
+  }, [ run ])
 
   const status = run?.status
   const isEdited = editedCells[index]

--- a/src/features/workflow/WorkflowDatasetPreview.tsx
+++ b/src/features/workflow/WorkflowDatasetPreview.tsx
@@ -20,9 +20,9 @@ const WorkflowDatasetPreview: React.FC<WorkflowDatasetPreviewProps> = ({
       {dataset ? (
         <TabbedComponentViewer
           dataset={dataset}
-          loading={false}
           selectedComponent={selectedComponent}
           preview
+          showLoadingState={false}
         />
       ) : (
         <TabbedComponentViewer


### PR DESCRIPTION
- fixes a perpetual loading state bug that was introduced after the history view loading state was merged.

The workflow "next version preview" Data tab would always show its loading state.  This happened because the logic that it uses is based on a different part of the state tree (`dataset`) which has nothing to do with the current workflow and loading is always `true`

This introduces a prop `showLoadingState` to `TabbedComponentViewer` which ensures the Data tab will never show loading state.  

Closes #493 

Also fixes a useEffect endless loop which was happening in `WorkflowCell`