### PR TITLE
fix(*): add `ExecutionMode` and show user photo in `UserProfile` component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG app_port
 ENV REACT_APP_API_BASE_URL=$api_base_url
 ENV REACT_APP_WS_BASE_URL=$ws_base_url
 ENV PORT=$app_port
+ENV APP_EXEC_MODE="CLOUD"
 
 # create app directory
 WORKDIR /app

--- a/src/execution/execution.ts
+++ b/src/execution/execution.ts
@@ -1,0 +1,22 @@
+export enum ExecutionMode {
+  // LOCAL represents running the app as a browser application running locally
+  LOCAL = "LOCAL",
+  // CLOUD represents running the app as a browser application running in the cloud
+  CLOUD = "CLOUD",
+  // DESKTOP represents running the app as an electron application running locally
+  DESKTOP = "DESKTOP"
+}
+
+export function getAppExecMode (mode: string): ExecutionMode {
+  mode = mode.toUpperCase()
+  switch (mode) {
+    case "LOCAL":
+      return ExecutionMode.LOCAL
+    case "CLOUD":
+      return ExecutionMode.CLOUD
+    case "DESKTOP":
+      return ExecutionMode.DESKTOP
+    default:
+      return ExecutionMode.LOCAL
+  }
+}

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -42,7 +42,7 @@ const SessionUserMenu: React.FC<{}> = () => {
       style={{
         height: '30px',
         width: '30px',
-        backgroundImage: `url(${user.profile})`
+        backgroundImage: `url(${user.photo})`
       }}
     />
   )

--- a/src/features/session/state/sessionState.ts
+++ b/src/features/session/state/sessionState.ts
@@ -1,4 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit'
+import { UserProfile } from '../../../qri/userProfile'
 import { RootState } from '../../../store/store'
 
 interface SessionTokens {
@@ -8,7 +9,7 @@ interface SessionTokens {
 
 export const RESET_FORGOT_STATE = 'RESET_FORGOT_STATE'
 
-export const selectSessionUser = (state: RootState): User => state.session.user
+export const selectSessionUser = (state: RootState): UserProfile => state.session.user
 
 export const selectSessionTokens = (state: RootState): SessionTokens => {
   return {
@@ -23,16 +24,8 @@ export const selectResetError = (state: RootState): string => state.session.rese
 
 export const selectResetSent = (state: RootState): boolean => state.session.resetSent
 
-export interface User {
-  name?: string
-  profile?: string
-  username: string
-  description?: string
-  email?: string
-}
-
 export interface SessionState {
-  user: User
+  user: UserProfile
   loading: boolean
   token: string
   refreshToken: string
@@ -40,20 +33,41 @@ export interface SessionState {
   resetError: string
 }
 
-export const AnonUser: User = {
-  username: 'new'
+export const AnonUser: UserProfile = {
+  username: 'new',
+  profile_id: '',
+  PrivKey: '',
+  created: 0,
+  updated: 0,
+  type: '',
+  email: '',
+  name: '',
+  description: '',
+  home_url: '',
+  color: '',
+  thumb: '',
+  photo: '',
+  poster: '',
+  twitter: '',
+  PeerIDs: [],
+  NetworkAddrs: [],
+  id: '',
+  currentKey: '',
+  EmailConfirmed: false,
+  isAdmin: false
 }
 
 function getAuthState (): SessionState {
   try {
     const token = localStorage.getItem('state.auth.token') || ''
     const refreshToken = localStorage.getItem('state.auth.refreshToken') || ''
-    const user = localStorage.getItem('state.auth.user') || AnonUser
+    const userStr = localStorage.getItem('state.auth.user') || ''
+    const user = userStr === '' ? AnonUser : JSON.parse(userStr)
 
     return {
       token: JSON.parse(token),
       refreshToken: JSON.parse(refreshToken),
-      user: typeof user === 'string' ? JSON.parse(user) : user,
+      user: user,
       loading: false,
       resetSent: false,
       resetError: ''
@@ -73,28 +87,14 @@ function getAuthState (): SessionState {
 const initialState: SessionState = getAuthState()
 
 interface AuthAction {
-  user: User
+  user: UserProfile
   token: string
   refreshToken: string
 }
 
 // same state changes on successful login or signup
 const loginOrSignupSuccess = (state: SessionState, action: AuthAction) => {
-  const {
-    name,
-    profile,
-    username,
-    description,
-    email
-  } = action.user
-
-  state.user = {
-    name,
-    profile,
-    username,
-    description,
-    email
-  }
+  state.user = action.user
   state.loading = false
 
   state.token = action.token

--- a/src/features/userProfile/UserProfile.tsx
+++ b/src/features/userProfile/UserProfile.tsx
@@ -119,7 +119,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
               <div className='rounded-2xl inline-block bg-cover flex-shrink-0 mr-3' style={{
                 height: '30px',
                 width: '30px',
-                backgroundImage: `url(${profile.profile})`
+                backgroundImage: `url(${profile.photo})`
               }}/>
               <div>
                 <div className='text-black text-sm font-semibold'>{profile.name}</div>

--- a/src/features/userProfile/UserProfileHeader.tsx
+++ b/src/features/userProfile/UserProfileHeader.tsx
@@ -6,8 +6,6 @@ import ContentLoader from 'react-content-loader'
 import ContentBox from '../../chrome/ContentBox'
 
 import { UserProfile } from '../../qri/userProfile'
-import { useSelector } from "react-redux"
-import { selectSessionUser } from "../session/state/sessionState"
 
 export interface UserProfileHeaderProps {
   profile: UserProfile
@@ -18,9 +16,9 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile, loading 
   const {
     name,
     username,
-    created
+    created,
+    photo
   } = profile
-  const user = useSelector(selectSessionUser)
 
   return (
     <ContentBox paddingClassName='w-full ' className='flex h-20 mt-8 mb-6 w-full'>
@@ -28,7 +26,7 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile, loading 
         <div className='rounded-full inline-block bg-cover absolute -top-8' style={{
           height: '100px',
           width: '100px',
-          backgroundImage: `url(${user.profile})`
+          backgroundImage: `url(${photo})`
         }}/>
       </div>
       <div className='flex-grow ml-32'>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,10 @@ import './index.css'
 import App from './features/app/App'
 import { configureStore } from './store/store'
 import * as serviceWorker from './serviceWorker'
+import { getAppExecMode } from './execution/execution'
+
+// API_EXEC_MODE is a global, unique constant for determining which "execution mode" the app is running under (local, desktop, or cloud)
+export const APP_EXEC_MODE = getAppExecMode(process.env.APP_EXEC_MODE || "LOCAL")
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/qri/userProfile.ts
+++ b/src/qri/userProfile.ts
@@ -12,7 +12,7 @@ export interface UserProfile {
   home_url: string
   color: string
   thumb: string
-  profile: string
+  photo: string
   poster: string
   twitter: string
   PeerIDs: string[]
@@ -37,7 +37,7 @@ export const NewUserProfile = () => {
     home_url: '',
     color: '',
     thumb: '',
-    profile: '',
+    photo: '',
     poster: '',
     twitter: '',
     PeerIDs: [],

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -15,9 +15,9 @@ export const CALL_API = Symbol('CALL_API')
 export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:2503'
 
 // API_BASE_CLOUD_URL is only used if we are NOT in `ExecutionMode.CLOUD`
-// TODO(ramfox): hack - eventually the `identity` endpoints will be routed
+// TODO(ramfox): hack - eventually the cloud endpoints will be routed
 // through qri core, until then we need to check for possible fetch to
-// the `identity` endpoints, and use this endpoint instead
+// the cloud endpoints, and use this endpoint instead
 export const API_BASE_CLOUD_URL = process.env.REACT_APP_API_BASE_CLOUD_URL || 'https://rosebud-api.qri.cloud'
 
 export interface ApiErr {
@@ -163,11 +163,11 @@ function apiUrl (endpoint: string, segments?: QriRef, query?: ApiQuery, pageInfo
 
   let url = API_BASE_URL + `/${endpoint}`
 
-  // TODO (ramfox): hack - eventually the `identity` endpoints will be routed through
+  // TODO (ramfox): hack - eventually the cloud endpoints will be routed through
   // the core registry endpoints & we will pick up the registry url there. However,
   // until then, we must ensure we are fetching from the cloud url when fetching
   // from the identity endpoints in the DESKTOP or LOCAL execution modes
-  if (endpoint.includes('identity/') && APP_EXEC_MODE !== ExecutionMode.CLOUD) {
+  if (isCloudEndpoint(endpoint) && APP_EXEC_MODE !== ExecutionMode.CLOUD) {
     url = API_BASE_CLOUD_URL + `/${endpoint}`
   }
 
@@ -405,4 +405,12 @@ const refreshSession = async (token: string, refreshToken: string): Promise<any>
     console.log(`error refreshing token - ${error.message}`)
     return await Promise.reject(error)
   }
+}
+
+// TODO(ramfox): isCloudEndpoint is a hack to ensure the endpoint is a cloud only
+// endpoint. these endpoints will eventally be routed through core as
+// registry endpoints. Until then, this hack ensure we catch the cloud
+// specific endpoints and fetch from the correct place
+function isCloudEndpoint (endpoint: string): boolean {
+  return endpoint.includes('identity/') || endpoint.includes('dataset_summary') || endpoint.includes('follow')
 }


### PR DESCRIPTION
This pr takes a few basic steps to allow us to split behavior between a local, desktop, and cloud version of the frontend app.

It adds an `ExecutionMode` enum with options `LOCAL`, `DESKTOP`, and `CLOUD`

To allow local to fetch identity, dataset_summary, and follow information correctly, add a hack that, if we are NOT in `CLOUD` execution mode, will fetch those endpoints from the `API_BASE_CLOUD_URL`

This does not solve all of our user photo problems. We are still only showing hard coded values in the commit (using <UsernameWithIcon>). Solving this will require some refactoring to the state tree, so I want to do it in a follow up.

closes #535 