### PR TITLE
feat: abbreviate numbers higher than 1000 in dataset side nav

### DIFF
--- a/src/features/dataset/DatasetSideNavItem.tsx
+++ b/src/features/dataset/DatasetSideNavItem.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import ReactTooltip from 'react-tooltip'
 import classNames from 'classnames'
+import numeral from 'numeral'
 
 import Icon from '../../chrome/Icon'
 
@@ -55,13 +56,20 @@ const DatasetSideNavItem: React.FC<DatasetSideNavItemProps> = ({
   let numberContent
 
   if (number && (number > 0)) {
+    let displayNumber: string = number.toString()
+
+    if (number > 1000) {
+      displayNumber = numeral(number).format('0.0a')
+    }
+
     numberContent = (
       <div
         className='text-center bg-qrigray-400 px-1 py-0.5 rounded-sm text-white leading-none absolute -top-0 right-1'
         style={{
           fontSize: 9
         }}
-      >{number}</div>
+        title={number > 1000 ? number.toString() : ''}
+      >{displayNumber}</div>
     )
   }
 


### PR DESCRIPTION
Abbreviates large numbers in the dataset nav.  Also shows a tooltip with the actual number if the number has been abbreviated
<img width="138" alt="chriswhong_brooklyn_hourly_temperature_humidity_dataset_preview___Qri" src="https://user-images.githubusercontent.com/1833820/145639886-4da55749-5113-478f-b294-2bac26eda31e.png">
.

Closes #619 