### PR TITLE
fix: remove execute from monaco editor context menu

### DIFF
--- a/src/features/workflow/CodeEditor.tsx
+++ b/src/features/workflow/CodeEditor.tsx
@@ -83,7 +83,6 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
       id: "executeCurrentAndAdvance",
       label: "Execute Block and Advance",
       keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
-      contextMenuGroupId: "2_execution",
       precondition: "editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible",
       run: () => {
         onRun()


### PR DESCRIPTION
remove execute from monaco editor context menu

fixes #499 