### PR TITLE
feat: make all download links get the body

### DIFF
--- a/src/features/dataset/DatasetMiniHeader.tsx
+++ b/src/features/dataset/DatasetMiniHeader.tsx
@@ -56,7 +56,7 @@ const DatasetMiniHeader: React.FC<DatasetMiniHeaderProps> = ({
                   Share
                 </Button>
               */}
-              <DownloadDatasetButton title='Download the full dataset version as a zip file' qriRef={qriRef} type='primary' small />
+              <DownloadDatasetButton title='Download this version' qriRef={qriRef} type='primary' small />
             </>
           )}
         </div>

--- a/src/features/download/DownloadDatasetButton.tsx
+++ b/src/features/download/DownloadDatasetButton.tsx
@@ -29,7 +29,7 @@ const DownloadDatasetButton: React.FC<DownloadDatasetButtonProps> = ({
   small = false,
   type = 'primary-outline',
   asIconLink = false,
-  body = false,
+  body = true,
   hideIcon = false,
   title
 }) => {

--- a/src/features/dsComponents/DatasetComponents.tsx
+++ b/src/features/dsComponents/DatasetComponents.tsx
@@ -40,7 +40,7 @@ const DatasetComponents: React.FC<{}> = () => {
         <DatasetCommitList qriRef={qriRef} />
         <div className='flex flex-col flex-grow overflow-hidden'>
           <CommitSummaryHeader loading={loading} dataset={dataset}>
-            <DownloadDatasetButton type='primary' title='Download the full dataset version as a zip file' qriRef={qriRef} />
+            <DownloadDatasetButton type='primary' title='Download this Version' qriRef={qriRef} />
           </CommitSummaryHeader>
           <TabbedComponentViewer
             dataset={dataset}

--- a/src/features/dsComponents/body/BodyHeader.tsx
+++ b/src/features/dsComponents/body/BodyHeader.tsx
@@ -57,7 +57,7 @@ const BodyHeader: React.FC<BodyHeaderProps> = ({
             </>}
         </div>
       </div>
-      {showDownload && <DownloadDatasetButton title="Download this version's body" qriRef={qriRefFromDataset(dataset)} asIconLink body />}
+      {showDownload && <DownloadDatasetButton title="Download data" qriRef={qriRefFromDataset(dataset)} asIconLink body />}
       {showExpand && <IconLink icon='fullScreen' onClick={onToggleExpanded} />}
     </div>
   )

--- a/src/features/dsPreview/DatasetPreviewPage.tsx
+++ b/src/features/dsPreview/DatasetPreviewPage.tsx
@@ -116,10 +116,10 @@ const DatasetPreviewPage: React.FC<DatasetPreviewPageProps> = ({
                         </div>
                         <div className='flex flex-shrink-0'>
                           <div className='hidden md:block'>
-                            <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' hideIcon type='primary' qriRef={qriRef} />
+                            <DownloadDatasetButton title='Download the latest version' hideIcon type='primary' qriRef={qriRef} />
                           </div>
                           <div className='block md:hidden'>
-                            <DownloadDatasetButton title='Download the latest version of this dataset as a zip file' type='primary' qriRef={qriRef} small />
+                            <DownloadDatasetButton title='Download the latest version' type='primary' qriRef={qriRef} small />
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
- Refactors all download buttons to get the body.  We can reinstate full dataset downloads easily if users ask for them.
Closes #604