### PR TITLE
Cw/various

### DIFF
--- a/src/features/collection/Collection.tsx
+++ b/src/features/collection/Collection.tsx
@@ -90,7 +90,7 @@ const Collection: React.FC<{}> = () => {
                   {collection.length}
                 </div>
               </div>
-              { loading && collection.length && (
+              { loading && collection.length > 0 && (
                 <div>
                   <Icon icon='loader' className='ml-2 text-qrigray-400'/>
                 </div>

--- a/src/features/commits/DatasetCommitList.tsx
+++ b/src/features/commits/DatasetCommitList.tsx
@@ -39,7 +39,7 @@ const DatasetCommits: React.FC<DatasetCommitsProps> = ({
         <h3 className='text-2xl text-black-500 font-black'>History</h3>
         <div id='dataset_commit_list_versions_text' className='text-xs text-qrigray-400 tracking-wider'>{commits.length} {commits.length === 1 ? 'version' : 'versions'}</div>
       </header>
-      <ul className='block flex-grow overflow-y-auto pb-40 pr-8'>
+      <ul className='block flex-grow overflow-y-auto hide-scrollbar pr-8'>
         {/*
           TODO(chriswhong): restore when these features become available
           <HistorySearchBox />

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -89,7 +89,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
   }
 
   const onTitleClick = () => {
-    if (!isNew) {
+    if (!isNew && editable) {
       dispatch(resetDatasetTitleError())
       dispatch(showModal(ModalType.editDatasetTitle, {
         title: dataset.meta?.title ? dataset.meta?.title : header.name,

--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -18,7 +18,7 @@ import { selectIsBodyLoading, selectIsDatasetLoading } from "../dataset/state/da
 export interface DatasetComponentProps {
   dataset: Dataset
   componentName: ComponentName
-  // preview will cause the body component to render only what is in dataset and not fetch more data
+  // preview is used to change the display of the body table for previews vs history
   preview?: boolean
   showLoadingState?: boolean
 }
@@ -42,7 +42,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
   switch (componentName) {
     case 'body':
       component = (
-        <Body loading={showLoadingState ? (loading || bodyLoading) : false} data={dataset} preview={preview} />
+        <Body loading={showLoadingState ? (loading || bodyLoading) : false} data={dataset} />
       )
       componentHeader = (
         <BodyHeader
@@ -97,7 +97,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
 
       {/* full screen component view functions as a modal */}
       { expanded && (
-      <div className="fixed top-0 right-0 bottom-0 left-0 inset-0 transition-opacity z-20" aria-hidden="true">
+      <div className="fixed top-0 right-0 bottom-0 left-0 inset-0 transition-opacity z-40" aria-hidden="true">
         <div className="absolute inset-0 bg-gray-200 p-4 flex">
           <ContentBox className='flex-grow flex flex-col'>
             <div className='flex'>

--- a/src/features/dsComponents/body/Body.tsx
+++ b/src/features/dsComponents/body/Body.tsx
@@ -20,7 +20,6 @@ import { newQriRef } from '../../../qri/ref'
 
 export interface BodyProps {
   data: Dataset
-  preview?: boolean
   loading?: boolean
   // stats: IStatTypes[]
   // details: Details
@@ -52,7 +51,6 @@ const extractColumnHeaders = (structure: Structure, value: any[]): ColumnPropert
 
 const Body: React.FC<BodyProps> = ({
   data,
-  preview = false,
   loading = false
 }) => {
   const dispatch = useDispatch()
@@ -61,11 +59,11 @@ const Body: React.FC<BodyProps> = ({
 
   // list out dependencies on dataset body individually for proper memoization
   useEffect(() => {
-    if (preview) { return }
+    if (data.body) { return }
     if (name && username) {
       dispatch(loadBody(newQriRef({ path, name, username }), 1, 100))
     }
-  }, [preview, dispatch, path, name, username])
+  }, [dispatch, path, name, username])
 
   if (loading) {
     return <BodyTable loading />


### PR DESCRIPTION
- fixes body fullscreen bug (closes #596)
- fixes the errant '0' that was showing up at the top of the collection view when loading
- users can only edit title on datasets they own (closes #598)
- hides the scrollbars on the history list