### PR TITLE
refactor: eliminate unnecessary calls to /ds/get

### DIFF
--- a/src/features/dataset/DatasetRoutes.tsx
+++ b/src/features/dataset/DatasetRoutes.tsx
@@ -1,14 +1,6 @@
-// All dataset routes share DatasetWrapper, which handles the rendering of the
-// dataset menu and fetches dsPreview (the latest version of the dataset)
-// All routes use dsPreview to render the dataset header, so it is always needed
-// regardless of th other dataset content being displayed
-
-// DatasetPreviewPage fetches the other necessary parts of the preview (body + readme)
-
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Route, Switch, useParams } from 'react-router'
 import { useLocation } from 'react-router-dom'
-import { useDispatch } from "react-redux"
 
 import ExistingAutomationEditor from '../workflow/ExistingAutomationEditor'
 import DatasetComponents from '../dsComponents/DatasetComponents'
@@ -17,7 +9,6 @@ import DatasetPreviewPage from '../dsPreview/DatasetPreviewPage'
 import DatasetIssues from '../issues/DatasetIssues'
 import { newQriRef } from '../../qri/ref'
 import DatasetWrapper from '../dsComponents/DatasetWrapper'
-import { loadDataset, loadHeader } from "./state/datasetActions"
 import { PrivateRoute } from '../../routes'
 import ExistingDatasetEditor from "../../features/datasetEditor/ExistingDatasetEditor"
 
@@ -29,19 +20,11 @@ const DatasetRoutes: React.FC<{}> = () => {
   // ref. Move all ref constructino into container components to avoid potential
   // bugs
   const qriRef = newQriRef(useParams())
-  const dispatch = useDispatch()
   const { pathname } = useLocation()
   const isEditor = pathname.includes('/edit')
 
-  useEffect(() => {
-    dispatch(loadHeader({ username: qriRef.username, name: qriRef.name, path: qriRef.path }))
-  }, [dispatch, qriRef.username, qriRef.name, qriRef.path])
-  useEffect(() => {
-    dispatch(loadDataset(qriRef))
-  }, [dispatch, qriRef.username, qriRef.name])
-
   return (
-    <DatasetWrapper editor={isEditor}>
+    <DatasetWrapper qriRef={qriRef} editor={isEditor}>
       <Switch>
         {/* dataset preview */}
         <Route path='/:username/:name' exact>

--- a/src/features/dsComponents/DatasetWrapper.tsx
+++ b/src/features/dsComponents/DatasetWrapper.tsx
@@ -1,14 +1,9 @@
-// all dataset routes need the same info to display in the header
-// our state tree includes dataset, but it really represents the current version
-// of a dataset which can change in the history view
-// for all dataset routes, we can reference the dataset in dsPreview to populate the header
+// DatasetWrapper now does all of the API calls for the active dataset
 
 import React, { useEffect } from 'react'
-import { useParams } from 'react-router'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { newQriRef } from '../../qri/ref'
-import { fetchDsPreview } from '../dsPreview/state/dsPreviewActions'
+import { QriRef } from '../../qri/ref'
 import { selectDsPreviewError } from '../dsPreview/state/dsPreviewState'
 import { loadWorkflowByDatasetRef } from '../workflow/state/workflowActions'
 import { loadDatasetLogs } from '../activityFeed/state/activityFeedActions'
@@ -16,30 +11,35 @@ import NavBar from '../navbar/NavBar'
 import DatasetNavSidebar from '../dataset/DatasetNavSidebar'
 import NotFoundPage from '../notFound/NotFoundPage'
 import WebAppLayout from '../layouts/WebAppLayout'
+import { loadHeader } from "../dataset/state/datasetActions"
 
 interface DatasetWrapperProps {
+  qriRef?: QriRef
   fetchData?: boolean
   editor?: boolean
 }
 
 const DatasetWrapper: React.FC<DatasetWrapperProps> = ({
+  qriRef = { username: '', name: '' },
   fetchData = true,
   editor = false,
   children
 }) => {
-  const qriRef = newQriRef(useParams())
   const dispatch = useDispatch()
 
   const error = useSelector(selectDsPreviewError)
 
-  useEffect(() => {
-    // dont' fetch data if the user is making a new workflow
-    if (fetchData) {
-      dispatch(fetchDsPreview(qriRef))
+  if (fetchData) {
+    // fetch workflow and logs here so we know whether to enable their respective nav links
+    useEffect(() => {
       dispatch(loadWorkflowByDatasetRef(qriRef))
       dispatch(loadDatasetLogs(qriRef))
-    }
-  }, [ qriRef.username, qriRef.name])
+    }, [ qriRef.username, qriRef.name])
+
+    useEffect(() => {
+      dispatch(loadHeader({ username: qriRef.username, name: qriRef.name, path: qriRef.path }))
+    }, [dispatch, qriRef.username, qriRef.name, qriRef.path])
+  }
 
   let content = (
     <div className='flex overflow-hidden w-full flex-grow'>


### PR DESCRIPTION
Closes #266 

We had api calls spread across `DatasetRoutes`, `DatasetWrapper`, and `DatasetPreviewPage`, resulting in 3 separate calls to the same endpoint (`/ds/get`) when a preview route was loaded.

- We have separate state for `dataset` and `preview` but they are both populated by the same data, so this refactors the reducers for both to listen for the same action.
-  Calls happening in `DatasetRoutes` are moved down into `DatasetWrapper` so they are all happening in the same place, leaving `DatasetRoutes` to just be a router, not a router and a data-getter.