### PR TITLE
fix: fixed password reset forms to handle enter click

### DIFF
--- a/src/features/analytics/analytics.ts
+++ b/src/features/analytics/analytics.ts
@@ -7,5 +7,7 @@ declare global {
 window.fathom = window.fathom || {}
 
 export function trackGoal (id: string, cents: number): void {
-  window?.fathom?.trackGoal(id, cents)
+  if (window?.fathom?.trackGoal) {
+    window?.fathom?.trackGoal(id, cents)
+  }
 }

--- a/src/features/session/ForgotPassword.tsx
+++ b/src/features/session/ForgotPassword.tsx
@@ -28,7 +28,8 @@ const ForgotPassword: React.FC = () => {
     dispatch(showModal(ModalType.signUp))
   }
 
-  const handleSubmitClick = () => {
+  const handleSubmitClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     dispatch(fetchPasswordForgot(identifier))
   }
 
@@ -78,7 +79,7 @@ const ForgotPassword: React.FC = () => {
                 placeholder='Username or Email'
               />
             </div>
-            <Button type='secondary' className='mb-6' onClick={handleSubmitClick} block>
+            <Button type='secondary' className='mb-6' onClick={handleSubmitClick} submit block>
               {loading ? <Spinner color='#fff' size={6} /> : 'Send Password Reset'}
             </Button>
             <div onClick={handleSignUpClick} className='cursor-pointer text-center text-black text-xs font-bold'>

--- a/src/features/session/PasswordReset.tsx
+++ b/src/features/session/PasswordReset.tsx
@@ -22,7 +22,8 @@ const PasswordReset: React.FC = () => {
   const dispatch = useDispatch()
   const loading = useSelector(selectIsSessionLoading)
 
-  const handleSubmitClick = () => {
+  const handleSubmitClick = (e: React.MouseEvent) => {
+    e.preventDefault()
     setInputError('')
     const error = validatePassword(password)
     if (password !== rePassword) {
@@ -64,7 +65,7 @@ const PasswordReset: React.FC = () => {
             />
           </div>
 
-          <Button type='secondary' className='mb-6' onClick={handleSubmitClick} block>
+          <Button type='secondary' className='mb-6' onClick={handleSubmitClick} submit block>
             {loading ? <Spinner color='#fff' size={6} /> : 'Reset Password'}
           </Button>
         </form>


### PR DESCRIPTION
fixed password reset forms to handle enter click

This part is not fixed "If you open the forgot password page and enter your email the entire modal becomes clickable and acts like the submit button" Not sure what causes the issue, I could also see the same problem on log in modal and sign up modal

fixes #531