### PR TITLE
fix: readme now only expands if content exceeds container

### DIFF
--- a/src/features/app/App.css
+++ b/src/features/app/App.css
@@ -91,3 +91,14 @@ html {
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }
+
+/* Adds a transition to the bottom of an overflowing div (i.e. long readme on preview page) */
+.fade-bottom:before {
+  content:'';
+  width:100%;
+  height:100%;
+  position:absolute;
+  left:0;
+  top:0;
+  background:linear-gradient(transparent 150px, white);
+}

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -64,6 +64,8 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
     dispatch(loadDsPreview(ref))
   }, [dispatch, qriRef.username, qriRef.name, qriRef.path ])
 
+  const readmeHeightLargerThanContainerHeight = readmeHeight >= readmeContainerHeight
+
   const location = useLocation()
 
   return (
@@ -88,10 +90,12 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                   <ContentBox className='flex flex-col h-full'>
                     <div style={{ minHeight: minReadmeHeight }} className='flex flex-col h-full overflow-hidden'>
                       <ContentBoxTitle title='Readme'/>
-                      <div className='flex-grow overflow-hidden'>
+                      <div className={classNames('flex-grow overflow-hidden relative', {
+                        'fade-bottom': readmeHeightLargerThanContainerHeight
+                      })}>
                         <Readme data={dataset.readme} />
                       </div>
-                      {!expandReadme && (readmeHeight >= readmeContainerHeight) && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-1' onClick={() => { setExpandReadme(true) }}>See More</div>)}
+                      {!expandReadme && (readmeHeightLargerThanContainerHeight) && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-2' onClick={() => { setExpandReadme(true) }}>See More</div>)}
                     </div>
                   </ContentBox>
                 </div>

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -51,7 +51,7 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
   useEffect(() => {
     const readmeComponent = document.getElementsByClassName('markdown-body')[0]
     if (readmeComponent) {
-      setReadmeHeight(readmeComponent.clientHeight + 64) // adding pudding and see more button dimensions
+      setReadmeHeight(readmeComponent.clientHeight + 64) // adding padding and see more button dimensions
     }
   }, [ dataset ])
 

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -37,8 +37,23 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
 
   const [versionInfoContainer, { height: versionInfoContainerHeight }] = useDimensions()
   const [expandReadme, setExpandReadme] = useState(false)
+  const [minReadmeHeight, setMinReadmeHeight] = useState(0)
+  const [readmeHeight, setReadmeHeight] = useState(0)
 
   let readmeContainerHeight = versionInfoContainerHeight || 'auto'
+
+  useEffect(() => {
+    if (!isNaN(readmeContainerHeight)) {
+      setMinReadmeHeight(readmeContainerHeight - 42)// removing padding here
+    }
+  }, [ readmeContainerHeight ])
+
+  useEffect(() => {
+    const readmeComponent = document.getElementsByClassName('markdown-body')[0]
+    if (readmeComponent) {
+      setReadmeHeight(readmeComponent.clientHeight + 64) // adding pudding and see more button dimensions
+    }
+  }, [ dataset ])
 
   if (expandReadme) {
     readmeContainerHeight = 'auto'
@@ -71,12 +86,12 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                   'absolute': !expandReadme
                 })} style={{ height: readmeContainerHeight }}>
                   <ContentBox className='flex flex-col h-full'>
-                    <div className='flex flex-col h-full overflow-hidden'>
+                    <div style={{ minHeight: minReadmeHeight }} className='flex flex-col h-full overflow-hidden'>
                       <ContentBoxTitle title='Readme'/>
                       <div className='flex-grow overflow-hidden'>
                         <Readme data={dataset.readme} />
                       </div>
-                      {!expandReadme && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-1' onClick={() => { setExpandReadme(true) }}>See More</div>)}
+                      {!expandReadme && (readmeHeight >= readmeContainerHeight) && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-1' onClick={() => { setExpandReadme(true) }}>See More</div>)}
                     </div>
                   </ContentBox>
                 </div>


### PR DESCRIPTION
readme now only expends if content exceeds container

fixes #571 