### PR TITLE
fix(activity): show `runEnd` time rather than `commitTime` in the activity log

### DIFF
--- a/src/chrome/RelativeTimestamp.tsx
+++ b/src/chrome/RelativeTimestamp.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import format from 'date-fns/format'
 import { formatDistanceToNow } from 'date-fns'
+import { timestampIsZero } from '../utils/timestampIsZero'
 
 interface RelativeTimestampProps {
   timestamp: Date
@@ -11,6 +12,9 @@ const RelativeTimestamp: React.FunctionComponent<RelativeTimestampProps> = ({
   timestamp,
   className
 }) => {
+  if (timestamp.toString() === 'Invalid Date' || timestampIsZero(timestamp)) {
+    return <div className={className}>--</div>
+  }
   let timeFromNowAbbreviation = formatDistanceToNow(timestamp, { addSuffix: true })
   // manipulate the output of date-fns formatDistanceToNow() for shorter screen renders
   timeFromNowAbbreviation = timeFromNowAbbreviation

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -9,6 +9,7 @@ import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import RunStatusBadge from '../run/RunStatusBadge'
 import { LogItem } from '../../qri/log'
 import { customStyles, customSortIcon } from '../../features/collection/CollectionTable'
+import { runEndTime } from '../../utils/runEndTime'
 
 
 interface ActivityListProps {
@@ -46,13 +47,14 @@ const ActivityList: React.FC<ActivityListProps> = ({
     },
     {
       name: 'Time',
-      selector: (row: LogItem) => row.timestamp,
+      selector: (row: LogItem) => row.runStart,
       width: '180px',
       cell: (row: LogItem) => {
+        const runEnd = runEndTime(row.runStart, row.runDuration)
         return (
           <div className='text-qrigray-400 flex flex-col text-sm'>
             <div className='mb-1'>
-              <RelativeTimestamp timestamp={new Date(row.timestamp)} />
+              {runEnd ? <RelativeTimestamp timestamp={runEnd} /> : <div className='w-full'>--</div> }
             </div>
             <div className='flex items-center'>
               <Icon icon='clock' size='2xs' className='mr-1' />

--- a/src/qri/log.ts
+++ b/src/qri/log.ts
@@ -18,6 +18,7 @@ export interface LogItem {
   runNumber: number
   runDuration: number
   runStatus: RunStatus
+  runStart: string
 
   bodySize: number
   bodyRows: number
@@ -41,6 +42,7 @@ export function NewLogItem(d: Record<string,any>): LogItem {
     runNumber: d.runNumber,
     runDuration: d.runDuration,
     runStatus: d.runStatus,
+    runStart: d.runStart,
 
     bodySize: d.bodySize,
     bodyRows: d.bodyRows,

--- a/src/utils/runEndTime.ts
+++ b/src/utils/runEndTime.ts
@@ -1,4 +1,5 @@
 export function runEndTime(runStart: string, runDuration: number): Date {
   const runStartTime = new Date(runStart)
+  if (!runDuration) { runDuration = 0 }
   return new Date(runStartTime.getTime() + (runDuration / 1000000))
 }

--- a/src/utils/timestampIsZero.ts
+++ b/src/utils/timestampIsZero.ts
@@ -1,0 +1,5 @@
+export function timestampIsZero(t: string | Date): boolean {
+  // '0001-01-01 00:00:00 +0000 UTC' is the stringified "zero" time in golang
+  // '0001-01-01T00:00:00.000Z' is the stringified "zero" time using JSON.stringify
+  return t === '0001-01-01 00:00:00 +0000 UTC' || t === '0001-01-01T00:00:00.000Z' || JSON.stringify(t) === '"0001-01-01T00:00:00.000Z"'
+}


### PR DESCRIPTION
Also, adds logic to see if a timestamp is actually the "zero" value before displaying it. If it is the "zero" value (or is somehow invalid), instead return "--"