### PR TITLE
refactor(UserProfile): request a user's datasets from the core `/list` endpoint

### DIFF
--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -52,7 +52,7 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset, loading = 
           {/* <DatasetInfoItem icon='automationFilled' label='automated' iconClassName='text-qrigreen' /> TODO(chriswhong): enable when we have automation info */}
           {/* <DatasetInfoItem icon='commit' label={`17 versions`} /> TODO(chriswhong): enable when we have commit info */}
           {/* stats?.downloadCount > 0 && <DatasetInfoItem size='md' icon='download' label={`${stats.downloadCount} download${(stats.downloadCount !== 1) ? 's' : ''}`} /> */}
-          { followStats.followCount > 0 && <DatasetInfoItem size='md' icon='follower' label={`${followStats.followCount} follower${(followStats.followCount !== 1) ? 's' : ''}`} /> }
+          { followStats && followStats.followCount > 0 && <DatasetInfoItem size='md' icon='follower' label={`${followStats.followCount} follower${(followStats.followCount !== 1) ? 's' : ''}`} /> }
 
           <DatasetInfoItem size='md' icon='lock' label='public' />
           <UsernameWithIcon username={username} />

--- a/src/features/session/state/sessionState.ts
+++ b/src/features/session/state/sessionState.ts
@@ -1,5 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit'
-import { UserProfile } from '../../../qri/userProfile'
+import { NewUserProfile, UserProfile } from '../../../qri/userProfile'
 import { RootState } from '../../../store/store'
 
 interface SessionTokens {
@@ -33,29 +33,7 @@ export interface SessionState {
   resetError: string
 }
 
-export const AnonUser: UserProfile = {
-  username: 'new',
-  profile_id: '',
-  PrivKey: '',
-  created: 0,
-  updated: 0,
-  type: '',
-  email: '',
-  name: '',
-  description: '',
-  home_url: '',
-  color: '',
-  thumb: '',
-  photo: '',
-  poster: '',
-  twitter: '',
-  PeerIDs: [],
-  NetworkAddrs: [],
-  id: '',
-  currentKey: '',
-  EmailConfirmed: false,
-  isAdmin: false
-}
+export const AnonUser = NewUserProfile({ username: 'new' })
 
 function getAuthState (): SessionState {
   try {
@@ -94,7 +72,8 @@ interface AuthAction {
 
 // same state changes on successful login or signup
 const loginOrSignupSuccess = (state: SessionState, action: AuthAction) => {
-  state.user = action.user
+  const pro = NewUserProfile(action.user)
+  state.user = pro
   state.loading = false
 
   state.token = action.token

--- a/src/features/userProfile/state/userProfileState.ts
+++ b/src/features/userProfile/state/userProfileState.ts
@@ -4,12 +4,15 @@ import { RootState } from '../../../store/store'
 import { PageInfo, SearchResult } from '../../../qri/search'
 import { UserProfile, NewUserProfile } from '../../../qri/userProfile'
 import { ApiErr, NewApiErr } from '../../../store/api'
+import { UserProfileAction } from './userProfileActions'
 
 export const selectUserProfile = (state: RootState): UserProfile => state.userProfile.profile
 export const selectUserProfileLoading = (state: RootState): boolean => state.userProfile.loading
 export const selectUserProfileError = (state: RootState): ApiErr => state.userProfile.error
 export const selectUserProfileDatasets = (state: RootState): PaginatedResults => state.userProfile.datasets
 export const selectUserProfileFollowing = (state: RootState): PaginatedResults => state.userProfile.following
+
+export const USERPROFILE_SET = 'USERPROFILE_SET'
 
 export interface PaginatedResults {
   results: SearchResult[]
@@ -49,7 +52,7 @@ export interface UserProfileState {
 }
 
 const initialState: UserProfileState = {
-  profile: NewUserProfile(),
+  profile: NewUserProfile({}),
   loading: false,
   error: NewApiErr(),
   datasets: NewPaginatedResults(),
@@ -62,7 +65,7 @@ export const userProfileReducer = createReducer(initialState, {
     state.error = NewApiErr()
   },
   'API_USERPROFILE_SUCCESS': (state: UserProfileState, action) => {
-    state.profile = action.payload.data
+    state.profile = NewUserProfile(action.payload.data)
     state.loading = false
   },
   'API_USERPROFILE_FAILURE': (state: UserProfileState, action) => {
@@ -70,12 +73,17 @@ export const userProfileReducer = createReducer(initialState, {
     state.error = action.payload.err
   },
 
+  USERPROFILE_SET: (state: UserProfileState, action: UserProfileAction) => {
+    state.profile = action.user
+  },
+
   'API_USERPROFILEDATASETS_REQUEST': (state: UserProfileState, action) => {
     state.datasets.loading = true
   },
   'API_USERPROFILEDATASETS_SUCCESS': (state: UserProfileState, action) => {
     state.datasets.results = action.payload.data
-    state.datasets.pageInfo = action.payload.pagination
+    state.datasets.pageInfo = action.payload.request.pageInfo
+    state.datasets.pageInfo.resultCount = state.datasets.results.length
     state.datasets.loading = false
   },
   'API_USERPROFILEDATASETS_FAILURE': (state: UserProfileState) => {

--- a/src/qri/userProfile.ts
+++ b/src/qri/userProfile.ts
@@ -1,7 +1,7 @@
 
 export interface UserProfile {
   profile_id: string
-  PrivKey: string
+  privKey: string
   username: string
   created: number
   updated: number
@@ -15,37 +15,53 @@ export interface UserProfile {
   photo: string
   poster: string
   twitter: string
-  PeerIDs: string[]
-  NetworkAddrs: string[]
+  peerIDs: string[]
+  networkAddrs: string[]
   id: string
   currentKey: string
-  EmailConfirmed: boolean
+  emailConfirmed: boolean
   isAdmin: boolean
 }
 
-export const NewUserProfile = () => {
+export const NewUserProfile = (d: Record<string, any>): UserProfile => {
+  let created = 0
+  let updated = 0
+
+  if (typeof d.created === 'string') {
+    const c = new Date(created)
+    created = c.getTime() / 1000
+  } else if (d.created) {
+    created = d.created
+  }
+
+  if (typeof d.updated === 'string') {
+    const u = new Date(updated)
+    updated = u.getTime() / 1000
+  } else if (d.updated) {
+    updated = d.updated
+  }
   return {
-    profile_id: '',
-    PrivKey: '',
-    username: '',
-    created: 0,
-    updated: 0,
-    type: '',
-    email: '',
-    name: '',
-    description: '',
-    home_url: '',
-    color: '',
-    thumb: '',
-    photo: '',
-    poster: '',
-    twitter: '',
-    PeerIDs: [],
-    NetworkAddrs: [],
-    id: '',
-    currentKey: '',
-    EmailConfirmed: false,
-    isAdmin: false
+    profile_id: d.id || d.profile_id || '',
+    privKey: d.privKey || d.PrivKey || '',
+    username: d.username || '',
+    created,
+    updated,
+    type: d.type || '',
+    email: d.email || '',
+    name: d.name || '',
+    description: d.description || '',
+    home_url: d.home_url || '',
+    color: d.color || '',
+    thumb: d.thumb || '',
+    photo: d.photo || '',
+    poster: d.poster || '',
+    twitter: d.twitter || '',
+    peerIDs: d.peerIDs || d.PeerIDs || [],
+    networkAddrs: d.networkAddrs || d.NetworkAddrs || [],
+    id: d.id || '',
+    currentKey: d.currentKey || '',
+    emailConfirmed: d.emailConfirmed || d.EmailConfirmed || '',
+    isAdmin: d.isAdmin || d.IsAdmin || false
   }
 }
 


### PR DESCRIPTION
Now that we have `Collection` in core and cloud & now that we have basic sorting on the `/list` endpoint, we can remove references of the `/dataset_summary` cloud specific endpoint.

NOTE

This will only work on cloud when PR https://github.com/qri-io/qri/pull/1981 is merged & then cloud dependencies are updated.

We may want to hold off on merging this PR until those conditions are met, otherwise sorting on the user profile page will be broken on cloud.