### PR TITLE
feat(users): add `Users` state tree & use profiles to power showing icons

### DIFF
--- a/src/chrome/UsernameWithIcon.tsx
+++ b/src/chrome/UsernameWithIcon.tsx
@@ -1,30 +1,42 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import classNames from 'classnames'
+import { useDispatch, useSelector } from 'react-redux'
+import { loadUser } from '../features/users/state/usersActions'
+import { selectUserProfile } from '../features/users/state/usersState'
+import { DEFAULT_PROFILE_PHOTO_URL } from '..'
 
 interface UsernameWithIconProps {
   username: string
+  text?: string // optional text to override the username
   className?: string
   iconWidth?: number
   iconOnly?: boolean
   tooltip?: boolean
 }
 
-// TODO(chriswhong): make the prop a user object, or pass in icon URL as a separate prop
 const UsernameWithIcon: React.FunctionComponent<UsernameWithIconProps> = ({
   username,
+  text = username,
   className,
   iconWidth = 18,
   iconOnly = false,
   tooltip = false
-}) => (
-  <div className={classNames('flex items-center tracking-wider', className)}>
+}) => {
+  const dispatch = useDispatch()
+  const profile = useSelector(selectUserProfile(username))
+
+  useEffect(() => {
+    loadUser(username)
+  }, [dispatch, username])
+
+  return (<div className={classNames('flex items-center tracking-wider', className)}>
     <div className='rounded-2xl inline-block bg-cover flex-shrink-0' title={tooltip ? username : ''} style={{
       height: iconWidth,
       width: iconWidth,
-      backgroundImage: 'url(https://qri-user-images.storage.googleapis.com/1570029763701.png)'
+      backgroundImage: `url(${(profile && profile.photo) || DEFAULT_PROFILE_PHOTO_URL})`
     }}/>
-    {!iconOnly && <p className='ml-1.5 truncate'>{username}</p>}
-  </div>
-)
+    {!iconOnly && <p className='ml-1.5 truncate'>{text}</p>}
+  </div>)
+}
 
 export default UsernameWithIcon

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -123,7 +123,7 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
           <div className='truncate'>
             <div className='mb-1'>
               <Link to={pathToDatasetHeadPreview(row)}>
-                <UsernameWithIcon username={`${row.username}/${row.name}`} className='text-sm font-bold text-black transition-colors group-hover:text-qripink-600 group-hover:underline' />
+                <UsernameWithIcon text={`${row.username}/${row.name}`} username={row.username} className='text-sm font-bold text-black transition-colors group-hover:text-qripink-600 group-hover:underline' />
               </Link>
             </div>
             <div className='flex text-xs items-center overflow-y-hidden'>

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -10,6 +10,7 @@ import Button from '../../chrome/Button'
 import Link from '../../chrome/Link'
 import { resetCollectionState } from "../collection/state/collectionActions"
 import { trackGoal } from '../../features/analytics/analytics'
+import { DEFAULT_PROFILE_PHOTO_URL } from '../..'
 
 const SessionUserMenu: React.FC<{}> = () => {
   const user = useSelector(selectSessionUser)
@@ -42,7 +43,7 @@ const SessionUserMenu: React.FC<{}> = () => {
       style={{
         height: '30px',
         width: '30px',
-        backgroundImage: `url(${user.photo})`
+        backgroundImage: `url(${user.photo || DEFAULT_PROFILE_PHOTO_URL})`
       }}
     />
   )

--- a/src/features/userProfile/UserProfile.tsx
+++ b/src/features/userProfile/UserProfile.tsx
@@ -126,7 +126,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
               <div className='rounded-2xl inline-block bg-cover flex-shrink-0 mr-3' style={{
                 height: '30px',
                 width: '30px',
-                backgroundImage: `url(${profile.photo})`
+                backgroundImage: `url(${profile.photo || DEFAULT_PROFILE_PHOTO_URL})`
               }}/>
               <div>
                 <div className='text-black text-sm font-semibold'>{profile.name}</div>

--- a/src/features/userProfile/UserProfileHeader.tsx
+++ b/src/features/userProfile/UserProfileHeader.tsx
@@ -6,6 +6,7 @@ import ContentLoader from 'react-content-loader'
 import ContentBox from '../../chrome/ContentBox'
 
 import { UserProfile } from '../../qri/userProfile'
+import { DEFAULT_PROFILE_PHOTO_URL } from '../..'
 
 export interface UserProfileHeaderProps {
   profile: UserProfile
@@ -26,7 +27,7 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({ profile, loading 
         <div className='rounded-full inline-block bg-cover absolute -top-8' style={{
           height: '100px',
           width: '100px',
-          backgroundImage: `url(${photo})`
+          backgroundImage: `url(${photo || DEFAULT_PROFILE_PHOTO_URL})`
         }}/>
       </div>
       <div className='flex-grow ml-32'>

--- a/src/features/userProfile/state/userProfileActions.ts
+++ b/src/features/userProfile/state/userProfileActions.ts
@@ -5,12 +5,6 @@ import { UserProfileDatasetListParams } from '../../../qri/userProfile'
 
 export const searchPageSizeDefault = 25
 
-export function loadUserProfile (username: string): ApiActionThunk {
-  return async (dispatch, getState) => {
-    return dispatch(fetchUserProfile(username))
-  }
-}
-
 export function loadUserProfileDatasets (username: string, userProfileParams: UserProfileDatasetListParams): ApiActionThunk {
   return async (dispatch, getState) => {
     return dispatch(fetchUserProfileDatasets(username, userProfileParams))
@@ -20,16 +14,6 @@ export function loadUserProfileDatasets (username: string, userProfileParams: Us
 export function loadUserProfileFollowing (username: string, userProfileParams: UserProfileDatasetListParams): ApiActionThunk {
   return async (dispatch, getState) => {
     return dispatch(fetchUserProfileFollowing(username, userProfileParams))
-  }
-}
-
-function fetchUserProfile (username: string): ApiAction {
-  return {
-    type: 'userprofile',
-    [CALL_API]: {
-      endpoint: `identity/profile/${username}`,
-      method: 'GET'
-    }
   }
 }
 

--- a/src/features/userProfile/state/userProfileState.ts
+++ b/src/features/userProfile/state/userProfileState.ts
@@ -2,11 +2,8 @@ import { createReducer } from '@reduxjs/toolkit'
 
 import { RootState } from '../../../store/store'
 import { PageInfo, SearchResult } from '../../../qri/search'
-import { UserProfile, NewUserProfile } from '../../../qri/userProfile'
 import { ApiErr, NewApiErr } from '../../../store/api'
 
-export const selectUserProfile = (state: RootState): UserProfile => state.userProfile.profile
-export const selectUserProfileLoading = (state: RootState): boolean => state.userProfile.loading
 export const selectUserProfileError = (state: RootState): ApiErr => state.userProfile.error
 export const selectUserProfileDatasets = (state: RootState): PaginatedResults => state.userProfile.datasets
 export const selectUserProfileFollowing = (state: RootState): PaginatedResults => state.userProfile.following
@@ -33,7 +30,6 @@ const NewPaginatedResults = () => {
 }
 
 export interface UserProfileState {
-  profile: UserProfile
   loading: boolean
   error: ApiErr
   datasets: {
@@ -49,7 +45,6 @@ export interface UserProfileState {
 }
 
 const initialState: UserProfileState = {
-  profile: NewUserProfile(),
   loading: false,
   error: NewApiErr(),
   datasets: NewPaginatedResults(),
@@ -57,19 +52,6 @@ const initialState: UserProfileState = {
 }
 
 export const userProfileReducer = createReducer(initialState, {
-  'API_USERPROFILE_REQUEST': (state: UserProfileState, action) => {
-    state.loading = true
-    state.error = NewApiErr()
-  },
-  'API_USERPROFILE_SUCCESS': (state: UserProfileState, action) => {
-    state.profile = action.payload.data
-    state.loading = false
-  },
-  'API_USERPROFILE_FAILURE': (state: UserProfileState, action) => {
-    state.loading = false
-    state.error = action.payload.err
-  },
-
   'API_USERPROFILEDATASETS_REQUEST': (state: UserProfileState, action) => {
     state.datasets.loading = true
   },

--- a/src/features/users/state/usersActions.ts
+++ b/src/features/users/state/usersActions.ts
@@ -1,0 +1,30 @@
+import { ThunkDispatch } from "redux-thunk"
+import { newQriRef } from "../../../qri/ref"
+import { mapProfile } from "../../../qri/userProfile"
+import { ApiAction, CALL_API } from "../../../store/api"
+import { RootState } from "../../../store/store"
+import { selectUserProfile } from "./usersState"
+
+export function loadUser (username: string) {
+  return async (dispatch: ThunkDispatch<any, any, any>, getState: () => RootState) => {
+    const state = getState()
+    const user = selectUserProfile(username)(state)
+    if (user) { return user }
+
+    if (!state.users.loading[username]) {
+      return dispatch(fetchUser(username))
+    }
+  }
+}
+
+function fetchUser (username: string): ApiAction {
+  return {
+    type: 'userprofile',
+    [CALL_API]: {
+      endpoint: `identity/profile/`,
+      method: 'GET',
+      segments: newQriRef({ username }),
+      map: mapProfile
+    }
+  }
+}

--- a/src/features/users/state/usersState.ts
+++ b/src/features/users/state/usersState.ts
@@ -1,0 +1,68 @@
+import { RootState } from '../../../store/store'
+import { createReducer } from '@reduxjs/toolkit'
+import { UserProfile } from '../../../qri/userProfile'
+import { ApiErr } from '../../../store/api'
+
+export interface UsersState {
+  // profiles is a record of all the fetched user profiles, indexed by username
+  profiles: Record<string, UserProfile>
+  // loading is a record of all the user profiles that are currently loading, indexed by username
+  loading: Record<string, boolean>
+  // errors is a record of all the user profile errors, indexed by username
+  errors: Record<string, ApiErr>
+}
+
+export const selectUserProfile = (username: string): (state: RootState) => UserProfile =>
+  (state) => state.users.profiles[username]
+
+export const selectUserProfileLoading = (username: string): (state: RootState) => boolean => (state) => state.users.loading[username] === undefined || state.users.loading[username]
+
+export const selectUserProfileError = (username: string): (state: RootState) => ApiErr => (state) => state.users.errors[username]
+
+function getInitialUsersState (): UsersState {
+  let state: UsersState = {
+    profiles: {},
+    loading: {},
+    errors: {}
+  }
+  try {
+    const userStr = localStorage.getItem('state.auth.user') || ''
+    if (userStr !== '') {
+      const user = JSON.parse(userStr)
+      state.profiles[user.username] = user
+      state.loading[user.username] = false
+    }
+  } catch (err) {
+    return state
+  }
+  return state
+}
+
+const initialState: UsersState = getInitialUsersState()
+
+const profileRequest = (state: UsersState, action: any) => {
+  state.loading[action.segments.username] = true
+  delete state.errors[action.username]
+}
+
+const profileSuccess = (state: UsersState, action: any) => {
+  const username = action.payload.data.username
+  state.profiles[username] = action.payload.data
+  state.loading[username] = false
+}
+
+const profileFailure = (state: UsersState, action: any) => {
+  const username = action.payload.request.segments.username
+  state.loading[username] = false
+  state.errors[username] = action.payload.err
+}
+
+export const usersReducer = createReducer(initialState, {
+  'API_USERPROFILE_REQUEST': profileRequest,
+  'API_USERPROFILE_SUCCESS': profileSuccess,
+  'API_USERPROFILE_FAILURE': profileFailure,
+  'LOGIN_SUCCESS': (state: UsersState, action) => {
+    state.profiles[action.user.username] = action.user
+    state.loading[action.user.username] = false
+  }
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,10 @@ import { getAppExecMode } from './execution/execution'
 
 // API_EXEC_MODE is a global, unique constant for determining which "execution mode" the app is running under (local, desktop, or cloud)
 export const APP_EXEC_MODE = getAppExecMode(process.env.APP_EXEC_MODE || "LOCAL")
+// DEFAULT_PHOTO_URL is the default profile photo.
+// TODO(ramfox): this should be replaced with a component that generates
+// an icon based on a username
+export const DEFAULT_PROFILE_PHOTO_URL = 'https://qri-user-images.storage.googleapis.com/1570029763701.png'
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/qri/userProfile.ts
+++ b/src/qri/userProfile.ts
@@ -1,4 +1,3 @@
-
 export interface UserProfile {
   profile_id: string
   PrivKey: string
@@ -46,6 +45,45 @@ export const NewUserProfile = () => {
     currentKey: '',
     EmailConfirmed: false,
     isAdmin: false
+  }
+}
+
+export const mapProfile = (obj: Record<string, any>): UserProfile => {
+  return {
+    profile_id: obj.profile_id,
+    PrivKey: obj.PrivKey,
+    username: obj.peername || obj.username,
+    created: ensureDateIsUnixTimestamp(obj.created),
+    updated: ensureDateIsUnixTimestamp(obj.updated),
+    type: obj.type,
+    email: obj.email,
+    name: obj.name,
+    description: obj.description,
+    home_url: obj.home_url,
+    color: obj.color,
+    thumb: obj.thumb,
+    photo: obj.photo,
+    poster: obj.poster,
+    twitter: obj.twitter,
+    PeerIDs: obj.PeerIDs,
+    NetworkAddrs: obj.NetworkAddrs,
+    id: obj.id,
+    currentKey: obj.currentKey,
+    EmailConfirmed: obj.EmailConfirmed,
+    isAdmin: obj.isAdmin
+  }
+}
+
+const ensureDateIsUnixTimestamp = (d: string | number): number => {
+  if (typeof d === 'number') {
+    return d
+  }
+  try {
+    const date = new Date(d)
+    return Math.floor(date.getTime() / 1000)
+  } catch (err) {
+    console.log(`Error getting unix timestamp from date ${d}`)
+    return 0
   }
 }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -22,6 +22,7 @@ import { datasetEditsReducer, DatasetEditsState } from '../features/dataset/stat
 import { WebsocketState, websocketReducer } from '../features/websocket/state/websocketState'
 import { UserProfileState, userProfileReducer } from '../features/userProfile/state/userProfileState'
 import { eventsReducer, EventsState } from "../features/events/state/eventsState"
+import { usersReducer, UsersState } from '../features/users/state/usersState'
 
 export const history = createBrowserHistory()
 
@@ -39,6 +40,7 @@ export interface RootState {
   session: SessionState
   transfers: RemoteEvents
   userProfile: UserProfileState
+  users: UsersState
   workflow: WorkflowState
   edits: DatasetEditsState
   events: EventsState
@@ -62,6 +64,7 @@ const rootReducer = (h: History) => combineReducers({
   session: sessionReducer,
   transfers: transfersReducer,
   userProfile: userProfileReducer,
+  users: usersReducer,
   workflow: workflowReducer,
   edits: datasetEditsReducer,
   events: eventsReducer,


### PR DESCRIPTION
- creates a state tree section called `Users` that we can use to store multiple profiles.
- because we can store multiple profiles, we can now load profiles for icons on the history and collection pages
- lazy fetches profiles: if we already have it we don't fetch it each time
- adds `DEFAULT_PROFILE_PHOTO_URL` as a stopgap between now and when we can generate icons for users with no photo
