### PR TITLE
feat: add responsive layouts for preview, search, user profile, login…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <!-- <meta
       name="description"

--- a/src/chrome/ContentBox.tsx
+++ b/src/chrome/ContentBox.tsx
@@ -13,15 +13,15 @@ interface ContentBoxProps {
 
 const ContentBox: React.FC<ContentBoxProps> = ({
   className,
-  paddingClassName = 'py-6 px-8',
+  paddingClassName = 'p-6',
   warning,
   card = false,
   children
 }) => (
   <div className={className}>
     <div className={classNames('min-height-200 h-full bg-white', paddingClassName, {
-      'rounded-lg': !warning,
-      'rounded-t-lg': warning
+      'rounded-2xl': !warning,
+      'rounded-t-2xl': warning
     })} style={{
       boxShadow: card ? '0px 0px 8px rgba(0, 0, 0, 0.1)' : ''
     }}>

--- a/src/chrome/DropdownMenu.tsx
+++ b/src/chrome/DropdownMenu.tsx
@@ -49,7 +49,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   }, [handleClickOutside])
 
   return (
-    <div id={id} ref={ref} className={classNames('relative inline-block text-left w-full', className)}>
+    <div id={id} ref={ref} className={classNames('relative inline-block text-left', className)}>
       <div onClick={() => { setOpen(!open) }} className='cursor-pointer flex items-center'>
         {(typeof icon === 'string') ? <Icon icon={icon} /> : icon}
       </div>

--- a/src/chrome/PageControl.tsx
+++ b/src/chrome/PageControl.tsx
@@ -51,8 +51,8 @@ const PageControl: React.FC<PageControlProps> = ({
   }
 
   return (
-    <div className='page-control mt-2 flex justify-between px-2.5 text-qrigray text-xs'>
-      { showRange && <div className='current-page-info flex items-center'>{numeral(lowItem).format('0,0')}-{numeral(highItem).format('0,0')} of {numeral(resultCount).format('0,0')}</div> }
+    <div className='page-control mt-2 flex flex-col md:flex-row items-center justify-between px-2.5 text-qrigray text-xs'>
+      { showRange && <div className='current-page-info flex items-center mb-2'>{numeral(lowItem).format('0,0')}-{numeral(highItem).format('0,0')} of {numeral(resultCount).format('0,0')}</div> }
       { pageCount > 1 && (
         <div className='text-right'>
           <ReactPaginate

--- a/src/features/activityFeed/DatasetActivityFeed.tsx
+++ b/src/features/activityFeed/DatasetActivityFeed.tsx
@@ -78,7 +78,8 @@ const DatasetActivityFeed: React.FC<DatasetActivityFeedProps> = ({
       <Head data={{
         title: `${qriRef.username}/${qriRef.name} run log | Qri`,
         pathname: location.pathname,
-        description: `Explore the automation run log for the Qri Dataset ${qriRef.username}/${qriRef.name}`
+        description: `Explore the automation run log for the Qri Dataset ${qriRef.username}/${qriRef.name}`,
+        appView: true
       }}/>
       <div ref={tableContainer} className='overflow-y-hidden rounded-lg relative flex-grow bg-white'>
         <div className='rounded-none h-full'>

--- a/src/features/app/Head.tsx
+++ b/src/features/app/Head.tsx
@@ -8,6 +8,8 @@ interface HeadProps {
     description?: string
     image?: string
     imageAlt?: string
+    // appView will set the viewport meta tag to a fixed width
+    appView?: boolean
   }
 }
 
@@ -17,7 +19,8 @@ const Head: React.FunctionComponent<HeadProps> = ({ data = {}, children }) => {
     pathname,
     description,
     image,
-    imageAlt
+    imageAlt,
+    appView = false
   } = data
 
   return (
@@ -40,7 +43,9 @@ const Head: React.FunctionComponent<HeadProps> = ({ data = {}, children }) => {
 
         { imageAlt && <meta name="twitter:image-alt" content={imageAlt} />}
 
-        {pathname && <meta property="og:url" content={`https://qri.cloud${pathname}`} />}
+        { pathname && <meta property="og:url" content={`https://qri.cloud${pathname}`} />}
+
+        { appView ? <meta name="viewport" content="width=1024" /> : <meta name="viewport" content="width=device-width, initial-scale=1" /> }
 
         {children}
       </Helmet>

--- a/src/features/app/modal/Modal.tsx
+++ b/src/features/app/modal/Modal.tsx
@@ -55,12 +55,18 @@ const Modal: React.FC<any> = () => {
 
   return (
     <div className='fixed z-50 inset-0 overflow-y-auto'>
-      <div className='flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0'>
+      <div className='flex items-center justify-center min-h-screen p-6 text-center sm:block sm:p-0 w-full'>
         <div ref={maskRef} className="fixed inset-0 transition-opacity" aria-hidden="true">
           <div className="absolute inset-0 bg-gray-500 opacity-75"/>
         </div>
 
-        <div style={modal.position && { position: modal.position.position, top: modal.position.top, left: modal.position.left }} className={`inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle ${modal.customWidth ? '' : 'max-w-xl'}`} role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+        <div
+          style={modal.position && { position: modal.position.position, top: modal.position.top, left: modal.position.left }}
+          className={`w-full inline-block align-bottom bg-white rounded-2xl text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle ${modal.customWidth ? '' : 'max-w-md'}`}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-headline"
+        >
           {(() => {
             switch (modal.type) {
               case ModalType.schedulePicker:

--- a/src/features/collection/Collection.tsx
+++ b/src/features/collection/Collection.tsx
@@ -4,7 +4,7 @@ import useDimensions from 'react-use-dimensions'
 
 import { loadCollection } from './state/collectionActions'
 import { selectCollection, selectIsCollectionLoading } from './state/collectionState'
-import PageWithFooter from '../app/PageWithFooter'
+import FixedLayout from '../layouts/FixedLayout'
 import CollectionTable from './CollectionTable'
 import Spinner from '../../chrome/Spinner'
 import Link from '../../chrome/Link'
@@ -80,9 +80,10 @@ const Collection: React.FC<{}> = () => {
   }
 
   return (
-    <PageWithFooter>
+    <FixedLayout>
       <Head data={{
-        title: `My Datasets | Qri`
+        title: `My Datasets | Qri`,
+        appView: true
       }}/>
       <div className='h-full' style={{ backgroundColor: '#f3f4f6' }}>
         <div className='h-full w-9/12 mx-auto pt-7 pb-7 flex flex-col'>
@@ -113,7 +114,7 @@ const Collection: React.FC<{}> = () => {
           </div>
         </div>
       </div>
-    </PageWithFooter>
+    </FixedLayout>
   )
 }
 

--- a/src/features/dataset/DatasetHeader.tsx
+++ b/src/features/dataset/DatasetHeader.tsx
@@ -127,7 +127,7 @@ const DatasetHeader: React.FC<DatasetHeaderProps> = ({
             ? <ContentLoader height='29.6'>
               <rect width="320" y='5' height="20" rx="1" fill="#D5DADD"/>
             </ContentLoader>
-            : <div ref={measuredRef} onClick={onTitleClick} className={classNames({ 'cursor-pointer whitespace-nowrap': !isNew }, 'flex items-center group hover:text')}>
+            : <div ref={measuredRef} onClick={onTitleClick} className={classNames({ 'cursor-pointer': !isNew }, 'flex items-center group hover:text')}>
               <h3 className='text-2xl font-bold'>{isNew ? newWorkflowTitle : dataset.meta?.title ? dataset.meta?.title : header.name}</h3>
               {
                 editable && <Icon size='sm' className='text-qrigray-300 ml-4 opacity-0 group-hover:opacity-100 transition-opacity' icon='edit' />

--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -26,11 +26,10 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
   const qriRef = qriRefFromVersionInfo(header)
 
   return (
-    <div className={classNames('sticky bg-white border border-qrigray-200 z-30', {
+    <div className={classNames('sticky bg-white border border-qrigray-200 z-30 md:rounded-tl-3xl', {
       'invisible -top-16 h-0': !show,
       'visible top-0': show
     })} style={{
-      borderTopLeftRadius: '20px',
       transition: 'top 150ms cubic-bezier(0.4, 0, 0.2, 1)'
     }}>
       <div className='px-7 pt-4 pb-3 flex items-center z-10'>

--- a/src/features/dataset/DatasetNavSidebar.tsx
+++ b/src/features/dataset/DatasetNavSidebar.tsx
@@ -52,7 +52,7 @@ const DatasetNavSidebar: React.FC<DatasetNavSidebarProps> = ({ qriRef }) => {
   const isNewWorkflow = segments[segments.length - 1] === 'new'
 
   return (
-    <div className={`side-nav h-full bg-white relative py-9 flex flex-col flex-shrink-0 ${expanded ? 'w-44' : 'w-24'}`}>
+    <div className={`hidden md:flex side-nav h-full bg-white relative py-9 flex-col flex-shrink-0 ${expanded ? 'w-44' : 'w-24'}`}>
       <div className='mb-9 flex align-center items-center h-6 mx-auto'>
         <div
           className='text-qrigray-300 text-sm font-medium mr-3 leading-6 transition-all duration-700'

--- a/src/features/dataset/DatasetScrollLayout.tsx
+++ b/src/features/dataset/DatasetScrollLayout.tsx
@@ -10,6 +10,7 @@ import { selectSessionUserCanEditDataset } from './state/datasetState'
 import DatasetHeader from './DatasetHeader'
 import DatasetMiniHeader from '../dataset/DatasetMiniHeader'
 import Scroller from '../scroller/Scroller'
+import MobileFooter from '../footer/MobileFooter'
 
 interface DatasetScrollLayoutProps {
   isNew?: boolean
@@ -48,7 +49,7 @@ const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
       <DatasetMiniHeader isNew={isNew} show={!inView} >
         {headerChildren}
       </DatasetMiniHeader>
-      <div className={classNames('dataset_fixed_layout p-7 w-full', contentClassName)}>
+      <div className={classNames('dataset_fixed_layout p-6 w-full', contentClassName)}>
         <div ref={stickyHeaderTriggerRef}>
           <DatasetHeader isNew={isNew} editable={editable}>
             {headerChildren}
@@ -70,6 +71,9 @@ const DatasetScrollLayout: React.FC<DatasetScrollLayoutProps> = ({
   return (
     <div className='overflow-y-scroll overflow-x-hidden flex-grow relative'>
       {content}
+      <div className='bg-white flex-shrink-0 md:hidden'>
+        <MobileFooter />
+      </div>
     </div>
   )
 }

--- a/src/features/dsComponents/DatasetComponent.tsx
+++ b/src/features/dsComponents/DatasetComponent.tsx
@@ -91,7 +91,7 @@ const DatasetComponent: React.FC<DatasetComponentProps> = ({
       <ComponentHeader border={!['body', 'structure', 'transform'].includes(componentName)}>
         {componentHeader}
       </ComponentHeader>
-      <div className='overflow-auto flex-grow'>
+      <div className='overflow-auto flex-grow hide-scrollbar'>
         {componentContent}
       </div>
 

--- a/src/features/dsComponents/DatasetComponents.tsx
+++ b/src/features/dsComponents/DatasetComponents.tsx
@@ -33,7 +33,8 @@ const DatasetComponents: React.FC<{}> = () => {
       <Head data={{
         title: `${qriRef.username}/${qriRef.name} history | Qri`,
         pathname: location.pathname,
-        description: dataset?.meta?.description || `Explore the history of commits for the Qri Dataset ${qriRef.username}/${qriRef.name}`
+        description: dataset?.meta?.description || `Explore the history of commits for the Qri Dataset ${qriRef.username}/${qriRef.name}`,
+        appView: true
       }}/>
       <div className='flex-grow flex overflow-hidden'>
         <DatasetCommitList qriRef={qriRef} />

--- a/src/features/dsComponents/body/BodyPreview.tsx
+++ b/src/features/dsComponents/body/BodyPreview.tsx
@@ -46,7 +46,7 @@ const Body: React.FC<BodyProps> = ({
       <ComponentHeader border={false}>
         <BodyHeader dataset={dataset} showExpand={false} loading={loading} />
       </ComponentHeader>
-      <div className='overflow-auto flex-grow'>
+      <div className='overflow-auto flex-grow hide-scrollbar'>
         {
         (structure.format === 'csv' && Array.isArray(body))
           ? <BodyTable

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -68,6 +68,24 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
 
   const location = useLocation()
 
+  const readmeContent = (
+    <div className={classNames('px-3 align-top w-full', {
+      'absolute': !expandReadme
+    })} style={{ height: readmeContainerHeight }}>
+      <ContentBox className='flex flex-col h-full'>
+        <div style={{ minHeight: minReadmeHeight }} className='flex flex-col h-full overflow-hidden'>
+          <ContentBoxTitle title='Readme'/>
+          <div className={classNames('flex-grow overflow-hidden relative', {
+            'fade-bottom': readmeHeightLargerThanContainerHeight
+          })}>
+            <Readme data={dataset.readme} />
+          </div>
+          {!expandReadme && (readmeHeightLargerThanContainerHeight) && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-2' onClick={() => { setExpandReadme(true) }}>See More</div>)}
+        </div>
+      </ContentBox>
+    </div>
+  )
+
   return (
     <>
       <Head data={{
@@ -81,27 +99,13 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
         </div>)
         : (
           <DatasetScrollLayout contentClassName='max-w-screen-lg mx-auto'>
-            <div className='flex -ml-2 -mr-3 mb-6'>
+            <div className='flex -mx-3 mb-6'>
               {dataset.readme && (
-              <div className='flex-grow w-7/12 relative'>
-                <div className={classNames('px-2 align-top w-full', {
-                  'absolute': !expandReadme
-                })} style={{ height: readmeContainerHeight }}>
-                  <ContentBox className='flex flex-col h-full'>
-                    <div style={{ minHeight: minReadmeHeight }} className='flex flex-col h-full overflow-hidden'>
-                      <ContentBoxTitle title='Readme'/>
-                      <div className={classNames('flex-grow overflow-hidden relative', {
-                        'fade-bottom': readmeHeightLargerThanContainerHeight
-                      })}>
-                        <Readme data={dataset.readme} />
-                      </div>
-                      {!expandReadme && (readmeHeightLargerThanContainerHeight) && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-2' onClick={() => { setExpandReadme(true) }}>See More</div>)}
-                    </div>
-                  </ContentBox>
-                </div>
+              <div className='flex-grow w-7/12 relative hidden md:block'>
+                {readmeContent}
               </div>
               )}
-              <div ref={versionInfoContainer} className={`${dataset.readme ? 'w-5/12' : 'w-full'} px-3 align-top`}>
+              <div ref={versionInfoContainer} className={`${dataset.readme ? 'w-full md:w-5/12' : 'w-full'} px-3 align-top`}>
                 <ContentBox>
                   <div className='flex items-center'>
                     <div className='flex-grow truncate'>
@@ -111,12 +115,31 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                           <DatasetCommitInfo item={newVersionInfoFromDataset(dataset)} small />
                         </div>
                         <div className='flex flex-shrink-0'>
-                          <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' hideIcon={true} type='primary' qriRef={qriRef} />
+                          <div className='hidden md:block'>
+                            <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' hideIcon type='primary' qriRef={qriRef} />
+                          </div>
+                          <div className='block md:hidden'>
+                            <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' type='primary' qriRef={qriRef} small />
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </ContentBox>
+                {/* Displays readme content box between version info and meta, shown only on smaller screen widths */}
+                {dataset.readme && (
+                  <ContentBox className='flex flex-col mt-6 block md:hidden'>
+                    <div className='flex flex-col h-full overflow-hidden'>
+                      <ContentBoxTitle title='Readme'/>
+                      <div className={classNames('flex-grow overflow-hidden relative', {
+                        'fade-bottom': readmeHeightLargerThanContainerHeight
+                      })} style={{ maxHeight: expandReadme ? '' : 256 }}>
+                        <Readme data={dataset.readme} />
+                      </div>
+                      {!expandReadme && (<div className='font-semibold text-qritile text-sm cursor-pointer mt-2' onClick={() => { setExpandReadme(true) }}>See More</div>)}
+                    </div>
+                  </ContentBox>
+                )}
                 <ContentBox className='mt-6'>
                   {/* Bottom of the box */}
                   <ContentBoxTitle title='Metadata' />

--- a/src/features/footer/Footer.tsx
+++ b/src/features/footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Link from '../../chrome/Link'
-import IconLink from '../../chrome/IconLink'
+import QriSocialLinks from './QriSocialLinks'
 
 const Footer: React.FC<{}> = () => (
   <div className='flex w-9/12 mx-auto text-black text-sm py-5 tracking-wide'>
@@ -28,33 +28,7 @@ const Footer: React.FC<{}> = () => (
         FAQs
       </Link>
     </div>
-    <div className='flex flex-grow justify-end'>
-      {
-        [
-          { icon: 'github',
-            link: 'https://github.com/qri-io'
-          },
-          { icon: 'youtube',
-            link: 'https://www.youtube.com/channel/UC7E3_hURgFO2mVCLDwPSyOQ'
-          },
-          { icon: 'twitter',
-            link: 'https://twitter.com/qri_io'
-          },
-          { icon: 'discord',
-            link: 'https://discordapp.com/invite/thkJHKj'
-          }
-        ].map(({ icon, link }, i) => (
-          <IconLink
-            key={i}
-            icon={icon}
-            size='md'
-            link={link}
-            className='ml-5'
-            colorClassName='text-black hover:text-qripink-600'
-          />
-        ))
-      }
-    </div>
+    <QriSocialLinks />
   </div>
 )
 

--- a/src/features/footer/MobileFooter.tsx
+++ b/src/features/footer/MobileFooter.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import Link from '../../chrome/Link'
+import QriSocialLinks from './QriSocialLinks'
+
+const Footer: React.FC<{}> = () => (
+  <div className='flex flex-col text-black text-sm py-8 tracking-wide items-center'>
+    <div className='flex flex-grow justify-center md:justify-end mb-6'>
+      <div
+        className='mr-5'
+      >
+        &copy; 2021 qri, inc.
+      </div>
+      <Link
+        className='mr-5'
+        colorClassName='text-black hover:text-qripink-600'
+        to='https://qri.io/legal/tos'
+      >
+        Terms of Service
+      </Link>
+      <Link
+        colorClassName='text-black hover:text-qripink-600'
+        to='https://qri.io/legal/privacy-policy'
+      >
+        Privacy Policy
+      </Link>
+    </div>
+    <QriSocialLinks/>
+  </div>
+)
+
+export default Footer

--- a/src/features/footer/QriSocialLinks.tsx
+++ b/src/features/footer/QriSocialLinks.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import IconLink from '../../chrome/IconLink'
+
+const QriSocialLinks = () => (
+  <div className='flex flex-grow justify-end'>
+    {
+      [
+        { icon: 'github',
+          link: 'https://github.com/qri-io'
+        },
+        { icon: 'youtube',
+          link: 'https://www.youtube.com/channel/UC7E3_hURgFO2mVCLDwPSyOQ'
+        },
+        { icon: 'twitter',
+          link: 'https://twitter.com/qri_io'
+        },
+        { icon: 'discord',
+          link: 'https://discordapp.com/invite/thkJHKj'
+        }
+      ].map(({ icon, link }, i) => (
+        <IconLink
+          key={i}
+          icon={icon}
+          size='md'
+          link={link}
+          className='ml-5 first:ml-0'
+          colorClassName='text-black hover:text-qripink-600'
+        />
+      ))
+    }
+  </div>
+)
+
+export default QriSocialLinks

--- a/src/features/layouts/FixedLayout.tsx
+++ b/src/features/layouts/FixedLayout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import NavBar from '../navbar/NavBar'
 import Footer from '../footer/Footer'
 
-const Page: React.FC = ({ children }) => (
+const FixedLayout: React.FC = ({ children }) => (
   <div className='flex flex-col h-full'>
     <NavBar />
     <div className='flex-grow overflow-y-hidden bg-white'>
@@ -13,4 +13,4 @@ const Page: React.FC = ({ children }) => (
   </div>
 )
 
-export default Page
+export default FixedLayout

--- a/src/features/layouts/ScrollLayout.tsx
+++ b/src/features/layouts/ScrollLayout.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import NavBar, { NavBarProps } from '../navbar/NavBar'
+import Footer from '../footer/Footer'
+import MobileFooter from '../footer/MobileFooter'
+
+interface ScrollLayoutProps {
+  navBarProps?: NavBarProps
+}
+
+const ScrollLayout: React.FC<ScrollLayoutProps> = ({ navBarProps, children }) => {
+  return (
+    <div className='flex flex-col h-full w-full' style={{ backgroundColor: '#f3f4f6' }}>
+      <NavBar {...navBarProps}/>
+      <div className='flex-grow w-full overflow-y-scroll flex flex-col'>
+        {children}
+        <div className='bg-white flex-shrink-0 md:hidden'>
+          <MobileFooter />
+        </div>
+      </div>
+      <div className='bg-white flex-shrink-0 hidden md:block'>
+        <Footer />
+      </div>
+    </div>
+  )
+}
+
+export default ScrollLayout

--- a/src/features/layouts/WebAppLayout.tsx
+++ b/src/features/layouts/WebAppLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const WebAppLayout: React.FC<{}> = ({ children }) => (
-  <div className='web-app-layout h-full w-full' style={{ minWidth: '1100px' }}>
+  <div className='web-app-layout h-full w-full'>
     { children }
   </div>
 )

--- a/src/features/navbar/NavBar.tsx
+++ b/src/features/navbar/NavBar.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux'
 import SessionUserMenu from './SessionUserMenu'
 import SearchBox from '../search/SearchBox'
 import QriLogo from '../../chrome/QriLogo'
+import IconLink from '../../chrome/IconLink'
 import ButtonGroup from '../../chrome/ButtonGroup'
 import { selectNavExpanded } from '../app/state/appState'
 import { AnonUser, selectSessionUser } from '../session/state/sessionState'
@@ -47,7 +48,7 @@ const NavBar: React.FC<NavBarProps> = ({
   }
 
   return (
-    <div className={classNames('text-black text-bold flex items-center pr-8 font-medium w-full z-40', {
+    <div className={classNames('text-black text-bold flex items-center pr-6 font-medium w-full z-40', {
       'bg-white': !transparent,
       'absolute top-0': absolute
     })} style={{
@@ -56,16 +57,19 @@ const NavBar: React.FC<NavBarProps> = ({
     }}>
       {!noLogo && (
         <Link className='mr-5' to='/'>
-          <div className={`flex align-center items-center justify-center ${expanded ? 'w-44' : 'w-24'}`}>
+          <div className={`flex align-center items-center ml-6 md:ml-0 justify-start md:justify-center ${expanded ? 'w-44' : 'w-24'}`}>
             <QriLogo />
             <div className={`font-bold text-xl ml-2 ${expanded ? 'block' : 'hidden'}`} style={{ fontSize: 21 }}>Qri</div>
           </div>
         </Link>
       )}
-      <div className='w-48'>
-        {!minimal && showSearch && <SearchBox onSubmit={handleSearchSubmit} placeholder='Search for Datasets' />}
+      {!minimal && showSearch && (
+      <div className='w-48 hidden md:block'>
+        <SearchBox onSubmit={handleSearchSubmit} placeholder='Search for Datasets' />
       </div>
-      <div className='flex m-auto items-center'>
+      )}
+
+      <div className='m-auto items-center hidden md:flex'>
         {!minimal && (user !== AnonUser) && (
           <ButtonGroup
             items={buttonItems}
@@ -73,7 +77,15 @@ const NavBar: React.FC<NavBarProps> = ({
           />
         )}
       </div>
-      <SessionUserMenu />
+      <div className='flex-grow md:flex-grow-0'/>
+      {!minimal && showSearch && (
+      <div className='md:hidden'>
+        <IconLink icon='skinnySearch' size='lg' link='/search' />
+      </div>
+      )}
+      <div className='flex justify-end items-center'>
+        <SessionUserMenu />
+      </div>
     </div>
   )
 }

--- a/src/features/navbar/SessionUserMenu.tsx
+++ b/src/features/navbar/SessionUserMenu.tsx
@@ -54,14 +54,14 @@ const SessionUserMenu: React.FC<{}> = () => {
     <div className="relative flex items-center font-medium">
       <Link
         to='https://qri.io/docs'
-        className='text-sm font-semibold'
+        className='text-sm font-semibold hidden md:block'
         colorClassName='text-black hover:text-qripink-600'
         onClick={() => {
           // general-click-help event
           trackGoal('MN77WFUZ', 0)
         }}
       >Help</Link>
-      <DropdownMenu icon={userIcon} className='ml-8 session_user_menu' items={[
+      <DropdownMenu icon={userIcon} className='ml-4 md:ml-8 session_user_menu' items={[
         {
           element: (
             <div className='flex'>

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -10,10 +10,9 @@ import {
   selectSearchPageInfo,
   selectSearchLoading
 } from './state/searchState'
-import NavBar from '../navbar/NavBar'
 import SearchBox from './SearchBox'
 import PageControl, { PageChangeObject } from '../../chrome/PageControl'
-import Footer from '../footer/Footer'
+import ScrollLayout from '../layouts/ScrollLayout'
 import { NewSearchParams, CleanSearchParams } from '../../qri/search'
 import DatasetList from '../../chrome/DatasetList'
 import Link from '../../chrome/Link'
@@ -124,72 +123,72 @@ const Search: React.FC<{}> = () => {
   </div>
 
   return (
-    <div className='flex flex-col h-full w-full overflow-y-scroll' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6' }}>
-      <Head data={{
-        title: `${q ? `Datasets matching '${q}'` : 'Dataset Search'} | Qri`,
-        pathname: '/search',
-        description: 'Search thousands of public versioned datasets on qri.cloud'
-      }}/>
-      <NavBar showSearch={false} />
-      <div className='flex-grow w-full py-9'>
-        <div className='w-4/5 max-w-screen-lg mx-auto'>
-          <div className='text-black text-3xl font-black mb-4'>Dataset Search</div>
-          <div className='mb-4'>
-            <SearchBox onSubmit={handleSearchSubmit} size='lg' placeholder='Search for Datasets' value={q}/>
-          </div>
-          <div className='flex items-center mb-4 h-8'>
-            {searchResults.length > 0
-              ? (
-                <>
-                  <div className='flex-grow'>
-                    <div className='text-qrigray-400 text-sm '>
-                      { loading
-                        ? (
-                          <ContentLoader
-                        width={300}
-                        height={20}
-                      >
-                            <rect y="0" width="300" height="18" rx="6"/>
-                          </ContentLoader>
-                          )
-                        : (
-                          <>{pageInfo.resultCount} datasets found matching &apos;{q}&apos;</>
-                          )}
+    <ScrollLayout navBarProps={{
+      showSearch: false
+    }}>
+      <>
+        <Head data={{
+          title: `${q ? `Datasets matching '${q}'` : 'Dataset Search'} | Qri`,
+          pathname: '/search',
+          description: 'Search thousands of public versioned datasets on qri.cloud'
+        }}/>
+        <div className='flex-grow w-full py-9 px-6'>
+          <div className='w-full max-w-screen-lg mx-auto'>
+            <div className='text-black text-3xl font-black mb-4'>Dataset Search</div>
+            <div className='mb-5'>
+              <SearchBox onSubmit={handleSearchSubmit} size='lg' placeholder='Search for Datasets' value={q} border={false}/>
+            </div>
+            <div className='flex items-center mb-5 h-8'>
+              {searchResults.length > 0
+                ? (
+                  <>
+                    <div className='flex-grow'>
+                      <div className='text-qrigray-400 text-sm '>
+                        { loading
+                          ? (
+                            <ContentLoader
+                          width={300}
+                          height={20}
+                        >
+                              <rect y="0" width="300" height="18" rx="6"/>
+                            </ContentLoader>
+                            )
+                          : (
+                            <>{pageInfo.resultCount} datasets found matching &apos;{q}&apos;</>
+                            )}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <DropdownMenu
-                    icon={sortIcon}
-                    className='ml-8'
-                    items={[
-                      {
-                        label: 'Dataset Name',
-                        active: sort === 'name',
-                        onClick: () => { updateQueryParams({ sort: 'name' }) }
-                      },
-                      {
-                        label: 'Recently Updated',
-                        active: sort === 'recentlyupdated',
-                        onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
-                      }
-                    ]}
-                  />
-                  </div>
-                </>
-                )
-              : (
-                <>&nbsp;</>
-                )}
+                    <div>
+                      <DropdownMenu
+                      icon={sortIcon}
+                      className='ml-8'
+                      items={[
+                        {
+                          label: 'Dataset Name',
+                          active: sort === 'name',
+                          onClick: () => { updateQueryParams({ sort: 'name' }) }
+                        },
+                        {
+                          label: 'Recently Updated',
+                          active: sort === 'recentlyupdated',
+                          onClick: () => { updateQueryParams({ sort: 'recentlyupdated' }) }
+                        }
+                      ]}
+                    />
+                    </div>
+                  </>
+                  )
+                : (
+                  <>&nbsp;</>
+                  )}
+            </div>
+          </div>
+          <div className='w-full max-w-screen-lg mx-auto overflow-hidden'>
+            { resultsContent }
           </div>
         </div>
-        <div className='w-4/5 max-w-screen-lg mx-auto'>
-          { resultsContent }
-        </div>
-      </div>
-      <div className='bg-white flex-shrink-0'>
-        <Footer />
-      </div>
-    </div>
+      </>
+    </ScrollLayout>
   )
 }
 

--- a/src/features/search/SearchBox.tsx
+++ b/src/features/search/SearchBox.tsx
@@ -61,22 +61,25 @@ const SearchBox: React.FC<SearchBoxProps> = ({
   const LARGE_HEIGHT = 50
 
   return (
-    <form className={classNames('relative flex focus-within:border-qripink-600 border rounded-lg w-full', {
+    <form className={classNames('relative flex focus-within:border-qripink-600 w-full', {
       'bg-transparent': transparent,
       'bg-white': !transparent,
-      'border-qrigray-300': !dark && border,
-      'border-black': dark && border,
+      'border border-qrigray-300': !dark && border,
+      'border border-black': dark && border,
+      'rounded-xl': size === 'lg',
+      'rounded-lg': size !== 'lg',
       'border-0': !border
     })} onSubmit={handleSubmit} style={{
       boxShadow: shadow ? '0px 0px 8px rgba(0, 0, 0, 0.1)' : '',
       height: size === 'lg' ? LARGE_HEIGHT : DEFAULT_HEIGHT
     }}>
       <input
-        className={classNames('focus:ring-transparent border-0 bg-transparent block rounded-lg w-full p-0', {
+        className={classNames('focus:ring-transparent border-0 bg-transparent block w-full p-0', {
           'placeholder-black': dark,
           'placeholder-qrigray-300': !dark,
           'text-sm': size === 'md',
-          'text-base': size === 'lg',
+          'text-base rounded-xl': size === 'lg',
+          'rounded-lg': size !== 'lg',
           'cursor-pointer': disabled
         })}
         id='search'

--- a/src/features/search/SearchResultItem.tsx
+++ b/src/features/search/SearchResultItem.tsx
@@ -44,7 +44,7 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({ dataset, loading = 
     itemContent = (
       <>
         <Link to={`/${humanRef}`}><div className='text-xs text-qrigray-400 relative flex items-baseline group hover:text mb-1 font-mono hover:underline'>{humanRef}</div></Link>
-        <Link to={`/${humanRef}`}><div className='text-xl text-black-500 font-bold hover:text hover:underline'>{title}</div></Link>
+        <Link to={`/${humanRef}`}><div className='text-xl text-black-500 font-bold hover:text hover:underline overflow-hidden overflow-ellipsis'>{title}</div></Link>
         <div className='text-sm text-qrigray-400 hover:text line-clamp-3 mb-1'>{meta?.description || 'No Description'}</div>
         <div className='flex items-center flex-wrap text-xs'>
           { commit?.timestamp && <DatasetInfoItem size='md' icon='clock' label={<RelativeTimestamp timestamp={new Date(commit.timestamp)} />} />}

--- a/src/features/session/Login.tsx
+++ b/src/features/session/Login.tsx
@@ -2,18 +2,17 @@ import React from 'react'
 
 import LogInModal from './modal/LogInModal'
 import Head from '../app/Head'
+import ScrollLayout from '../layouts/ScrollLayout'
 
 const Login: React.FC<{}> = () => (
-  <div className='flex flex-col h-full bg-gray-100'>
+  <ScrollLayout>
     <Head data={{
       title: `Login | Qri`
     }}/>
-    <div className='m-auto p-10'>
-      <div className="shadow-md">
-        <LogInModal />
-      </div>
+    <div className='my-auto p-6'>
+      <LogInModal />
     </div>
-  </div>
+  </ScrollLayout>
 )
 
 export default Login

--- a/src/features/session/Signup.tsx
+++ b/src/features/session/Signup.tsx
@@ -2,18 +2,17 @@ import React from 'react'
 
 import SignUpModal from './modal/SignUpModal'
 import Head from '../app/Head'
+import ScrollLayout from '../layouts/ScrollLayout'
 
 const Signup: React.FC<{}> = () => (
-  <div className='flex flex-col h-full bg-gray-100'>
+  <ScrollLayout>
     <Head data={{
       title: `Login | Qri`
     }}/>
-    <div className='m-auto p-10'>
-      <div className="shadow-md">
-        <SignUpModal />
-      </div>
+    <div className='my-auto p-6'>
+      <SignUpModal />
     </div>
-  </div>
+  </ScrollLayout>
 )
 
 export default Signup

--- a/src/features/session/modal/LogInModal.tsx
+++ b/src/features/session/modal/LogInModal.tsx
@@ -43,7 +43,7 @@ const LogInModal: React.FC = () => {
   }
 
   return (
-    <div className='bg-white py-9 px-5 text-center' style={{ width: '440px' }}>
+    <div className='bg-white py-9 px-5 text-center w-full rounded-2xl mx-auto' style={{ maxWidth: 440 }}>
       <div className='w-10 m-auto mb-4'>
         <QriLogo size='sm'/>
       </div>

--- a/src/features/session/modal/SignUpModal.tsx
+++ b/src/features/session/modal/SignUpModal.tsx
@@ -59,7 +59,7 @@ const SignUpModal: React.FC = () => {
   }
 
   return (
-    <div className='bg-white py-9 px-5 text-center' style={{ width: '440px' }}>
+    <div className='bg-white py-9 px-5 text-center w-full rounded-2xl mx-auto' style={{ maxWidth: 440 }}>
       <div className='w-10 m-auto mb-4'>
         <QriLogo size='sm'/>
       </div>

--- a/src/features/userProfile/UserProfile.tsx
+++ b/src/features/userProfile/UserProfile.tsx
@@ -17,8 +17,8 @@ import {
   selectUserProfileDatasets,
   selectUserProfileFollowing
 } from './state/userProfileState'
-import NavBar from '../navbar/NavBar'
-import Footer from '../footer/Footer'
+import ScrollLayout from '../layouts/ScrollLayout'
+
 import {
   UserProfileDatasetListParams,
   NewUserProfileDatasetListParams,
@@ -118,44 +118,39 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
         pathname: location.pathname,
         description: `A list of public datasets for the Qri user ${usernameParam}`
       }}/>
-      <div className='flex-grow w-full overflow-y-scroll'>
-        {/* begin sticky header */}
-        <div className={classNames('sticky bg-white  border border-qrigray-200 z-10', {
-          'invisible -top-16 h-0': inView,
-          'visible top-0 transition-all': !inView
-        })}>
-          <div className='px-8 pt-4 pb-3 flex'>
-            <div className='flex items-center'>
-              <div className='rounded-2xl inline-block bg-cover flex-shrink-0 mr-3' style={{
-                height: '30px',
-                width: '30px',
-                backgroundImage: `url(${userIcon})`
-              }}/>
-              <div>
-                <div className='text-black text-sm font-semibold'>{profile.username}</div>
-              </div>
+      {/* begin sticky header */}
+      <div className={classNames('sticky bg-white  border-t border-b border-qrigray-200 z-10', {
+        'invisible -top-16 h-0': inView,
+        'visible top-0 transition-all': !inView
+      })}>
+        <div className='px-8 pt-4 pb-3 flex'>
+          <div className='flex items-center'>
+            <div className='rounded-2xl inline-block bg-cover flex-shrink-0 mr-3' style={{
+              height: '30px',
+              width: '30px',
+              backgroundImage: `url(${userIcon})`
+            }}/>
+            <div>
+              <div className='text-black text-sm font-semibold'>{profile.username}</div>
             </div>
-          </div>
-        </div>
-        {/* end sticky header */}
-        <div className='mx-auto flex py-9' style={{ maxWidth: '1040px' }}>
-          <div className='flex-auto'>
-            <div className='w-full' ref={stickyHeaderTriggerRef}>
-              <UserProfileHeader profile={profile} loading={loading} />
-            </div>
-            <ContentTabs
-              tabs={tabs}
-            />
-            <UserProfileDatasetList
-              paginatedResults={path === '/' ? paginatedDatasetResults : paginatedFollowingResults}
-              userProfileParams={userProfileParams}
-              onParamsUpdate={updateQueryParams}
-            />
           </div>
         </div>
       </div>
-      <div className='bg-white flex-shrink-0'>
-        <Footer />
+      {/* end sticky header */}
+      <div className='mx-auto flex py-9 px-6 w-full' style={{ maxWidth: '1040px' }}>
+        <div className='flex-auto min-w-0'>
+          <div className='w-full' ref={stickyHeaderTriggerRef}>
+            <UserProfileHeader profile={profile} loading={loading} />
+          </div>
+          <ContentTabs
+            tabs={tabs}
+          />
+          <UserProfileDatasetList
+            paginatedResults={path === '/' ? paginatedDatasetResults : paginatedFollowingResults}
+            userProfileParams={userProfileParams}
+            onParamsUpdate={updateQueryParams}
+          />
+        </div>
       </div>
     </>
   )
@@ -165,10 +160,9 @@ const UserProfile: React.FC<UserProfileProps> = ({ path = '/' }) => {
   }
 
   return (
-    <div className='flex flex-col h-full w-full' ref={scrollContainer} style={{ backgroundColor: '#f3f4f6' }}>
-      <NavBar />
+    <ScrollLayout>
       {content}
-    </div>
+    </ScrollLayout>
   )
 }
 

--- a/src/features/userProfile/UserProfileDatasetList.tsx
+++ b/src/features/userProfile/UserProfileDatasetList.tsx
@@ -48,7 +48,7 @@ const UserProfileDatasetList: React.FC<UserProfileDatasetListProps> = ({
 
   return (
     <>
-      <div className='flex items-center justify-between px-2.5 pb-2'>
+      <div className='flex items-center justify-between pb-2'>
         <div className='text-qrigray flex-grow'>
           {
             loading

--- a/src/features/workflow/WorkflowPage.tsx
+++ b/src/features/workflow/WorkflowPage.tsx
@@ -35,7 +35,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ qriRef }) => {
   return (
     <>
       <Head data={{
-        title: isNew ? ' New Automated Dataset ' : `${qriRef.username}/${qriRef.name} workflow editor | Qri`
+        title: isNew ? ' New Automated Dataset ' : `${qriRef.username}/${qriRef.name} workflow editor | Qri`,
+        appView: true
       }}/>
       {dataset || isNew
         ? (<DatasetScrollLayout isNew={isNew} headerChildren={runBar} useScroller>

--- a/src/features/workflow/modal/SplashModal.tsx
+++ b/src/features/workflow/modal/SplashModal.tsx
@@ -17,7 +17,7 @@ const SignUpModal: React.FC = () => {
   }
 
   return (
-    <div className='bg-white p-8 text-left text-black' style={{ width: '440px' }}>
+    <div className='bg-white p-8 text-left text-black' style={{ width: 440 }}>
       <div className='flex'>
         <div className='flex-grow text-3xl font-black'>Welcome to the workflow editor!</div>
         <IconButton icon='close' className='ml-10' onClick={handleClose}/>

--- a/src/utils/fileSize.ts
+++ b/src/utils/fileSize.ts
@@ -31,7 +31,7 @@ export default function fileSize (l: number): string {
   if (l !== 1) {
     length.name += 's'
   }
-  return `${length.value}${length.name}`
+  return `${length.value} ${length.name}`
 }
 
 let SI_SYMBOL = ['', 'k', 'M', 'G', 'T', 'P', 'E']

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -154,7 +154,8 @@ module.exports = {
         'md': '4.5px',
         'lg': '6px',
         'xl': '8px',
-        '2xl': '10px'
+        '2xl': '10px',
+        '3xl': '20px'
       },
       fontSize: {
         ...fontSize,
@@ -180,7 +181,7 @@ module.exports = {
       fontWeight: ['hover'],
       cursor: ['hover'],
       borderWidth: ['last'],
-      margin: ['last'],
+      margin: ['first', 'last'],
       padding: ['first', 'last']
     },
   },


### PR DESCRIPTION
Reviewers:  Please use the app using the mobile emulator at various sizes and see if you can find situations where the layouts break or other UI awkwardness shows up.

Closes #602 

- Adds responsive layout for dataset previews, user profiles, search/search results, login/signup pages.
- Adds an `appView` prop to `Head` which injects  a `meta` `viewport` tag with a fixed width for the "app" views (collection, history, run log, workflow editor.  This causes them to appear "zoomed out" on mobile so they are still usable until a responsive layout can be designed)
- Adds a `ScrollLayout` layout component used for Previews, User Profiles, and Search where long-scrolling content is needed
- Renames `PageWithFooter` to `FixedLayout` and moves it to `/features/layouts` so we are more consistent with layout components
- Lots of little style tweaks to more closely match the mockups