### PR TITLE
fix: toggle bodyLoading state on dataset success

### DIFF
--- a/src/features/dataset/state/datasetState.ts
+++ b/src/features/dataset/state/datasetState.ts
@@ -100,9 +100,11 @@ export const datasetReducer = createReducer(initialState, {
   'API_DATASET_SUCCESS': (state, action) => {
     state.dataset = action.payload.data as Dataset
     state.datasetLoading = false
+    state.bodyLoading = false
   },
   'API_DATASET_FAILURE': (state) => {
     state.datasetLoading = false
+    state.bodyLoading = false
   },
   'API_BODY_REQUEST': (state, action) => {
     state.bodyLoading = true


### PR DESCRIPTION
Closes #634

Fixes the perpetual loading state for dataset body in the history view. 

Looks like we are dispatching `setBodyLoading()` but because there is not a separate API call for body, we are never setting loading back to false when `API_DATASET_SUCCESS` happens.

This sets `dataset.bodyLoading` to `false` when `API_DATASET_SUCCESS` or `API_DATASET_FAILURE` fires.