### PR TITLE
fix(NoBody): show `NoBody` component if a dataset has no body

### DIFF
--- a/src/chrome/Icon.tsx
+++ b/src/chrome/Icon.tsx
@@ -44,6 +44,7 @@ import Disk from './icon/Disk'
 import Download from './icon/Download'
 import EllipsesVertical from './icon/EllipsesVertical'
 import Eye from './icon/Eye'
+import FaceMeh from './icon/FaceMeh'
 import Follower from './icon/Follower'
 import FullScreen from './icon/FullScreen'
 import Github from './icon/Github'
@@ -137,6 +138,7 @@ const Icon: React.FunctionComponent<IconProps> = (props) => {
     ellipsesVertical: <EllipsesVertical {...props} />,
     eye: <Eye {...props} />,
     face: <Face {...props}/>,
+    faceMeh: <FaceMeh {...props} />,
     follower: <Follower {...props} />,
     fullScreen: <FullScreen {...props} />,
     github: <Github {...props} />,

--- a/src/chrome/icon/FaceMeh.tsx
+++ b/src/chrome/icon/FaceMeh.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import CustomIcon, { CustomIconProps } from '../CustomIcon'
+
+const FaceMeh: React.FC<CustomIconProps> = (props) => (
+  <CustomIcon {...props}>
+    <path d="M12 22.6194C17.5228 22.6194 22 18.1422 22 12.6194C22 7.09654 17.5228 2.61938 12 2.61938C6.47715 2.61938 2 7.09654 2 12.6194C2 18.1422 6.47715 22.6194 12 22.6194Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M8 15.6194H16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M9 9.61938H9.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M15 9.61938H15.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </CustomIcon>
+)
+
+export default FaceMeh

--- a/src/features/dsComponents/body/Body.tsx
+++ b/src/features/dsComponents/body/Body.tsx
@@ -7,6 +7,7 @@ import BodyTable from './BodyTable'
 import BodyJson from './BodyJson'
 import { loadBody } from '../../dataset/state/datasetActions'
 import { newQriRef } from '../../../qri/ref'
+import NoBody from './NoBody'
 // import { ApiActionThunk } from '../../../store/api'
 // import { DetailsType, StatsDetails, Details } from '../../../models/details'
 // import { RouteProps } from '../../../models/store'
@@ -68,6 +69,11 @@ const Body: React.FC<BodyProps> = ({
   if (loading) {
     return <BodyTable loading />
   }
+
+  if (!body) {
+    return <NoBody />
+  }
+
   if (!structure) {
     return (
       <div className='h-full w-full flex justify-center items-center'>

--- a/src/features/dsComponents/body/BodyPreview.tsx
+++ b/src/features/dsComponents/body/BodyPreview.tsx
@@ -7,6 +7,7 @@ import BodyJson from './BodyJson'
 import BodyHeader from './BodyHeader'
 import ComponentHeader from '../ComponentHeader'
 import Spinner from '../../../chrome/Spinner'
+import NoBody from './NoBody'
 
 export interface BodyProps {
   dataset: Dataset
@@ -22,13 +23,20 @@ const Body: React.FC<BodyProps> = ({
     structure
   } = dataset
 
-  if (!body) {
+  if (loading) {
     return (
       <div className='h-full w-full flex justify-center items-center'>
         <Spinner color='#43B3B2' />
       </div>
     )
   }
+
+  if (!body) {
+    return (
+      <NoBody />
+    )
+  }
+
   if (!structure) {
     return (
       <div className='h-full w-full flex justify-center items-center'>

--- a/src/features/dsComponents/body/NoBody.tsx
+++ b/src/features/dsComponents/body/NoBody.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import Icon from '../../../chrome/Icon'
+
+interface NoBodyProps {
+  styles?: string
+}
+const NoBody: React.FC<NoBodyProps> = ({ styles }) => {
+  return (<div className={`h-full w-full flex flex-col justify-center items-center border rounded-lg border-dangerred ${styles}`}>
+    <Icon className='text-dangerred mb-2' icon="faceMeh" />
+    <div>Seems that you don&apos;t have a body</div>
+  </div>)
+}
+
+export default NoBody

--- a/src/features/dsPreview/state/dsPreviewActions.ts
+++ b/src/features/dsPreview/state/dsPreviewActions.ts
@@ -2,27 +2,8 @@ import { QriRef } from "../../../qri/ref"
 import { ApiAction, ApiActionThunk, CALL_API } from "../../../store/api"
 
 export function loadDsPreview (ref: QriRef): ApiActionThunk {
-  return async (dispatch, getState) => {
-    dispatch({ type: 'DS_PREVIEW_REQUEST' })
-
-    try {
-      await Promise.all([
-        // for the moment we don't get a preview explicitly because we already
-        // have what we need in state.dataset
-        // dispatch(fetchDsPreview(ref)),
-        dispatch(fetchDsPreviewBody(ref))
-      ])
-
-      return dispatch({
-        type: 'DS_PREVIEW_SUCCESS',
-        ref
-      })
-    } catch (e: any) {
-      return dispatch({
-        type: 'DS_PREVIEW_FAILURE',
-        error: e.toString()
-      })
-    }
+  return async (dispatch) => {
+    return dispatch(fetchDsPreview(ref))
   }
 }
 
@@ -36,27 +17,6 @@ export function fetchDsPreview (ref: QriRef): ApiAction {
       endpoint: 'ds/get',
       method: 'GET',
       segments: ref
-    }
-  }
-}
-
-function fetchDsPreviewBody (ref: QriRef, page: number = 1, pageSize: number = bodyPageSizeDefault): ApiAction {
-  return {
-    type: 'previewbody',
-    ref,
-    [CALL_API]: {
-      endpoint: 'ds/get',
-      method: 'GET',
-      pageInfo: {
-        page,
-        pageSize
-      },
-      segments: {
-        username: ref.username,
-        name: ref.name,
-        path: ref.path,
-        selector: ['body']
-      }
     }
   }
 }

--- a/src/features/dsPreview/state/dsPreviewState.ts
+++ b/src/features/dsPreview/state/dsPreviewState.ts
@@ -29,16 +29,6 @@ const initialState: DsPreviewState = {
 }
 
 export const dsPreviewReducer = createReducer(initialState, {
-  'DS_PREVIEW_REQUEST': (state) => {
-    state.loading = true
-  },
-  'DS_PREVIEW_SUCCESS': (state) => {
-    state.loading = false
-  },
-  'DS_PREVIEW_FAILURE': (state) => {
-    state.loading = false
-  },
-
   'API_PREVIEW_REQUEST': (state) => {
     state.preview = NewDataset({})
     state.loading = true
@@ -53,13 +43,7 @@ export const dsPreviewReducer = createReducer(initialState, {
       ...state.preview,
       ...NewDataset(action.payload.data)
     }
-  },
-
-  'API_PREVIEWBODY_REQUEST': (state) => {
-    state.loading = true
-  },
-  'API_PREVIEWBODY_SUCCESS': (state, action) => {
-    state.preview.body = action.payload.data
+    state.loading = false
   },
 
   'API_PREVIEWREADME_SUCCESS': (state, action) => {

--- a/src/qri/dataset.ts
+++ b/src/qri/dataset.ts
@@ -92,6 +92,27 @@ export type ComponentName =
  | 'viz'
  | 'stats'
 
+// rankedComponentNames is a ranked list ranging from the components we deem
+// it most important that user see first, to the least important
+const rankedComponentNames = ['body', 'readme', 'transform', 'viz', 'meta', 'stats', 'commit', 'structure']
+
+export function getRankedComponentNames (dataset: Dataset): ComponentName[] {
+  return rankedComponentNames.reduce<ComponentName[]>((acc, name) => {
+    const comp = getComponentFromDatasetByName(dataset, name)
+    if (name === "body" && comp) {
+      const bodyComp = comp as BodyComponent
+      if (bodyComp.body) {
+        acc.push(name as ComponentName)
+      }
+      return acc
+    }
+    if (comp) {
+      acc.push(name as ComponentName)
+    }
+    return acc
+  }, [])
+}
+
 export type ComponentStatus =
  | 'modified'
  | 'unmodified'


### PR DESCRIPTION
closes #593 

Also removes extraneous call to get the dataset body,  now that (as per https://github.com/qri-io/qri/pull/1980, when it is merged) the `/ds/get` endpoint returns a dataset preview if no selectors are given.

NOTE

Until the above pr is merged and then cloud is updated to use that version of qri, this PR will cause problems on the dataset preview page. We may want to wait for the backend to be pushed before merging this pr.