### PR TITLE
fix(qri): add `runID` field to `Commit` interface

### DIFF
--- a/src/chrome/DatasetCommitInfo.tsx
+++ b/src/chrome/DatasetCommitInfo.tsx
@@ -5,10 +5,11 @@ import Icon from './Icon'
 import RelativeTimestampWithIcon from './RelativeTimestampWithIcon'
 import UsernameWithIcon from './UsernameWithIcon'
 import commitishFromPath from '../utils/commitishFromPath'
-import { Dataset } from '../qri/dataset'
+import { LogItem } from '../qri/log'
+import { VersionInfo } from '../qri/versionInfo'
 
 interface DatasetCommitInfoProps {
-  dataset: Dataset
+  item: LogItem | VersionInfo
   // small yields the same info with smaller text, used in collection, history list and run log
   small?: boolean
   // inRow will set the commit title to normal (instead of semibold) so it's less noisy when displayed in a row of other info
@@ -17,18 +18,14 @@ interface DatasetCommitInfoProps {
   preview?: boolean
   // sets the maxWidth, used for dynamic display in dataset preview page
   flex?: boolean
-  // determines whether or not to show the automated icon.  This should be included in dataset, but our responses
-  // are inconsistent, so this prop allows us to turn it on manually wherever we know it should appear
-  automated?: boolean
   // determines if the status text will have a hover effect.
   hover?: boolean
 }
 
 const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
-  dataset,
+  item,
   small = false,
   inRow = false,
-  automated = false,
   hover = false
 }) => {
   return (
@@ -42,7 +39,7 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
       })}>
         <div className={classNames(`dataset_commit_info_text truncate transition-colors flex-grow ${hover && 'group-hover:underline group-hover:text-qripink-600'}`, {
 
-        })} title={dataset.commit?.title}>{dataset.commit?.title}</div>
+        })} title={item?.commitTitle}>{item.commitTitle}</div>
       </div>
       {/* end first row */}
 
@@ -51,7 +48,7 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
         'text-xs': small
       })}>
         {/* automation icon */}
-        {automated && (
+        {item?.runID && item.runID !== '' && (
           <div className='flex-grow-0 mr-2' title='version created by this dataset&apos;s transform script'>
             <Icon icon='automationFilled' size={small ? '2xs' : 'xs'}/>
           </div>
@@ -59,18 +56,18 @@ const DatasetCommitInfo: React.FC<DatasetCommitInfoProps> = ({
         {/* end automation icon */}
 
         {/* username icon */}
-        <UsernameWithIcon username={dataset.username} tooltip className='mr-2' iconWidth={small ? 12 : 18} iconOnly={small} />
+        <UsernameWithIcon username={item.username} tooltip className='mr-2' iconWidth={small ? 12 : 18} iconOnly={small} />
         {/* end username icon */}
 
         {/* relative timestamp icon */}
-        {dataset.commit?.timestamp && <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(dataset.commit.timestamp)} />}
+        {item?.commitTime && <RelativeTimestampWithIcon className='mr-3' timestamp={new Date(item?.commitTime)} />}
         {/* end relative timestamp icon */}
 
         {/* commit icon */}
-        {dataset.path && (
-          <div className='flex items-center leading-tight' title={dataset.path}>
+        {item.path && (
+          <div className='flex items-center leading-tight' title={item.path}>
             <Icon icon='commit' size={small ? 'xs' : 'sm'} className='-ml-2' />
-            <div>{commitishFromPath(dataset.path)}</div>
+            <div>{commitishFromPath(item.path)}</div>
           </div>
         )}
         {/* end commit icon */}

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -69,7 +69,7 @@ const ActivityList: React.FC<ActivityListProps> = ({
     },
     {
       name: 'Commit',
-      selector: (row: LogItem) => row.message,
+      selector: (row: LogItem) => row.commitMessage,
       width: '180px',
       // eslint-disable-next-line react/display-name
       cell: (row: LogItem) => {
@@ -78,8 +78,8 @@ const ActivityList: React.FC<ActivityListProps> = ({
           runID: row.runID,
           path: row.path,
           commit: NewCommit({
-            title: row.title,
-            timestamp: row.timestamp
+            title: row.commitTitle,
+            timestamp: row.commitTime
           })
         })
         if (!['failed', 'unchanged', 'running'].includes(row.runStatus)) {

--- a/src/features/activityFeed/ActivityList.tsx
+++ b/src/features/activityFeed/ActivityList.tsx
@@ -10,7 +10,6 @@ import RunStatusBadge from '../run/RunStatusBadge'
 import { LogItem } from '../../qri/log'
 import { customStyles, customSortIcon } from '../../features/collection/CollectionTable'
 import { runEndTime } from '../../utils/runEndTime'
-import { NewDataset, NewCommit } from '../../qri/dataset'
 
 interface ActivityListProps {
   log: LogItem[]
@@ -73,20 +72,11 @@ const ActivityList: React.FC<ActivityListProps> = ({
       width: '180px',
       // eslint-disable-next-line react/display-name
       cell: (row: LogItem) => {
-        const dataset = NewDataset({
-          username: row.username,
-          runID: row.runID,
-          path: row.path,
-          commit: NewCommit({
-            title: row.commitTitle,
-            timestamp: row.commitTime
-          })
-        })
         if (!['failed', 'unchanged', 'running'].includes(row.runStatus)) {
           const versionLink = `/${row.username}/${row.name}/at${row.path}/history/body`
           return (
             <Link to={versionLink} className='min-w-0 flex-grow'>
-              <DatasetCommitInfo dataset={dataset} small inRow automated/>
+              <DatasetCommitInfo item={row} small inRow />
             </Link>
           )
         } else {

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -45,7 +45,7 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
     trackGoal('GHUGYPYM', 0)
     dispatch(runNow(qriRef))
     const runningLog: LogItem = NewLogItem({
-      timestamp: new Date().toString(),
+      commitTime: new Date().toString(),
       runStatus: "running",
       title: '--',
       runID: latestRun.id

--- a/src/features/activityFeed/stories/data/activityLog.json
+++ b/src/features/activityFeed/stories/data/activityLog.json
@@ -1,7 +1,7 @@
 [
 	{
-		"timestamp": "2020-03-20T16:10:33.741276588-04:00",
-		"message": "no changes detected",
+		"commitTime": "2020-03-20T16:10:33.741276588-04:00",
+		"commitMessage": "no changes detected",
 
 		"username": "b5",
 		"name": "us_politicians_on_twitter",
@@ -9,19 +9,18 @@
 		"path": "",
 		"profileID": "QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W",
 
-		"runNumber": 11,
+		"runCount": 11,
 		"runID": "b9d1211c-6a53-11eb-9439-0242ac130002",
 		"runStatus": "unchanged",
 		"runDuration": 58,
 
 		"bodySize": 282000,
 		"bodyRows": 2345678,
-		"bodyFormat": "csv",
-		"changeAmount": 0
+		"bodyFormat": "csv"
 	},
 	{
-		"timestamp": "2020-03-19T16:10:33.741276588-04:00",
-		"message": "body and meta changed",
+		"commitTime": "2020-03-19T16:10:33.741276588-04:00",
+		"commitMessage": "body and meta changed",
 
 		"username": "b5",
 		"name": "world_bank_population",
@@ -29,19 +28,18 @@
 		"path": "/ipfs/Qmebr6jDGqPViYe7pXtggNN3wJ6SiQehEpU8aZLg83AVpr",
 		"profileID": "QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W",
 
-		"runNumber": 10,
+		"runCount": 10,
 		"runID": "b9d1211c-6a53-11eb-9439-0242ac130002",
 		"runStatus": "succeeded",
 		"runDuration": 128,
 
 		"bodySize": 282000,
 		"bodyRows": 2345678,
-		"bodyFormat": "csv",
-		"changeAmount": 0.45
+		"bodyFormat": "csv"
 	},
 	{
-		"timestamp": "2020-03-18T16:10:33.741276588-04:00",
-		"message": "http: no such host",
+		"commitTime": "2020-03-18T16:10:33.741276588-04:00",
+		"commitMessage": "http: no such host",
 
 		"initID": "u2gr5gy6a6s5jq7fhpiicpi5htnqd65ybey7r3pmaou7uwtqqisq",
 		"username": "b5",
@@ -49,19 +47,18 @@
 		"path": "/ipfs/Qmebr6jDGqPViYe7pXtggNN3wJ6SiQehEpU8aZLg83AVpr",
 		"profileID": "QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W",
 
-		"runNumber": 9,
+		"runCount": 9,
 		"runID": "b9d1211c-6a53-11eb-9439-0242ac130002",
 		"runStatus": "failed",
 		"runDuration": 3638,
 
 		"bodySize": 282000,
 		"bodyRows": 2345678,
-		"bodyFormat": "csv",
-		"changeAmount": 0
+		"bodyFormat": "csv"
 	},
 	{
-		"timestamp": "2020-03-17T16:10:33.741276588-04:00",
-		"message": "update readme to new website URLS",
+		"commitTime": "2020-03-17T16:10:33.741276588-04:00",
+		"commitMessage": "update readme to new website URLS",
 
 		"initID": "u2gr5gy6a6s5jq7fhpiicpi5htnqd65ybey7r3pmaou7uwtqqisq",
 		"username": "b5",
@@ -70,13 +67,12 @@
 		"profileID": "QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W",
 
 		"runID": "",
-		"runNumber": -1,
+		"runCount": -1,
 		"runStatus": "",
 		"runDuration": 10500,
 
 		"bodySize": 3240000,
 		"bodyRows": 25678,
-		"bodyFormat": "csv",
-		"changeAmount": 0.12
+		"bodyFormat": "csv"
 	}
 ]

--- a/src/features/collection/CollectionTable.tsx
+++ b/src/features/collection/CollectionTable.tsx
@@ -19,7 +19,6 @@ import ManualTriggerButton from '../workflow/ManualTriggerButton'
 import DatasetInfoItem from '../dataset/DatasetInfoItem'
 import { runEndTime } from '../../utils/runEndTime'
 import { trackGoal } from '../../features/analytics/analytics'
-import { NewCommit, NewDataset } from '../../qri/dataset'
 
 interface CollectionTableProps {
   filteredWorkflows: VersionInfo[]
@@ -149,31 +148,10 @@ const CollectionTable: React.FC<CollectionTableProps> = ({
       width: '180px',
       // eslint-disable-next-line react/display-name
       cell: (row: VersionInfo) => {
-        // TODO (ramfox): the activity feed expects more content than currently exists
-        // in the VersionInfo. Once the backend supplies these values, we can rip
-        // out this section that mocks durations & timestamps for us
-        const {
-          username,
-          commitTime,
-          commitTitle,
-          path,
-          runID
-        } = row
-
-        const dataset = NewDataset({
-          username,
-          commit: NewCommit({
-            title: commitTitle,
-            timestamp: commitTime
-          }),
-          path: path,
-          runID
-        })
-
         const versionLink = `/${row.username}/${row.name}/at${row.path}/history`
         return (
           <Link to={versionLink} className='min-w-0 flex-grow'>
-            <DatasetCommitInfo dataset={dataset} hover small inRow automated={!!runID}/>
+            <DatasetCommitInfo item={row} hover small inRow />
           </Link>
         )
       }

--- a/src/features/commits/CommitSummaryHeader.tsx
+++ b/src/features/commits/CommitSummaryHeader.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import ContentLoader from "react-content-loader"
 
 import Dataset from '../../qri/dataset'
-import DatasetVersionInfo from '../../chrome/DatasetCommitInfo'
+import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
+import { newVersionInfoFromDataset } from '../../qri/versionInfo'
 
 export interface CommitSummaryHeaderProps {
   dataset: Dataset
@@ -34,7 +35,7 @@ const CommitSummaryHeader: React.FC<CommitSummaryHeaderProps> = ({
           </>
           : <>
             <div className='text-sm text-qrigray-400 font-semibold mb-2'>Version Info</div>
-            <DatasetVersionInfo dataset={dataset} automated={dataset.commit.runID !== ''} />
+            <DatasetCommitInfo item={newVersionInfoFromDataset(dataset)} />
           </>
           }
       </div>

--- a/src/features/commits/CommitSummaryHeader.tsx
+++ b/src/features/commits/CommitSummaryHeader.tsx
@@ -34,7 +34,7 @@ const CommitSummaryHeader: React.FC<CommitSummaryHeaderProps> = ({
           </>
           : <>
             <div className='text-sm text-qrigray-400 font-semibold mb-2'>Version Info</div>
-            <DatasetVersionInfo dataset={dataset} />
+            <DatasetVersionInfo dataset={dataset} automated={dataset.commit.runID !== ''} />
           </>
           }
       </div>

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -7,7 +7,6 @@ import { LogItem } from '../../qri/log'
 import { newQriRef, refParamsFromLocation } from '../../qri/ref'
 import { pathToDatasetHistory } from '../dataset/state/datasetPaths'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
-import { NewDataset, NewCommit } from '../../qri/dataset'
 
 export interface DatasetCommitProps {
   logItem: LogItem
@@ -23,15 +22,6 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
   loading = false
 }) => {
   const location = useLocation()
-  // create a Dataset to pass into DatasetCommitInfo
-  const dataset = NewDataset({
-    username: logItem.username,
-    path: logItem.path,
-    commit: NewCommit({
-      title: logItem.commitTitle,
-      timestamp: logItem.commitTime
-    })
-  })
 
   const content = loading
     ? (
@@ -43,7 +33,7 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
       </ContentLoader>
       )
     : (
-      <DatasetCommitInfo dataset={dataset} small automated={!!logItem.runID} />
+      <DatasetCommitInfo item={logItem} small />
       )
 
   const containerClassNames = classNames('block rounded-md px-3 py-3 mb-6 w-full overflow-x-hidden', active && 'bg-white', !active && 'text-qrigray-400 border border-qrigray-300')

--- a/src/features/commits/DatasetCommit.tsx
+++ b/src/features/commits/DatasetCommit.tsx
@@ -28,8 +28,8 @@ const DatasetCommit: React.FC<DatasetCommitProps> = ({
     username: logItem.username,
     path: logItem.path,
     commit: NewCommit({
-      title: logItem.title,
-      timestamp: logItem.timestamp
+      title: logItem.commitTitle,
+      timestamp: logItem.commitTime
     })
   })
 

--- a/src/features/commits/DatasetCommitList.tsx
+++ b/src/features/commits/DatasetCommitList.tsx
@@ -55,8 +55,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
               // first={i === 0 && !editable} (restore when there is <NewVersionButton> at the top of the list)
               first={i === 0}
               last={i === 2}
-            />
-          ))
+            />))
           : commits.map((logItem, i) => (
             <DatasetCommitListItem
               key={i}

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -20,6 +20,7 @@ import MetaChips from '../../chrome/MetaChips'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import DownloadDatasetButton from "../download/DownloadDatasetButton"
 import ContentBoxSubTitle from "../../chrome/ContentBoxSubTitle"
+import { newVersionInfoFromDataset } from '../../qri/versionInfo'
 
 interface DatasetPreviewPageProps {
   qriRef: QriRef
@@ -79,7 +80,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                       <div className='flex items-center justify-between'>
                         <div className='flex-grow min-w-0 pr-6'>
                           <ContentBoxTitle title='Latest Version' />
-                          <DatasetCommitInfo dataset={dataset} small />
+                          <DatasetCommitInfo item={newVersionInfoFromDataset(dataset)} small />
                         </div>
                         <div className='flex flex-shrink-0'>
                           <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' hideIcon={true} type='primary' qriRef={qriRef} />

--- a/src/features/workflow/WorkflowScriptStatus.tsx
+++ b/src/features/workflow/WorkflowScriptStatus.tsx
@@ -4,6 +4,7 @@ import { Run } from '../../qri/run'
 import DatasetCommitInfo from '../../chrome/DatasetCommitInfo'
 import Icon from "../../chrome/Icon"
 import ContentLoader from "react-content-loader"
+import { newVersionInfoFromDataset } from '../../qri/versionInfo'
 
 interface WorkflowScriptStatusProps {
   run?: Run
@@ -32,7 +33,7 @@ const WorkflowScriptStatus: React.FC<WorkflowScriptStatusProps> = ({
           <rect x="72" y="30" width="25" height="10" rx="1" fill="#D5DADD"/>
         </ContentLoader>
         : dsPreview
-          ? <DatasetCommitInfo dataset={dsPreview} small automated />
+          ? <DatasetCommitInfo item={newVersionInfoFromDataset(dsPreview)} small />
           : <>
             <div className='text-xs flex items-center'>
               <Icon icon='playCircle' className='mr-1' size='3xs'/>

--- a/src/qri/dataset.ts
+++ b/src/qri/dataset.ts
@@ -148,6 +148,7 @@ export interface Commit extends Component {
   timestamp?: string
   title?: string
   count?: number // commit chain height
+  runID?: string // if runID is populated, the commit was created using a transform
 }
 
 export function NewCommit (d: Record<string, any>): Commit {
@@ -158,7 +159,8 @@ export function NewCommit (d: Record<string, any>): Commit {
     path: d.path,
     timestamp: d.timestamp,
     title: d.title,
-    count: d.count
+    count: d.count,
+    runID: d.runID
   }
 }
 

--- a/src/qri/dataset.ts
+++ b/src/qri/dataset.ts
@@ -4,6 +4,7 @@ import { QriRef } from "./ref"
 import fileSize, { abbreviateNumber } from '../utils/fileSize'
 
 export interface Dataset {
+  id?: string
   peername?: string
   username: string
   name: string

--- a/src/qri/log.ts
+++ b/src/qri/log.ts
@@ -4,9 +4,9 @@ import { RunStatus } from "./run"
 // TODO (ramfox): when "VersionInfo" contains commit title, message, runID, runDuration, and runStatus
 // this field can be removed
 export interface LogItem {
-  timestamp: string
-  title: string
-  message: string
+  commitTime: string
+  commitTitle: string
+  commitMessage: string
 
   username: string
   name: string
@@ -15,7 +15,7 @@ export interface LogItem {
   path: string
 
   runID: string
-  runNumber: number
+  runCount: number
   runDuration: number
   runStatus: RunStatus
   runStart: string
@@ -23,14 +23,13 @@ export interface LogItem {
   bodySize: number
   bodyRows: number
   bodyFormat: BodyDataFormat
-  changeAmount: number
 }
 
 export function NewLogItem (d: Record<string, any>): LogItem {
   return {
-    timestamp: d.timestamp || d.commitTime,
-    title: d.title || d.commitTitle,
-    message: d.message || d.commitMessage,
+    commitTime: d.commitTime,
+    commitTitle: d.commitTitle,
+    commitMessage: d.commitMessage,
 
     username: d.username,
     name: d.name || "",
@@ -39,14 +38,13 @@ export function NewLogItem (d: Record<string, any>): LogItem {
     path: d.path,
 
     runID: d.runID,
-    runNumber: d.runNumber,
+    runCount: d.runCount,
     runDuration: d.runDuration,
     runStatus: d.runStatus,
     runStart: d.runStart,
 
     bodySize: d.bodySize,
     bodyRows: d.bodyRows,
-    bodyFormat: d.bodyFormat,
-    changeAmount: d.changeAmount
+    bodyFormat: d.bodyFormat
   }
 }

--- a/src/qri/versionInfo.ts
+++ b/src/qri/versionInfo.ts
@@ -1,3 +1,4 @@
+import Dataset from "./dataset"
 import { QriRef } from "./ref"
 import { RunStatus } from './run'
 // VersionInfo pulls details from a dataset at a specific commit in a version
@@ -118,4 +119,25 @@ export function filterVersionInfos (collection: VersionInfo[], searchString: str
     d.path
   ].findIndex((f: string) => f.includes(searchString)) > -1
   )
+}
+
+export function newVersionInfoFromDataset (ds: Dataset): VersionInfo {
+  let theme: string | undefined
+  if (ds.meta?.theme) { theme = ds.meta.theme.join(",") }
+  return newVersionInfo({
+    initID: ds.id,
+    username: ds.username,
+    name: ds.name,
+    path: ds.path,
+    metaTitle: ds.meta?.title,
+    themeList: theme,
+    bodyFormat: ds.structure?.format,
+    bodySize: ds.structure?.length,
+    bodyRows: ds.structure?.entries,
+    numErrors: ds.structure?.errCount,
+    commitTitle: ds.commit?.title,
+    commitMessage: ds.commit?.message,
+    commitTime: ds.commit?.timestamp,
+    runID: ds.commit?.runID
+  })
 }

--- a/src/utils/assignUserIcon.ts
+++ b/src/utils/assignUserIcon.ts
@@ -23,8 +23,12 @@ export default function assignUserIcon (username: string): string {
     'tile'
   ]
 
-  const hash = hashStr(username)
-  const index = hash % icons.length
-
+  let index = 0
+  try {
+    const hash = hashStr(username)
+    index = hash % icons.length
+  } catch (e) {
+    console.log(e)
+  }
   return `/img/user-icons/${icons[index]}.png`
 }


### PR DESCRIPTION
closes #430

We already have a `runID` field on the `commit` in the backend, we just needed to surface it on the frontend!

Also closes the frontend portion of #576

---

Some notes:

a bunch of these refactors are to get `LogItem` in line with `VersionInfo`, which is the actual data structure that come back from the backend. I think with these changes we can mostly get rid of any references to `LogItem` in favor of using `VersionInfo`, but wanted to make a note of the changes and not do the entire refactor in one sweep, which can be jarring if everyone working on the code base isn't made aware of the change before it happens.

Why should we refactor away from `LogItem`? For long term maintenance, its easier to work with as few data models as possible. Since `VersionInfo` is the actual data structure coming from the backend, and it is exactly the same as the `LogItem`, it will be easier for us in the long term to slim down to using just one, and only create a separate data structure when we absolutely need it.