### PR TITLE
refactor(ops): tests are required for prod deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,8 @@ workflows:
       - frontend-prod-deploy:
           requires:
             - frontend-prod-image-push
+            - frontend-test
+            - frontend-test-e2e
           filters:
             branches:
               only:


### PR DESCRIPTION
E2E and unit tests should work and are mandatory for deployments to prod. Rosebud deploys don't depend on test results.

Pends on getting rid of 
```
/home/circleci/repo/node_modules/react-monaco-editor/lib/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
                                                                                             ^^^^^^

    SyntaxError: Cannot use import statement outside a module
    
    1 | import React, { useState, useEffect, useRef } from 'react'
    > 2 | import MonacoEditor, { EditorConstructionOptions } from 'react-monaco-editor'
        | ^
      3 | import { KeyMod, KeyCode } from "monaco-editor/esm/vs/editor/editor.api"
      4 | import { RunStatus } from "../../qri/run"
      5 |

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1350:14)
      at Object.<anonymous> (src/features/workflow/CodeEditor.tsx:2:1)

```
In unit tests